### PR TITLE
Add "powered by my.jobs" to templates

### DIFF
--- a/postajob/models.py
+++ b/postajob/models.py
@@ -692,7 +692,8 @@ class Product(BaseModel):
 
     def seosite(self):
         if hasattr(self.package, "sitepackage"):
-            return self.package.sitepackage.sites.values_list("domain", flat=True)
+            return self.package.sitepackage.sites.values_list("domain",
+                                                              flat=True)
         return []
 
 

--- a/templates/myjobs/email_inactive.html
+++ b/templates/myjobs/email_inactive.html
@@ -11,5 +11,5 @@
 
 <hr>
 
-Powered by My.jobs<br />
+Powered by <a href="https://secure.my.jobs">My.jobs</a><br />
 My.jobs <a href="https://secure.my.jobs{% url 'terms' %}">Terms</a> and <a href="https://secure.my.jobs{% url 'privacy' %}">Privacy</a>

--- a/templates/myjobs/email_inactive.html
+++ b/templates/myjobs/email_inactive.html
@@ -8,4 +8,8 @@
 
 <p>If you do not wish to receive emails, you will be removed from our list {% if time == 82 %}in seven days{% else %}tomorrow{% endif %}.</p>
 
-<p>My.jobs <a href="https://secure.my.jobs{% url 'terms' %}">Terms</a> and <a href="https://secure.my.jobs{% url 'privacy' %}">Privacy</a></p>
+
+<hr>
+
+Powered by My.jobs<br />
+My.jobs <a href="https://secure.my.jobs{% url 'terms' %}">Terms</a> and <a href="https://secure.my.jobs{% url 'privacy' %}">Privacy</a>

--- a/templates/postajob/invoice_email.html
+++ b/templates/postajob/invoice_email.html
@@ -68,3 +68,7 @@
         </td></tr>
     </table>
 {% endif %}
+
+<hr>
+
+Powered by My.jobs

--- a/templates/postajob/invoice_email.html
+++ b/templates/postajob/invoice_email.html
@@ -71,4 +71,4 @@
 
 <hr>
 
-Powered by My.jobs
+Powered by <a href="https://secure.my.jobs">My.jobs</a>

--- a/templates/postajob/request_email.html
+++ b/templates/postajob/request_email.html
@@ -3,4 +3,4 @@ You have a new request from {{ requester }}. You can view the request <a href="h
 
 <hr>
 
-Powered by My.jobs
+Powered by <a href="https://secure.my.jobs">My.jobs</a>

--- a/templates/postajob/request_email.html
+++ b/templates/postajob/request_email.html
@@ -1,1 +1,6 @@
-You have a new request from {{ requester }}. You can view the request <a href="https://secure.my.jobs{% url 'view_request' pk=request.pk %}">here.</a>
+{% load password_reset_tags %}
+You have a new request from {{ requester }}. You can view the request <a href="http://{% get_current_seosite_domain %}{% url 'view_request' pk=request.pk %}">here.</a>
+
+<hr>
+
+Powered by My.jobs


### PR DESCRIPTION
One email has a link to a view that I'm not introducing to microsites, so it remains secure.my.jobs.

The inactivity email seemed like it would benefit from Terms and Privacy links, so I added them. The postajob emails did not, so I didn't.

All tests pass.