### PR TITLE
my.jobs - saved search - x of more than z jobs, x=z [PD-943]

### DIFF
--- a/mysearches/tests/test_models.py
+++ b/mysearches/tests/test_models.py
@@ -535,11 +535,11 @@ class SavedSearchSendingTests(MyJobsBase):
         # last_sent to one year ago all of the jobs should be old.
         self.saved_search.send_email()
         email = mail.outbox.pop()
-        self.assertIn('Showing 3 of more than 3 total jobs', email.body)
+        self.assertIn('Showing the top 3 jobs', email.body)
 
         self.partner_search.send_email()
         email = mail.outbox.pop()
-        self.assertIn('Showing 3 of more than 3 total jobs', email.body)
+        self.assertIn('Showing the top 3 jobs', email.body)
 
     @patch('urllib2.urlopen')
     def test_some_jobs_new(self, urlopen_mock):
@@ -557,11 +557,11 @@ class SavedSearchSendingTests(MyJobsBase):
         # three days ago one of the jobs should be old.
         self.saved_search.send_email()
         email = mail.outbox.pop()
-        self.assertIn('Showing 1 of more than 1 total jobs', email.body)
+        self.assertIn('Showing the top 1 jobs', email.body)
 
         self.partner_search.send_email()
         email = mail.outbox.pop()
-        self.assertIn('Showing 3 of more than 3 total jobs', email.body)
+        self.assertIn('Showing the top 3 jobs', email.body)
 
     @patch('urllib2.urlopen')
     def test_no_jobs_new(self, urlopen_mock):
@@ -581,7 +581,7 @@ class SavedSearchSendingTests(MyJobsBase):
 
         self.partner_search.send_email()
         email = mail.outbox.pop()
-        self.assertIn('Showing 3 of more than 3 total jobs', email.body)
+        self.assertIn('Showing the top 3 jobs', email.body)
 
     @patch('urllib2.urlopen')
     def test_partner_saved_search_backfill(self, urlopen_mock):
@@ -596,19 +596,19 @@ class SavedSearchSendingTests(MyJobsBase):
         # jobs_per_email is default, so all 3 should get sent.
         self.partner_search.send_email()
         email = mail.outbox.pop()
-        self.assertIn('Showing 3 of more than 3 total jobs', email.body)
+        self.assertIn('Showing the top 3 jobs', email.body)
 
         self.partner_search.jobs_per_email = 2
         self.partner_search.save()
         self.partner_search.send_email()
         email = mail.outbox.pop()
-        self.assertIn('Showing 2 of more than 2 total jobs', email.body)
+        self.assertIn('Showing the top 2 jobs', email.body)
 
         self.partner_search.jobs_per_email = 1
         self.partner_search.save()
         self.partner_search.send_email()
         email = mail.outbox.pop()
-        self.assertIn('Showing 1 of more than 1 total jobs', email.body)
+        self.assertIn('Showing the top 1 jobs', email.body)
 
     @patch('urllib2.urlopen')
     def test_no_jobs(self, urlopen_mock):

--- a/mysearches/tests/test_models.py
+++ b/mysearches/tests/test_models.py
@@ -557,7 +557,7 @@ class SavedSearchSendingTests(MyJobsBase):
         # three days ago one of the jobs should be old.
         self.saved_search.send_email()
         email = mail.outbox.pop()
-        self.assertIn('Showing the top 1 jobs', email.body)
+        self.assertIn('Showing the top job', email.body)
 
         self.partner_search.send_email()
         email = mail.outbox.pop()
@@ -608,7 +608,7 @@ class SavedSearchSendingTests(MyJobsBase):
         self.partner_search.save()
         self.partner_search.send_email()
         email = mail.outbox.pop()
-        self.assertIn('Showing the top 1 jobs', email.body)
+        self.assertIn('Showing the top job', email.body)
 
     @patch('urllib2.urlopen')
     def test_no_jobs(self, urlopen_mock):

--- a/templates/mysearches/email_table_include.html
+++ b/templates/mysearches/email_table_include.html
@@ -12,7 +12,7 @@
 			        	<div style="padding-left: 10px;">
                         {% get_all_jobs_link saved_search.0 as all_jobs_link %}
 				    	{% if saved_search.1 %}
-				        <b>Showing the top {{ saved_search.1|length }} jobs.</b> - <a href="{{ all_jobs_link }}">View All Jobs</a>
+				        <b>Showing the top {{ saved_search.1|length }} jobs</b> - <a href="{{ all_jobs_link }}">View All Jobs</a>
 				        {% else %}
 				        <b>No jobs for the selected time</b> - <a href="{{ all_jobs_link }}">View your search anyway</a>
 				        {% endif %}

--- a/templates/mysearches/email_table_include.html
+++ b/templates/mysearches/email_table_include.html
@@ -12,7 +12,7 @@
 			        	<div style="padding-left: 10px;">
                         {% get_all_jobs_link saved_search.0 as all_jobs_link %}
 				    	{% if saved_search.1 %}
-				        <b>Showing the top {{ saved_search.1|length }} jobs</b> - <a href="{{ all_jobs_link }}">View All Jobs</a>
+				        <b>Showing the top {% if saved_search.1|length == 1 %}job{% else %}{{ saved_search.1|length }} jobs{% endif %}</b> - <a href="{{ all_jobs_link }}">View All Jobs</a>
 				        {% else %}
 				        <b>No jobs for the selected time</b> - <a href="{{ all_jobs_link }}">View your search anyway</a>
 				        {% endif %}

--- a/templates/mysearches/email_table_include.html
+++ b/templates/mysearches/email_table_include.html
@@ -12,7 +12,7 @@
 			        	<div style="padding-left: 10px;">
                         {% get_all_jobs_link saved_search.0 as all_jobs_link %}
 				    	{% if saved_search.1 %}
-				        <b>Showing {{ saved_search.1|length }} of {% if saved_search.2 > saved_search.1.jobs_per_email %}more than {{ saved_search.2 }}{% else %}{{ saved_search.1|length }}{% endif %} total jobs</b> - <a href="{{ all_jobs_link }}">View All Jobs</a>
+				        <b>Showing the top {{ saved_search.1|length }} jobs.</b> - <a href="{{ all_jobs_link }}">View All Jobs</a>
 				        {% else %}
 				        <b>No jobs for the selected time</b> - <a href="{{ all_jobs_link }}">View your search anyway</a>
 				        {% endif %}


### PR DESCRIPTION
Jason's suggestion, "In that case, change the line to read:
This email includes the top N jobs. There may be more on the source site."

Currently it reads:
Showing the top N jobs. - View All Jobs

The suggested text was making "View all Jobs" and the text on the right wrap.
Discuss.