### PR TITLE
[PD-930, PD-946] Updated disable saved search and saved search overview pages

### DIFF
--- a/mysearches/tests/test_views.py
+++ b/mysearches/tests/test_views.py
@@ -250,6 +250,28 @@ class MySearchViewTests(MyJobsBase):
             'saved_search_main_query')+'?d='+str(urllib2.quote(
                                                  search.label)))
 
+    def test_delete_unowned_partner_search(self):
+        """
+        Attempting to delete a partner saved search which was created for you
+        should do nothing.
+        """
+        import ipdb; ipdb.set_trace()
+        
+        user = UserFactory(email='asdfa@example.com')
+        company = CompanyFactory(id=2423, name="Bacon Factory",
+                                 user_created=False)
+        SavedSearchFactory(user=user)
+        pss = PartnerSavedSearchFactory(user=self.user, created_by=user,
+                                        provider=company)
+
+        response = self.client.get(reverse('delete_saved_search') +
+            '?id=ALL')
+        
+        self.assertEqual(response.status_code, 302)
+        self.assertTrue(models.PartnerSavedSearch.objects.filter(
+            pk=pss.pk).exists())
+        self.assertFalse(models.SavedSearch.objects.all().exists())
+
     def test_delete_unowned_search(self):
         """
         Attempting to delete a search that isn't yours should

--- a/mysearches/views.py
+++ b/mysearches/views.py
@@ -9,7 +9,8 @@ from django.shortcuts import render_to_response, get_object_or_404
 
 from myjobs.decorators import user_is_allowed
 from myjobs.models import User
-from mysearches.models import SavedSearch, SavedSearchDigest
+from mysearches.models import (SavedSearch, SavedSearchDigest,
+                               PartnerSavedSearch)
 from mysearches.forms import (SavedSearchForm, DigestForm,
                               PartnerSubSavedSearchForm)
 from mysearches.helpers import (get_interval_from_frequency, parse_feed,
@@ -47,13 +48,10 @@ def saved_search_main(request):
             SavedSearchDigest.MultipleObjectsReturned):
         digest_obj = None
     updated = request.REQUEST.get('d')
-    saved_searches = list(SavedSearch.objects.filter(user=request.user))
-    partner_saved_searches = []
-    # Check to see if any searches are PartnerSavedSearches
-    for saved_search in saved_searches[:]:
-        if hasattr(saved_search, 'partnersavedsearch'):
-            partner_saved_searches.append(
-                saved_searches.pop(saved_searches.index(saved_search)))
+    saved_searches = SavedSearch.objects.filter(
+        user=request.user, partnersavedsearch__isnull=True)
+    partner_saved_searches = PartnerSavedSearch.objects.filter(
+        user=request.user)
 
     if request.user.is_verified:
         form = DigestForm(user=request.user, instance=digest_obj)

--- a/mysearches/views.py
+++ b/mysearches/views.py
@@ -30,7 +30,7 @@ def delete_saved_search(request, user=None):
         search.delete()
     except ValueError:
         # all searches are being deleted
-        SavedSearch.objects.filter(user=user).delete()
+        SavedSearch.objects.filter(user=user, partnersavedsearch__isnull=True).delete()
         search_name = 'all'
 
     return HttpResponseRedirect(
@@ -250,7 +250,6 @@ def save_edit_form(request):
 
 @user_is_allowed(SavedSearch, 'id', pass_user=True)
 def unsubscribe(request, user=None):
-    import ipdb; ipdb.set_trace()
     """
     Deactivates a user's saved searches.
 
@@ -261,6 +260,7 @@ def unsubscribe(request, user=None):
     """
     search_id = request.REQUEST.get('id')
     user = user or request.user
+    has_pss = None
     try:
         search_id = int(search_id)
         saved_search = get_object_or_404(SavedSearch, id=search_id,
@@ -280,8 +280,6 @@ def unsubscribe(request, user=None):
             digest.save()
         saved_searches = SavedSearch.objects.filter(user=user,
                                                     is_active=True)
-        has_pss = saved_searches.filter(
-            partnersavedsearch__isnull=False).exists()
         # Updating the field that a queryset was filtered on seems to empty
         # that queryset; Make a copy and then update the queryset
         cache = list(saved_searches)

--- a/mysearches/views.py
+++ b/mysearches/views.py
@@ -250,6 +250,7 @@ def save_edit_form(request):
 
 @user_is_allowed(SavedSearch, 'id', pass_user=True)
 def unsubscribe(request, user=None):
+    import ipdb; ipdb.set_trace()
     """
     Deactivates a user's saved searches.
 
@@ -279,11 +280,12 @@ def unsubscribe(request, user=None):
             digest.save()
         saved_searches = SavedSearch.objects.filter(user=user,
                                                     is_active=True)
+        has_pss = saved_searches.filter(
+            partnersavedsearch__isnull=False).exists()
         # Updating the field that a queryset was filtered on seems to empty
         # that queryset; Make a copy and then update the queryset
         cache = list(saved_searches)
         saved_searches.update(is_active=False)
