### PR TITLE
[PD-961, PD-985] MyReports Updates

### DIFF
--- a/myreports/decorators.py
+++ b/myreports/decorators.py
@@ -1,0 +1,8 @@
+from functools import partial
+
+from universal.decorators import not_found_when
+
+restrict_to_staff_when = partial(
+    not_found_when,
+    feature="MyReports",
+    message="Feature currently restricted to DirectEmployers staff.")

--- a/myreports/decorators.py
+++ b/myreports/decorators.py
@@ -2,7 +2,8 @@ from functools import partial
 
 from universal.decorators import not_found_when
 
-restrict_to_staff_when = partial(
+restrict_to_staff = partial(
     not_found_when,
+    condition=lambda req: not req.user.is_staff,
     feature="MyReports",
     message="Feature currently restricted to DirectEmployers staff.")

--- a/myreports/tests.py
+++ b/myreports/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/myreports/tests/test_views.py
+++ b/myreports/tests/test_views.py
@@ -20,11 +20,11 @@ class TestReportsOverview(TestCase):
     def test_access_restricted_to_staff(self):
         """Until release, MyReports should only be viewable by staff users."""
 
+        self.user.is_staff = False
+        self.user.save()
         response = self.client.get(reverse('reports_overview'))
-
-        self.assertRedirects(response, "{}?next={}".format(
-            reverse('home'), reverse('reports_overview')))
-
+        
+        self.assertEqual(response.status_code, 404)
 
 class TestEditReport(TestCase):
     """

--- a/myreports/tests/test_views.py
+++ b/myreports/tests/test_views.py
@@ -1,0 +1,34 @@
+"""Tests associated with the various MyReports views."""
+
+from django.test import TestCase
+from django.core.urlresolvers import reverse
+
+from myjobs.tests.test_views import TestClient
+from myjobs.tests.factories import UserFactory
+
+class TestReportsOverview(TestCase):
+    """Tests the reports_overview view."""
+
+    def setUp(self):
+        self.client = TestClient()
+        # TODO: on release of MyReports, change this to set more appropriate
+        #       permissions
+        self.user = UserFactory(email="testuser@directemployers.org",
+                                is_staff=True)
+        self.client.login_user(self.user)
+
+    def test_access_restricted_to_staff(self):
+        """Until release, MyReports should only be viewable by staff users."""
+
+        response = self.client.get(reverse('reports_overview'))
+
+        self.assertRedirects(response, "{}?next={}".format(
+            reverse('home'), reverse('reports_overview')))
+
+
+class TestEditReport(TestCase):
+    """
+    Tests the edit_report view, which implements both editing and viewing of
+    reports.
+    """
+    pass

--- a/myreports/urls.py
+++ b/myreports/urls.py
@@ -2,4 +2,5 @@ from django.conf.urls import patterns, url
 
 urlpatterns = patterns('myreports.views',
     url(r'^view$', 'reports_overview', name='reports_overview'),
+    url(r'^view/edit$', 'edit_report', name='create_report'),
 )

--- a/myreports/views.py
+++ b/myreports/views.py
@@ -1,14 +1,15 @@
-from django.contrib.auth.decorators import user_passes_test
 from django.http import HttpResponse
 from django.shortcuts import render_to_response
 from django.template import RequestContext
 
+from myreports.decorators import restrict_to_staff_when
 
-@user_passes_test(lambda u: u.is_staff)
+
+@restrict_to_staff_when(lambda r: not r.user.is_staff)
 def reports_overview(request):
     return render_to_response('myreports/reports_overview.html', {},
                               RequestContext(request))
 
-@user_passes_test(lambda u: u.is_staff)
+@restrict_to_staff_when(lambda r: not r.user.is_staff)
 def edit_report(request):
     return HttpResponse()

--- a/myreports/views.py
+++ b/myreports/views.py
@@ -1,10 +1,14 @@
-from django.http import Http404
+from django.contrib.auth.decorators import user_passes_test
+from django.http import HttpResponse
 from django.shortcuts import render_to_response
 from django.template import RequestContext
 
 
+@user_passes_test(lambda u: u.is_staff)
 def reports_overview(request):
-    if not request.user.is_staff:
-        raise Http404
     return render_to_response('myreports/reports_overview.html', {},
                               RequestContext(request))
+
+@user_passes_test(lambda u: u.is_staff)
+def edit_report(request):
+    return HttpResponse()

--- a/myreports/views.py
+++ b/myreports/views.py
@@ -2,14 +2,14 @@ from django.http import HttpResponse
 from django.shortcuts import render_to_response
 from django.template import RequestContext
 
-from myreports.decorators import restrict_to_staff_when
+from myreports.decorators import restrict_to_staff
 
 
-@restrict_to_staff_when(lambda r: not r.user.is_staff)
+@restrict_to_staff()
 def reports_overview(request):
     return render_to_response('myreports/reports_overview.html', {},
                               RequestContext(request))
 
-@restrict_to_staff_when(lambda r: not r.user.is_staff)
+@restrict_to_staff()
 def edit_report(request):
     return HttpResponse()

--- a/postajob/decorators.py
+++ b/postajob/decorators.py
@@ -1,4 +1,5 @@
 from functools import partial
+from django.conf import settings
 from universal.decorators import not_found_when, warn_when
 
 # used in postajob

--- a/postajob/decorators.py
+++ b/postajob/decorators.py
@@ -1,0 +1,20 @@
+from functools import partial
+from universal.decorators import not_found_when, warn_when
+
+# used in postajob
+def site_misconfigured(request):
+    try:
+        return not settings.SITE.canonical_company.has_packages
+    except AttributeError:
+        return True
+
+message_when_site_misconfigured = partial(
+    warn_when,
+    condition=site_misconfigured,
+    message='Please contact your member representative to activate this '
+            'feature.')
+
+error_when_site_misconfigured = partial(
+    not_found_when,
+    condition=site_misconfigured,
+    message='Accessed company owns no site packages.')

--- a/postajob/urls.py
+++ b/postajob/urls.py
@@ -1,9 +1,9 @@
 from django.conf.urls import *
 
 from postajob import models, views
-from universal.decorators import (company_in_sitepackages, 
-                                  message_when_site_misconfigured,
-                                  error_when_site_misconfigured)
+from postajob.decorators import (message_when_site_misconfigured,
+                                 error_when_site_misconfigured)
+from universal.decorators import company_in_sitepackages 
 
 
 urlpatterns = patterns(

--- a/templates/myreports/reports_overview.html
+++ b/templates/myreports/reports_overview.html
@@ -8,7 +8,7 @@
     <div class="sidebar">
         <div class="navigation">
             <h2 class="top">Navigation</h2>
-            <a class="btn" href="{% url 'new_report' %}">New Report</a>
+            <a class="btn" href="{% url 'create_report' %}">New Report</a>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Cross-App changes
* I fixed the logic of my `warn_when` decorators to be less confusing
* I added anonymous user redirect behavior to the base decorator
* I moved app-specific decorators to the appropriate apps while keeping the really generic ones in universal.helpers

## MyReports-related changes
* updated url name to match scheme used in other apps
* ~switched to using user_passes_test since:~~
    * ~~@galitskyd  was interested in using the decorator to begin with~~
    * ~~we need the redirect behavior for anonymous login~~
* used a custom version of my decorator
    * we want the redirect behavior for anonymous logins still
    * we want a logged in user to 404, not redirect to the main screen
* created a dummy edit report response so that the overview renders properly
* started writing unit tests