### PR TITLE
[PD-997] Implemented Duplicating a Partner Saved Search

### DIFF
--- a/mypartners/tests/test_views.py
+++ b/mypartners/tests/test_views.py
@@ -885,6 +885,17 @@ class SearchEditTests(MyPartnersTestCase):
                              msg="%s != %s for field %s" %
                                  (v, getattr(search, k), k))
 
+    def test_copy_existing_saved_search(self):
+        saved_search = PartnerSavedSearch.objects.first()
+        response = self.client.post('%s?company=%s&partner=%s&copies=%s' %
+            (reverse('partner_edit_search'), self.company.id,
+             self.partner.id, saved_search.id))
+
+        self.assertEqual(response.status_code, 200)
+
+        # make sure the label is a copy
+        self.assertIn("Copy of %s" % saved_search.label, response.content)
+
     def test_partner_search_for_new_contact_email(self):
         """Confirms that an email is sent when a new user is created for a 
         contact because a saved search was created on that contact's behalf.

--- a/mypartners/views.py
+++ b/mypartners/views.py
@@ -540,6 +540,9 @@ def prm_edit_saved_search(request):
         else:
             values['label'] = "Copy of %s" % values['label']
             values.pop('email', None)
+            values.pop('notes', None)
+            values.pop('custom_message', None)
+            values.pop('partner_message', None)
             form = PartnerSavedSearchForm(initial=values, partner=partner)
     else:
         form = PartnerSavedSearchForm(partner=partner)

--- a/mypartners/views.py
+++ b/mypartners/views.py
@@ -526,11 +526,24 @@ def prm_saved_searches(request):
 def prm_edit_saved_search(request):
     company, partner, user = prm_worthy(request)
     item_id = request.REQUEST.get('id')
+    copy_id = request.REQUEST.get('copies')
+
     if item_id:
         instance = get_object_or_404(PartnerSavedSearch, id=item_id)
         form = PartnerSavedSearchForm(partner=partner, instance=instance)
+    elif copy_id:
+        try:
+            values = PartnerSavedSearch.objects.filter(pk=copy_id).values()[0]
+        except IndexError:
+            # saved search to be copied doesn't exist since values is empty
+            raise Http404
+        else:
+            values['label'] = "Copy of %s" % values['label']
+            values.pop('email', None)
+            form = PartnerSavedSearchForm(initial=values, partner=partner)
     else:
         form = PartnerSavedSearchForm(partner=partner)
+
 
     microsites = company.prm_saved_search_sites.values_list('domain', flat=True)
     microsites = [site.replace('http://', '').replace('https://', '').lower()
@@ -545,6 +558,7 @@ def prm_edit_saved_search(request):
         'content_type': ContentType.objects.get_for_model(PartnerSavedSearch).id,
         'view_name': 'PRM',
     }
+
     return render_to_response('mypartners/partner_edit_search.html', ctx,
                               RequestContext(request))
 

--- a/templates/mysearches/view_full_feed.html
+++ b/templates/mysearches/view_full_feed.html
@@ -115,6 +115,9 @@
             <div class="navigation">
                 <h2>Navigation</h2>
                 <a href="{% url 'partner_edit_search' %}?company={{ company.id }}&partner={{ partner.id }}&id={{ search.partnersavedsearch.id }}" class="btn edit">Edit</a>
+                <a href="{% url 'partner_edit_search' %}?company={{ company.id }}&partner={{ partner.id }}&copies={{ search.partnersavedsearch.id }}" 
+                   class="btn copy"
+                   title="This will create a copy of this saved search to be sent to a different contact.">Copy</a>
             </div>
         </div>
         {% else %}


### PR DESCRIPTION
* see ticket for screenshots
* added relevant unit test
* creates a copy of the existing search with "Copy of" appended to the name and email emptied.