### PR TITLE
[PD-834][PD-951] Updated a few decorators

### DIFF
--- a/postajob/urls.py
+++ b/postajob/urls.py
@@ -2,8 +2,8 @@ from django.conf.urls import *
 
 from postajob import models, views
 from universal.decorators import (company_in_sitepackages, 
-                                  message_when_no_packages,
-                                  error_when_no_packages)
+                                  message_when_site_misconfigured,
+                                  error_when_site_misconfigured)
 
 
 urlpatterns = patterns(
@@ -17,7 +17,7 @@ urlpatterns = patterns(
         views.is_company_user,
         name="is_company_user"),
     url(r'list/$',
-        error_when_no_packages(feature='Job Listing')(
+        error_when_site_misconfigured(feature='Job Listing')(
             views.product_listing),
         name='product_listing'),
 
@@ -28,61 +28,61 @@ urlpatterns = patterns(
 
     # Purchased job management
     url(r'^purchased-jobs/$',
-        error_when_no_packages(feature='Purchased Job Management')(
+        error_when_site_misconfigured(feature='Purchased Job Management')(
             views.purchasedproducts_overview),
         name='purchasedproducts_overview'),
     url(r'purchased-jobs/product/(?P<purchased_product>\d+)/view/(?P<pk>\d+)$',
-        error_when_no_packages(feature='Purchased Job Management')(
+        error_when_site_misconfigured(feature='Purchased Job Management')(
             views.view_job),
         {'admin': False},
         name='view_job'),
     url(r'^purchased-jobs/product/(?P<purchased_product>\d+)/',
-        error_when_no_packages(feature='Purchased Job Management')(
+        error_when_site_misconfigured(feature='Purchased Job Management')(
             views.purchasedjobs_overview),
         {'admin': False},
         name='purchasedjobs_overview'),
 
     # Purchased microsite management
     url(r'^admin/$',
-        company_in_sitepackages(message_when_no_packages(
+        company_in_sitepackages(message_when_site_misconfigured(
             feature='Microsite Admin is')(
                 views.purchasedmicrosite_admin_overview)),
         name='purchasedmicrosite_admin_overview'),
 
     # Invoices
     url(r'^admin/invoice/(?P<pk>\d+)/$',
-        company_in_sitepackages(message_when_no_packages(
+        company_in_sitepackages(message_when_site_misconfigured(
             feature='Invoices are')(
                 views.resend_invoice)),
         name='resend_invoice'),
 
     # Requests
     url(r'^admin/request/$',
-        company_in_sitepackages(message_when_no_packages(
+        company_in_sitepackages(message_when_site_misconfigured(
             feature='Requests are')(
                 views.admin_request)),
         name='request'),
     url(r'^admin/request/view/(?P<pk>\d+)/$',
-        company_in_sitepackages(message_when_no_packages(
+        company_in_sitepackages(message_when_site_misconfigured(
             feature='Requests are')(
                 views.view_request)),
         name='view_request'),
     url(r'^admin/request/approve/(?P<pk>\d+)/$',
-        company_in_sitepackages(message_when_no_packages(
+        company_in_sitepackages(message_when_site_misconfigured(
             feature='Requests are')(
                 views.process_admin_request)),
         {'approve': True,
          'block': False},
         name='approve_admin_request'),
     url(r'^admin/request/deny/(?P<pk>\d+)/$',
-        company_in_sitepackages(message_when_no_packages(
+        company_in_sitepackages(message_when_site_misconfigured(
             feature='Requests are')(
                 views.process_admin_request)),
         {'approve': False,
          'block': False},
         name='deny_admin_request'),
     url(r'^admin/request/block/(?P<pk>\d+)/$',
-        company_in_sitepackages(message_when_no_packages(
+        company_in_sitepackages(message_when_site_misconfigured(
             feature='Requests are')(
                 views.process_admin_request)),
         {'approve': False,
@@ -113,76 +113,76 @@ urlpatterns = patterns(
 
     # Product management
     url(r'^admin/product/$',
-        company_in_sitepackages(message_when_no_packages(
+        company_in_sitepackages(message_when_site_misconfigured(
             feature='Product Management is')(
                 views.admin_products)),
         name='product'),
     url(r'^admin/product/add/',
-        company_in_sitepackages(message_when_no_packages(
+        company_in_sitepackages(message_when_site_misconfigured(
             feature='Product Management is')(
                 views.ProductFormView.as_view())),
         name='product_add'),
     url(r'^admin/product/delete/(?P<pk>\d+)/',
-        company_in_sitepackages(message_when_no_packages(
+        company_in_sitepackages(message_when_site_misconfigured(
             feature='Product Management is')(
                 views.ProductFormView.as_view())),
         name='product_delete'),
     url(r'^admin/product/update/(?P<pk>\d+)/',
-        company_in_sitepackages(message_when_no_packages(
+        company_in_sitepackages(message_when_site_misconfigured(
             feature='Product Management is')(
                 views.ProductFormView.as_view())),
         name='product_update'),
 
     # ProductGrouping
     url(r'^admin/product/group/$',
-        company_in_sitepackages(message_when_no_packages(
+        company_in_sitepackages(message_when_site_misconfigured(
             feature='Product Groupings are')(
                 views.admin_groupings)),
         name='productgrouping'),
     url(r'^admin/product/group/add/',
-        company_in_sitepackages(message_when_no_packages(
+        company_in_sitepackages(message_when_site_misconfigured(
             feature='Product Groupings are')(
                 views.ProductGroupingFormView.as_view())),
         name='productgrouping_add'),
     url(r'^admin/product/group/delete/(?P<pk>\d+)/',
-        company_in_sitepackages(message_when_no_packages(
+        company_in_sitepackages(message_when_site_misconfigured(
             feature='Product Groupings are')(
                 views.ProductGroupingFormView.as_view())),
         name='productgrouping_delete'),
     url(r'^admin/product/group/update/(?P<pk>\d+)/',
-        company_in_sitepackages(message_when_no_packages(
+        company_in_sitepackages(message_when_site_misconfigured(
             feature='Product Groupings are')(
                 views.ProductGroupingFormView.as_view())),
         name='productgrouping_update'),
 
     # Offline Purchases
     url(r'^admin/purchase/offline/$',
-        company_in_sitepackages(message_when_no_packages(
+        company_in_sitepackages(message_when_site_misconfigured(
             feature='Offline Purchases are')(
                 views.admin_offlinepurchase)),
         name='offlinepurchase'),
     url(r'^admin/purchase/offline/add/',
-        company_in_sitepackages(message_when_no_packages(
+        company_in_sitepackages(message_when_site_misconfigured(
             feature='Offline Purchases are')(
                 views.OfflinePurchaseFormView.as_view())),
         name='offlinepurchase_add'),
     url(r'^admin/purchase/offline/delete/(?P<pk>\d+)/',
-        company_in_sitepackages(message_when_no_packages(
+        company_in_sitepackages(message_when_site_misconfigured(
             feature='Offline Purchases are')(
                 views.OfflinePurchaseFormView.as_view())),
         name='offlinepurchase_delete'),
     url(r'^admin/purchase/offline/update/(?P<pk>\d+)/',
-        company_in_sitepackages(message_when_no_packages(
+        company_in_sitepackages(message_when_site_misconfigured(
             feature='Offline Purchases are')(
                 views.OfflinePurchaseFormView.as_view())),
         name='offlinepurchase_update'),
 
     url(r'^purchase/redeem/$',
-        error_when_no_packages(feature='Purchase Redemption')(
+        error_when_site_misconfigured(feature='Purchase Redemption')(
             views.OfflinePurchaseRedemptionFormView.as_view()),
         name='offlinepurchase_redeem'),
     url(r'^admin/purchase/offline/success/(?P<pk>\d+)/$',
-        error_when_no_packages(feature='Purchase Redemption')(
+        error_when_site_misconfigured(feature='Purchase Redemption')(
             company_in_sitepackages(views.view_request)),
         {'model': models.OfflinePurchase},
         name='offline_purchase_success'),
@@ -199,23 +199,23 @@ urlpatterns = patterns(
         name='purchasedproduct_update'),
 
     url(r'^admin/purchased/product$',
-        company_in_sitepackages(message_when_no_packages(
+        company_in_sitepackages(message_when_site_misconfigured(
             feature='Purchased Products are')(
                 views.admin_purchasedproduct)),
         name='purchasedproduct'),
     url(r'^admin/purchased/product/(?P<purchased_product>\d+)/view/(?P<pk>\d+)$',
-        company_in_sitepackages(message_when_no_packages(
+        company_in_sitepackages(message_when_site_misconfigured(
             feature='Purchased Products are')(
                 views.view_job)),
         {'admin': True},
         name="admin_view_job"),
     url(r'^admin/purchased/product/(?P<purchased_product>\d+)/view-invoice',
-        company_in_sitepackages(message_when_no_packages(
+        company_in_sitepackages(message_when_site_misconfigured(
             feature='Purchased Products are')(
                 views.view_invoice)),
         name="admin_view_invoice"),
     url(r'^admin/purchased/product/(?P<purchased_product>\d+)/',
-        company_in_sitepackages(message_when_no_packages(
+        company_in_sitepackages(message_when_site_misconfigured(
             feature='Purchased Products are')(
         views.purchasedjobs_overview)),
         {'admin': True},

--- a/universal/decorators.py
+++ b/universal/decorators.py
@@ -108,7 +108,8 @@ def warn_when(condition, feature, message, link=None, link_text=None,
                    'link': link,
                    'link_text': link_text}
             if not condition(request):
-                if exception: raise exception('{0}: {1}'.format(feature, message))
+                if exception:
+                    raise exception('{0}: {1}'.format(feature, message))
 
                 return render_to_response('warning_page.html',
                                           ctx,

--- a/universal/decorators.py
+++ b/universal/decorators.py
@@ -121,7 +121,8 @@ def warn_when(condition, feature, message, link=None, link_text=None,
 # used in mypartners
 warn_when_inactive = partial(
     warn_when,
-    condition=lambda req: req.user.is_verified and req.user.is_active,
+    condition=lambda req: req.user.is_anonymous() or
+                          (req.user.is_verified and req.user.is_active),
     message='You have yet to activate your account.',
     link='/accounts/register/resend',
     link_text='Resend Activation')

--- a/universal/decorators.py
+++ b/universal/decorators.py
@@ -128,16 +128,22 @@ warn_when_inactive = partial(
     link_text='Resend Activation')
 
 # used in postajob
-warn_when_no_packages = partial(
-    warn_when,
-    condition=lambda req: settings.SITE.canonical_company.has_packages)
+def site_misconfigured(request):
+    try:
+        return settings.SITE.canonical_company.has_packages
+    except AttributeError:
+        return False
 
-message_when_no_packages = partial(
-    warn_when_no_packages,
+warn_when_site_misconfigured = partial(
+    warn_when,
+    condition = site_misconfigured)
+
+message_when_site_misconfigured = partial(
+    warn_when_site_misconfigured,
     message='Please contact your member representative to activate this '
             'feature.')
 
-error_when_no_packages = partial(
-    warn_when_no_packages,
+error_when_site_misconfigured = partial(
+    warn_when_site_misconfigured,
     message='Accessed company owns no site packages.',
     exception=Http404)

--- a/universal/decorators.py
+++ b/universal/decorators.py
@@ -18,7 +18,6 @@ def company_has_access(perm_field):
     inputs:
         :perm_field: The name of the BooleanField on Company that handles
             permissions for the requested feature.
-
     """
     def decorator(view_func):
         def wrap(request, *args, **kwargs):


### PR DESCRIPTION
- If a canonical company isn't set, 404. (instead of 500 caused by Attribute error because canonical company wasn't properly set)
- I also ensured that anonymous users don't see a 500 error and are correctly redirected to the login page instead.