### PR TITLE
[PD-899] Add help text to job view

### DIFF
--- a/postajob/templatetags/postajob_tags.py
+++ b/postajob/templatetags/postajob_tags.py
@@ -15,10 +15,10 @@ register = Library()
 
 @register.simple_tag
 def get_job_links(job, max_sites=3):
-    locations = job.locations.all()
-
     if hasattr(job, 'is_approved') and not job.is_approved:
+
         return ''
+    locations = job.locations.all()
 
     sites = job.on_sites()
     domains = [site.domain for site in sites]

--- a/postajob/templatetags/postajob_tags.py
+++ b/postajob/templatetags/postajob_tags.py
@@ -16,8 +16,8 @@ register = Library()
 @register.simple_tag
 def get_job_links(job, max_sites=3):
     if hasattr(job, 'is_approved') and not job.is_approved:
-
         return ''
+
     locations = job.locations.all()
 
     sites = job.on_sites()
@@ -88,8 +88,8 @@ def get_product_names(offline_purchase):
 
 
 @register.assignment_tag
-def get_content_type(object):
-    return ContentType.objects.get_for_model(object.__class__)
+def get_content_type(obj):
+    return ContentType.objects.get_for_model(obj.__class__)
 
 
 @register.filter

--- a/templates/postajob/dseo/view_job.html
+++ b/templates/postajob/dseo/view_job.html
@@ -47,7 +47,7 @@
     <h3 class="top">
         Tips
     </h3>
-    Job links may take up to 30 minutes to appear after they are approved.
+    Jobs may take up to 30 minutes to appear after they are approved.
     <h3>
         Product Details
     </h3>

--- a/templates/postajob/dseo/view_job.html
+++ b/templates/postajob/dseo/view_job.html
@@ -45,10 +45,6 @@
 </div>
 <div class="direct_rightColBox">
     <h3 class="top">
-        Tips
-    </h3>
-    Jobs may take up to 30 minutes to appear after they are approved.
-    <h3>
         Product Details
     </h3>
     <label>Job Limit:</label>
@@ -58,6 +54,10 @@
     <br/><label>Expires:</label>
     <b>{{ purchased_product.expiration_date }}</b>
     <br />
+    <h3>
+        Tips
+    </h3>
+    Jobs may take up to 30 minutes to appear after they are approved.
     {% if not admin %}
     <div class="navigation">
         <h3>Navigation</h3>

--- a/templates/postajob/dseo/view_job.html
+++ b/templates/postajob/dseo/view_job.html
@@ -44,7 +44,13 @@
     </table>
 </div>
 <div class="direct_rightColBox">
-    <h3>Product Details</h3>
+    <h3 class="top">
+        Tips
+    </h3>
+    Job links may take up to 30 minutes to appear after they are approved.
+    <h3>
+        Product Details
+    </h3>
     <label>Job Limit:</label>
     <b>{% if purchased_product.num_jobs_allowed == 0 %}Unlimited{%else%}{{ purchased_product.num_jobs_allowed }} ({{purchased_product.jobs_remaining}} left){%endif%}</b>
     <br /><label>Purchase Date:</label>

--- a/templates/postajob/myjobs/view_job.html
+++ b/templates/postajob/myjobs/view_job.html
@@ -67,7 +67,7 @@ View Job
             <h2 class="top">
                 Tips
             </h2>
-            Job links may take up to 30 minutes to appear after they are approved.
+            Jobs may take up to 30 minutes to appear after they are approved.
             <h2>
                 Product Details
             </h2>

--- a/templates/postajob/myjobs/view_job.html
+++ b/templates/postajob/myjobs/view_job.html
@@ -65,10 +65,6 @@ View Job
     <div class="span4">
         <div class="sidebar">
             <h2 class="top">
-                Tips
-            </h2>
-            Jobs may take up to 30 minutes to appear after they are approved.
-            <h2>
                 Product Details
             </h2>
             <label>Job Limit:</label>
@@ -77,6 +73,10 @@ View Job
             <b>{{ purchased_product.purchase_date }}</b>
             <label>Expires:</label>
             <b>{{ purchased_product.expiration_date }}</b>
+            <h2>
+                Tips
+            </h2>
+            Jobs may take up to 30 minutes to appear after they are approved.
             {% if not admin %}
             <div class="navigation">
                 <h2>Navigation</h2>

--- a/templates/postajob/myjobs/view_job.html
+++ b/templates/postajob/myjobs/view_job.html
@@ -65,6 +65,10 @@ View Job
     <div class="span4">
         <div class="sidebar">
             <h2 class="top">
+                Tips
+            </h2>
+            Job links may take up to 30 minutes to appear after they are approved.
+            <h2>
                 Product Details
             </h2>
             <label>Job Limit:</label>


### PR DESCRIPTION
This addresses the issue of notifying a user that there could be a delay between when the job link appears and when a job is actually available at that link. 

I moved the early bail out for the template tag so that we aren't needlessly doing queries on a job that hasn't even been approved. 

The issue of how best to represent job links has been deferred to a separate ticket (linked to in pd-899).