### PR TITLE
[PD-791] Reduce number of queries topbar makes

### DIFF
--- a/myjobs/templatetags/common_tags.py
+++ b/myjobs/templatetags/common_tags.py
@@ -7,7 +7,7 @@ from django.conf import settings
 from myjobs import version
 from myjobs.models import User
 from myjobs.helpers import get_completion, make_fake_gravatar
-from seo.models import CompanyUser
+from seo.models import Company
 from universal.helpers import get_company
 
 from django.db.models.loading import get_model
@@ -89,7 +89,10 @@ def get_company_name(user):
     """
 
     # Only return companies for which the user is a company user
-    return user.company_set.filter(companyuser__user=user)
+    try:
+        return user.company_set.filter(companyuser__user=user)
+    except ValueError:
+        return Company.objects.none()
 
 
 @register.simple_tag(takes_context=True)

--- a/myjobs/templatetags/common_tags.py
+++ b/myjobs/templatetags/common_tags.py
@@ -85,16 +85,11 @@ def get_company_name(user):
     :user: User instance
 
     Outputs:
-    :company_list: A list of company names, or an empty string if there are no
-                   companies associated with the user
+    A `QuerySet` of companies for which the user is a `CompanyUser`.
     """
 
-    try:
-        companies = CompanyUser.objects.filter(user=user)
-        company_list = [company.company for company in companies]
-        return company_list
-    except CompanyUser.DoesNotExist:
-        return {}
+    # Only return companies for which the user is a company user
+    return user.company_set.filter(companyuser__user=user)
 
 
 @register.simple_tag(takes_context=True)

--- a/myjobs/views.py
+++ b/myjobs/views.py
@@ -20,7 +20,7 @@ from django.views.generic import TemplateView
 
 from captcha.fields import ReCaptchaField
 
-from universal.helpers import get_domain
+from universal.helpers import get_domain, get_company
 from myjobs.decorators import user_is_allowed
 from myjobs.forms import ChangePasswordForm, EditCommunicationForm
 from myjobs.helpers import expire_login, log_to_jira, get_title_template

--- a/myjobs/views.py
+++ b/myjobs/views.py
@@ -20,7 +20,7 @@ from django.views.generic import TemplateView
 
 from captcha.fields import ReCaptchaField
 
-from universal.helpers import get_domain, get_company
+from universal.helpers import get_domain
 from myjobs.decorators import user_is_allowed
 from myjobs.forms import ChangePasswordForm, EditCommunicationForm
 from myjobs.helpers import expire_login, log_to_jira, get_title_template


### PR DESCRIPTION
Before, the number of queries made by the top bar grew linearly proportional to the number of companies the logged in user belonged to. This is now constant. For example, with 23 companies, 50 queries were being made, where as with this code, that was reduced to 27. Other queries seem to be tied to middleware and a few other things, which I expect can be tackled as a separate issue. 