### PR TITLE
Change get requests to posts.

### DIFF
--- a/myreports/tests/test_views.py
+++ b/myreports/tests/test_views.py
@@ -71,12 +71,11 @@ class TestSearchRecords(MyReportsTestCase):
     def test_restricted_to_ajax(self):
         """View should only be reachable through AJAX."""
 
-        response = self.client.get(reverse('filter_partners'))
+        response = self.client.post(reverse('filter_partners'))
 
         self.assertEqual(response.status_code, 404)
 
-    @unittest.skip("TODO: Change AJAX requests to GET")
-    def test_restricted_to_get(self):
+    def test_restricted_to_post(self):
         """GET requests should raise a 404."""
 
         response = self.client.get(reverse('filter_partners'),
@@ -90,10 +89,10 @@ class TestSearchRecords(MyReportsTestCase):
         # records to be filtered out
         ContactRecordFactory.create_batch(10, contact_name='John Doe')
 
-        response = self.client.get(reverse('filter_records',
-                                   kwargs={'model': 'contactrecord'}),
-                                   {'contact_name': 'Joe Shmoe'},
-                                   HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        response = self.client.post(reverse('filter_records',
+                                    kwargs={'model': 'contactrecord'}),
+                                    {'contact_name': 'Joe Shmoe'},
+                                    HTTP_X_REQUESTED_WITH='XMLHttpRequest')
         output = json.loads(response.content)
 
         self.assertEqual(response.status_code, 200)
@@ -106,9 +105,9 @@ class TestSearchRecords(MyReportsTestCase):
         partner = PartnerFactory(name="Wrong Partner")
         ContactRecordFactory.create_batch(10, partner=partner)
 
-        response = self.client.get(reverse('filter_records',
-                                   kwargs={'model': 'contactrecord'}),
-                                   HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        response = self.client.post(reverse('filter_records',
+                                    kwargs={'model': 'contactrecord'}),
+                                    HTTP_X_REQUESTED_WITH='XMLHttpRequest')
         output = json.loads(response.content)
 
         self.assertEqual(response.status_code, 200)
@@ -121,9 +120,9 @@ class TestSearchRecords(MyReportsTestCase):
         PartnerFactory.create_batch(9, name="Test Partner",
                                     owner=self.company)
 
-        response = self.client.get(reverse('filter_partners'),
-                                   {'name': 'Test Partner'},
-                                   HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        response = self.client.post(reverse('filter_partners'),
+                                    {'name': 'Test Partner'},
+                                    HTTP_X_REQUESTED_WITH='XMLHttpRequest')
         output = response.context
 
         # ContactRecordFactory creates 10 partners in setUp
@@ -135,9 +134,9 @@ class TestSearchRecords(MyReportsTestCase):
 
         ContactFactory.create_batch(10, partner__owner=self.company)
 
-        response = self.client.get(reverse('filter_partners'),
-                                   {'contact': range(1, 6)},
-                                   HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        response = self.client.post(reverse('filter_partners'),
+                                    {'contact': range(1, 6)},
+                                    HTTP_X_REQUESTED_WITH='XMLHttpRequest')
         output = response.context
 
         self.assertEqual(response.status_code, 200)
@@ -153,9 +152,9 @@ class TestSearchRecords(MyReportsTestCase):
         ContactFactory.create_batch(10, name="Jane Smith",
                                     partner=self.partner)
 
-        response = self.client.get(reverse('filter_contacts'),
-                                   {'name': 'Jane Doe'},
-                                   HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        response = self.client.post(reverse('filter_contacts'),
+                                    {'name': 'Jane Doe'},
+                                    HTTP_X_REQUESTED_WITH='XMLHttpRequest')
         output = response.context
 
         self.assertEqual(response.status_code, 200)

--- a/myreports/views.py
+++ b/myreports/views.py
@@ -64,18 +64,23 @@ def filter_records(request, model='contactrecord', output='json'):
                 'model': 'partner',
                 'output': 'myreports/example_view.html'}))
     """
-    if request.is_ajax() and request.method == 'GET':
+    if request.is_ajax() and request.method == 'POST':
         company = get_company_or_404(request)
 
         # get rid of empty params and flatten single-item lists
         params = {}
-        for key in request.GET.keys():
-            value = request.GET.getlist(key)
+        for key in request.POST.keys():
+            value = request.POST.getlist(key)
             if value:
                 if len(value) > 1:
                     params[key] = value
                 elif value[0]:
                     params[key] = value[0]
+
+        csrftoken = params.pop('csrfmiddlewaretoken', None)
+        if not csrftoken:
+            # probably better as a 403, what we don't use that anywhere else...
+            raise Http404("CSRF Middleware Token is missing!")
 
         # fetch results from cache if available
         records = get_model('mypartners', model).objects.from_search(


### PR DESCRIPTION
- re-enables test that checks request type
- 404 if csrfmiddlewaretoken is some how missing from post request and django doesn't catch it
- updates tests to use post instead of get