### PR TITLE
[PD-920] Disable opted-out emails on saved search form

### DIFF
--- a/mypartners/forms.py
+++ b/mypartners/forms.py
@@ -332,10 +332,10 @@ def PartnerEmailChoices(partner):
     contacts = Contact.objects.filter(partner=partner)
     for contact in contacts:
         if contact.user:
-            choices.append((contact.user.email, contact.name))
+            choices.append((contact.user.email, contact ))
         else:
             if contact.email:
-                choices.append((contact.email, contact.name))
+                choices.append((contact.email, contact ))
     return choices
 
 

--- a/templates/includes/error-highlight.html
+++ b/templates/includes/error-highlight.html
@@ -28,7 +28,11 @@
         {% if field.label == 'Send Results to *' %}
             <select id="id_email" name="email" style="display: inline-block;">
             {% for email, contact in form.fields.email.choices %}
-                <option value={{ email }} {% if contact.user and not contact.user.opt_in_myjobs %}disabled title="This contact has opted out of My.jobs communications"{% endif %}>{{ contact.name|default:"----------" }}</option>
+                <option value="{{ email }}"
+                        {% if contact.user and not contact.user.opt_in_myjobs %}disabled title="This contact has opted out of My.jobs communications"{% endif %}
+                        {% if field.value %}selected{% endif %}>
+                    {{ contact.name|default:"----------" }}
+                </option>
             {% endfor %}
             </select>
         {% else %}

--- a/templates/includes/error-highlight.html
+++ b/templates/includes/error-highlight.html
@@ -28,7 +28,7 @@
         {% if field.label == 'Send Results to *' %}
             <select id="id_email" name="email" style="display: inline-block;">
             {% for email, contact in form.fields.email.choices %}
-                <option value={{ email }} {% if contact.user and not contact.user.opt_in_myjobs %}disabled title="This contact has opted out of My.jobs communication"{% endif %}>{{ contact.name|default:"----------" }}</option>
+                <option value={{ email }} {% if contact.user and not contact.user.opt_in_myjobs %}disabled title="This contact has opted out of My.jobs communications"{% endif %}>{{ contact.name|default:"----------" }}</option>
             {% endfor %}
             </select>
         {% else %}

--- a/templates/includes/error-highlight.html
+++ b/templates/includes/error-highlight.html
@@ -26,7 +26,6 @@
     </div>
     <div class="profile-form-input {{ field.label|slugify }}-field">
         {% if field.label == 'Send Results to *' %}
-            {# TODO: find out what properties are passed to select by default #}
             <select id="id_email" name="email" style="display: inline-block;">
             {% for email, contact in form.fields.email.choices %}
                 <option value={{ email }} {% if contact.user and not contact.user.opt_in_myjobs %}disabled title="This contact has opted out of My.jobs communication"{% endif %}>{{ contact.name|default:"----------" }}</option>

--- a/templates/includes/error-highlight.html
+++ b/templates/includes/error-highlight.html
@@ -25,7 +25,16 @@
         {% add_required_label field %}
     </div>
     <div class="profile-form-input {{ field.label|slugify }}-field">
-        {{ field }}
+        {% if field.label == 'Send Results to *' %}
+            {# TODO: find out what properties are passed to select by default #}
+            <select id="id_email" name="email" style="display: inline-block;">
+            {% for email, contact in form.fields.email.choices %}
+                <option value={{ email }} {% if contact.user and not contact.user.opt_in_myjobs %}disabled title="This contact has opted out of My.jobs communication"{% endif %}>{{ contact.name|default:"----------" }}</option>
+            {% endfor %}
+            </select>
+        {% else %}
+            {{ field }}
+        {% endif %}
         {% if field.help_text %}
             {% if field|is_checkbox_field %}
                 <br/><span class="help-block checkbox-help-block">{{ field.help_text|safe }}</span>

--- a/templates/mypartners/includes/pss_card.html
+++ b/templates/mypartners/includes/pss_card.html
@@ -12,7 +12,7 @@
         {% endfor %}
     </div>
     <div class="product-details">
-        Last sent: {{search.last_sent}}
+        Last sent: {{search.last_sent|default:"Never"}}
     </div>
     <a id="savedsearch-{{search.id}}" class="btn" href="{% url 'partner_view_full_feed' %}?partner={{ partner.id }}&id={{ search.id }}">View</a>
 </div>


### PR DESCRIPTION
## Changes
- A partner saved search that hasn't been sent says "Never" for "Last sent" instead of "None"
- opted out emails are disabled with help text provided:
![2015-01-12-091137_827x385_scrot](https://cloud.githubusercontent.com/assets/93686/5703965/f3d9c78c-9a3a-11e4-9ba1-d67d593cbcfa.png)

- Unlike the last PR I submitted with the same title, you can save the form.