### PR TITLE
[PD-765, PD-1028] Split emails and partner saved search emails in contact record view.

### DIFF
--- a/mypartners/models.py
+++ b/mypartners/models.py
@@ -204,10 +204,7 @@ class Partner(models.Model):
             date_end = date_end + timedelta(1)
             records = records.filter(date_time__lte=date_end)
         if record_type:
-            if record_type == 'email':
-                records = records.filter(contact_type__in=['email', 'pssemail'])
-            else:
-                records = records.filter(contact_type=record_type)
+            records = records.filter(contact_type=record_type)
         if created_by:
             records = records.filter(created_by=created_by)
 

--- a/mypartners/views.py
+++ b/mypartners/views.py
@@ -711,9 +711,7 @@ def prm_records(request):
         response.content = html.content
         return response
 
-    contact_type_choices = [choice for choice in CONTACT_TYPE_CHOICES
-                            if choice[0] != 'pssemail']
-    contact_type_choices.insert(0, ('all', 'All'))
+    contact_type_choices = (('all', 'All'),) + CONTACT_TYPE_CHOICES
 
     contact_choices = [
         (c, c) for c in contact_records.order_by(


### PR DESCRIPTION
Previously, we were joining saved search emails and regular emails. This re-splits them. To test, you can go to "Manage Record" in the record overview (The old PRM one, not the new reports link) and check that the drop down shows the Partner Saved Search Email option.