### PR TITLE
All custom facets should be loaded on job listing homepage [PD-1032]

### DIFF
--- a/seo/views/search_views.py
+++ b/seo/views/search_views.py
@@ -1066,7 +1066,7 @@ def home_page(request):
 
     if site_config.browse_facet_show:
         cust_facets = get_custom_facets(request)
-        custom_facet_counts = helpers.combine_groups(cust_facets)[0:num_facet_items*2]
+        custom_facet_counts = helpers.combine_groups(cust_facets)
 
     ga = settings.SITE.google_analytics.all()
 


### PR DESCRIPTION
Since we can't sort custom facets until we have all of them anyway, we've switched to loading all of the facets at once. This makes homepage do the same.

All tests pass.