### PR TITLE
[PD-1051, PD-1052] Filtering by City in myreports

### DIFF
--- a/mypartners/models.py
+++ b/mypartners/models.py
@@ -214,6 +214,8 @@ class Contact(models.Model):
 
         start_date = parameters.pop('start_date', None)
         end_date = parameters.pop('end_date', None)
+        state = parameters.pop('state', None)
+        city = parameters.pop('city', None)
 
         # using a foreign relationship, so can't just filter twice
         if start_date and end_date:
@@ -227,8 +229,6 @@ class Contact(models.Model):
             records = records.filter(
                 partner__contactrecord__date_time__lte=end_date)
 
-        # parse state
-        state = parameters.pop('state', False)
         if state:
             state_query = models.Q()
             # match state synonyms when querying
@@ -237,6 +237,9 @@ class Contact(models.Model):
                     locations__state__iexact=synonym)
 
             records = records.filter(state_query)
+
+        if city:
+            records = records.filter(locations__city__icontains=city)
 
         return records
 
@@ -339,6 +342,8 @@ class Partner(models.Model):
 
         start_date = parameters.pop('start_date', None)
         end_date = parameters.pop('end_date', None)
+        state = parameters.pop('state', None)
+        city = parameters.pop('city', None)
 
         # using a foreign relationship, so can't just filter twice
         if start_date and end_date:
@@ -349,8 +354,6 @@ class Partner(models.Model):
         elif end_date:
             records = records.filter(contactrecord__date_time__lte=end_date)
 
-        # parse state
-        state = parameters.pop('state', False)
         if state:
             state_query = models.Q()
             # match state synonyms when querying
@@ -359,6 +362,9 @@ class Partner(models.Model):
                     contact__locations__state__iexact=synonym)
 
             records = records.filter(state_query)
+
+        if city:
+            records = records.filter(contact__locations__city__icontains=city)
 
         return records
 

--- a/myreports/tests/test_views.py
+++ b/myreports/tests/test_views.py
@@ -186,6 +186,22 @@ class TestFilterRecords(MyReportsTestCase):
         
         self.assertEqual(len(output['records']), 10)
 
+    def test_filter_by_city(self):
+        """Tests that filtering by city works."""
+
+        indianapolis = LocationFactory(city="Indianapolis")
+        ContactFactory.create_batch(10, name="Jane Doe", partner=self.partner,
+                                    locations=[indianapolis])
+
+        response = self.client.post(
+            reverse('filter_records',
+                    kwargs={'app': 'mypartners', 'model': 'contact'}),
+            {'city': 'indianapolis'},
+            HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        output = json.loads(response.content)
+        
+        self.assertEqual(len(output['records']), 10)
+
     def test_order_by(self):
         """Tests that `order_by` parameter is passed to `QuerySet`."""
 


### PR DESCRIPTION
* Extended TestClient so that you can specify a path and/or data at object creation.
* Refactored myreports unit tests using these improvements.

Basically, if you need to do multiple tests that hit the same view (but with different parameters), you can simply create a client with that path:
```python
client = TestClient(path='/foo/bar')
```
Now, when you call `post` or `get`, you don't have to pass the path every time:
```python
self.client.post()
```
If you do this, you can no longer pass a raw dict as data, and must name it explicitly:
```python
self.client.post(data={'foo': 'bar'})
```

If you don't pass in a path to the constructor (or manually pass a path when you call `get` or `post`, `TestClient` will act exactly is it always has (hence why older tests are still passing).