### PR TITLE
[PD-930] Updated partner saved search emails to include deactivation and unsubscribe links

### DIFF
--- a/mysearches/tests/test_forms.py
+++ b/mysearches/tests/test_forms.py
@@ -1,7 +1,6 @@
 from mock import patch
 
 from django.core import mail
-from django.core.urlresolvers import reverse
 
 from myjobs.tests.setup import MyJobsBase
 from mypartners.models import Contact

--- a/mysearches/tests/test_forms.py
+++ b/mysearches/tests/test_forms.py
@@ -143,5 +143,7 @@ class PartnerSavedSearchFormTests(MyJobsBase):
         form.save()
 
         # ensure email received with the correct content
-        self.assertIn(mail.outbox[0].body, 
-                      "Unsubscribe from all My.jobs emails")
+        for phrase in ["Deactivate this saved search",
+                       "Deactivate all saved searches",
+                       "Unsubscribe from all My.jobs emails"]:
+            self.assertIn(phrase, mail.outbox[0].body)

--- a/mysearches/views.py
+++ b/mysearches/views.py
@@ -269,6 +269,7 @@ def unsubscribe(request, user=None):
         # saved_search is a single search rather than a queryset this time
         cache = [saved_search]
         saved_search.is_active = False
+        has_pss = hasattr(saved_search, 'partnersavedsearch')
         saved_search.save()
     except ValueError:
         digest = SavedSearchDigest.objects.get_or_create(
@@ -286,7 +287,8 @@ def unsubscribe(request, user=None):
     return render_to_response('mysearches/saved_search_disable.html',
                               {'search_id': search_id,
                                'searches': cache,
-                               'email_user': user},
+                               'email_user': user,
+                               'contains_pss': has_pss},
                               RequestContext(request))
 
 

--- a/mysearches/views.py
+++ b/mysearches/views.py
@@ -283,6 +283,7 @@ def unsubscribe(request, user=None):
         # that queryset; Make a copy and then update the queryset
         cache = list(saved_searches)
         saved_searches.update(is_active=False)
+        has_pss = False
 
     return render_to_response('mysearches/saved_search_disable.html',
                               {'search_id': search_id,

--- a/templates/mysearches/email_base.html
+++ b/templates/mysearches/email_base.html
@@ -34,10 +34,8 @@
         </td>
     </tr>
 
-        {% if not contains_pss %}
-
-            {% with saved_search=saved_searches.0.0 %}
-
+        {% with saved_search=saved_searches.0.0 %}
+            {% if not contains_pss %}
                 {% block completion %}
                 <tr>
                     <td colspan="2">
@@ -45,11 +43,12 @@
                     </td>
                 </tr>
                 {% endblock %}
-
+            {% endif %}
                 <tr>
-
                     <td colspan=1 style="width: 33%; padding: 8px; line-height: 20px; border-top: 1px solid #ddd;">
-                        <a href="https://secure.my.jobs{% url 'view_profile' %}?verify={{saved_search.user.user_guid}}">{% trans 'My Resume' %}</a><br>
+                        {% if not contains_pss %}
+                            <a href="https://secure.my.jobs{% url 'view_profile' %}?verify={{saved_search.user.user_guid}}">{% trans 'My Resume' %}</a><br>
+                        {% endif %}
                         <a href="https://secure.my.jobs{% url 'saved_search_main' %}?verify={{saved_search.user.user_guid}}">{% trans 'My Saved Searches' %}</a><br>
                         <a href="https://secure.my.jobs{% url 'edit_account' %}?verify={{saved_search.user.user_guid}}">{% trans 'Account Settings' %}</a><br>
                     </td>
@@ -61,8 +60,6 @@
                 </tr>
 
             {% endwith %}
-
-        {% endif %}
 
     <tr>
         <td colspan=2 style="padding: 8px; line-height: 20px; border-top: 1px solid #ddd;">

--- a/templates/mysearches/email_base.html
+++ b/templates/mysearches/email_base.html
@@ -55,6 +55,8 @@
                     <td colspan=1 style="padding: 8px; line-height: 20px; border-top: 1px solid #ddd;">
                         {% block footer-right %}
                         {% endblock %}
+                        <a href="https://secure.my.jobs{% url 'unsubscribe' %}?id={{ saved_search.id }}&verify={{saved_search.user.user_guid}}">{% trans 'Deactivate this saved search' %}</a><br>
+                        <a href="https://secure.my.jobs{% url 'unsubscribe' %}?id=digest&verify={{saved_search.user.user_guid}}">{% trans 'Deactivate all saved searches' %}</a><br>
                         <a href="https://secure.my.jobs{% url 'unsubscribe_all' %}?verify={{saved_search.user.user_guid}}">{% trans 'Unsubscribe from all My.jobs emails' %}</a><br>
                     </td>
                 </tr>

--- a/templates/mysearches/saved_search_disable.html
+++ b/templates/mysearches/saved_search_disable.html
@@ -47,7 +47,7 @@
                 <h2>{% trans "What now:" %}</h2>
                 <table class="table table-bordered table-striped">
                 {% if user.is_authenticated %}
-                    {% if searches|length %}
+                    {% if searches|length and not contains_pss %}
                         <tr class="profile-section">
                             <td>
                                 <a href="{%url 'delete_saved_search'%}?id={{search_id}}&verify={{email_user.user_guid}}">


### PR DESCRIPTION
## Visual changes
* Addition of unsubscribe and deactivation links
![2015-01-15-125106_623x385_scrot](https://cloud.githubusercontent.com/assets/93686/5763069/0ab422aa-9cb5-11e4-8b3e-5a55f4491807.png)
* Removal of saved search deletion link when a partner saved search is deactivated
![2015-01-15-125223_958x196_scrot](https://cloud.githubusercontent.com/assets/93686/5763084/379ee7c8-9cb5-11e4-9a52-28b5e7ab17f7.png)