-        has_pss = False
 
     return render_to_response('mysearches/saved_search_disable.html',
                               {'search_id': search_id,

--- a/templates/mysearches/saved_search_disable.html
+++ b/templates/mysearches/saved_search_disable.html
@@ -56,7 +56,7 @@
                                     {% plural %}
                                     Delete them instead
                                     {% endblocktrans %}
-                                </button>
+                                </a>
                             </td>
                         </tr>
                     {% endif %}

--- a/templates/mysearches/saved_search_disable.html
+++ b/templates/mysearches/saved_search_disable.html
@@ -50,13 +50,13 @@
                     {% if searches|length and not contains_pss %}
                         <tr class="profile-section">
                             <td>
-                                <a href="{%url 'delete_saved_search'%}?id={{search_id}}&verify={{email_user.user_guid}}">
+                                <a id="delete" type="button" data-toggle="modal" data-target="#delete-confirm">
                                     {% blocktrans count counter=count %}
                                     Delete it instead
                                     {% plural %}
                                     Delete them instead
                                     {% endblocktrans %}
-                                </a>
+                                </button>
                             </td>
                         </tr>
                     {% endif %}
@@ -69,6 +69,23 @@
                     </tr>
                 {% endif %}
                 </table>
+            </div>
+            <div id="delete-confirm" class="modal hide fade row">
+                <div class="modal-header">
+                    {% trans 'Really Delete?' %}
+                </div>
+                <div class="modal-body">
+                    {% blocktrans %}
+                    <p>Are you sure you want to delete these saved searches?</p>
+                    <em>Note: Partner saved searches may only be deleted by the partner who created them.</em>
+                    {% endblocktrans %}
+                </div>
+                <div class="modal-footer">
+                    <div class="actions">
+                        <button data-dismiss="modal" class="btn primary pull-right">{% trans 'Cancel' %}</button>
+                        <a class="btn" href="{% url 'delete_saved_search' %}?id={{search_id}}&verify={{email_user.user_guid}}">{% trans 'Delete' %}</a>
+                    </div>
+                </div>
             </div>
     </div>
     {% endwith %}

--- a/templates/mysearches/saved_search_row.html
+++ b/templates/mysearches/saved_search_row.html
@@ -7,7 +7,7 @@
         <div class="pull-left">
             {{ search.label }}<br />
             {% if search.partner %}
-                <em>Partner: {{ search.partner }}</em>
+                <em>Created by: {{ search.partner.owner }}</em>
             {% endif %}
         </div>{% make_label search.is_active "pull-right" %}
     </td>

--- a/templates/mysearches/saved_search_row.html
+++ b/templates/mysearches/saved_search_row.html
@@ -3,7 +3,14 @@
 {% load humanize %}
 
 <tr id="saved-search-{{search.id}}">
-    <td class="view_search"><div class="pull-left">{{ search.label }}</div>{% make_label search.is_active "pull-right" %}</td>
+    <td class="view_search">
+        <div class="pull-left">
+            {{ search.label }}<br />
+            {% if search.partner %}
+                <em>Created by: <a href="{% url 'partner_overview' %}?partner={{ search.partner.id }}">{{ search.partner }}</a></em>
+            {% endif %}
+        </div>{% make_label search.is_active "pull-right" %}
+    </td>
     <td class="url mobile_hide {% if not search.is_active %}muted{% endif %}"><a href="{{ search.url }}" target="_blank">{{ search.url }}</a></td>
     <td class="frequency mobile_hide {% if not search.is_active %}muted{% endif %}">
 

--- a/templates/mysearches/saved_search_row.html
+++ b/templates/mysearches/saved_search_row.html
@@ -7,7 +7,7 @@
         <div class="pull-left">
             {{ search.label }}<br />
             {% if search.partner %}
-                <em>Partner: <a href="{% url 'partner_overview' %}?partner={{ search.partner.id }}">{{ search.partner }}</a></em>
+                <em>Partner: {{ search.partner }}</em>
             {% endif %}
         </div>{% make_label search.is_active "pull-right" %}
     </td>

--- a/templates/mysearches/saved_search_row.html
+++ b/templates/mysearches/saved_search_row.html
@@ -7,7 +7,7 @@
         <div class="pull-left">
             {{ search.label }}<br />
             {% if search.partner %}
-                <em>Created by: <a href="{% url 'partner_overview' %}?partner={{ search.partner.id }}">{{ search.partner }}</a></em>
+                <em>Partner: <a href="{% url 'partner_overview' %}?partner={{ search.partner.id }}">{{ search.partner }}</a></em>
             {% endif %}
         </div>{% make_label search.is_active "pull-right" %}
     </td>


### PR DESCRIPTION
## Saved Search Overview
I added information about the partner who created the saved search since those can't be deleted by the use. I also linked to the partner page.
Screenshot:
![2015-01-16-105115_1052x1056_scrot](https://cloud.githubusercontent.com/assets/93686/5779058/b3489988-9d6d-11e4-97a7-51dcd82eb326.png)

## Disable Saved Search
Before, when clicking the delete all saved searches link in the confirmation email, you'd still see a delete all link, which would delete partner saved searches as well. I originally hid this, but realized it would prevent users from deleting all saved searches. After first trying to separate the content on this page by saved search type as suggested, I went with a delete modal instead, a la partner library. I didn't bother listing the partner saved searches that wouldn't be deleted explicitly since clicking delete redirects to the saved search overview anyway.

In short, disabling a single partner saved search hides the delete button (that's already in master), but deleting all searches reenables that button, which now has modal behavior (in all cases, not just this one).

Screenshot:
![2015-01-16-105450_1052x1056_scrot](https://cloud.githubusercontent.com/assets/93686/5779103/08d46d32-9d6e-11e4-9a8b-893c8a682af9.png)

## Remaining Tasks
- [ ] Unit tests
