### PR TITLE
Add fields to partner saved search detail page [PD-1027]

### DIFF
--- a/mypartners/tests/test_views.py
+++ b/mypartners/tests/test_views.py
@@ -719,10 +719,12 @@ class SearchFeedTests(MyPartnersTestCase):
         details = soup.find(class_="sidebar")
         self.assertIn('Active', details.find('h2').get_text())
         texts = ['http://www.my.jobs/jobs',
+                 'None',
                  'Weekly on Monday',
                  'Relevance',
                  'Never',
                  'alice@example.com',
+                 str(self.search.jobs_per_email),
                  'All jobs from www.my.jobs']
         details = details('span', recursive=False)
         for i, text in enumerate(texts):

--- a/mypartners/views.py
+++ b/mypartners/views.py
@@ -656,12 +656,8 @@ def partner_view_full_feed(request):
     saved_search = get_object_or_404(PartnerSavedSearch, id=search_id)
 
     if company == saved_search.partnersavedsearch.provider:
-        url_of_feed = url_sort_options(saved_search.feed,
-                                       saved_search.sort_by,
-                                       saved_search.frequency)
         try:
-            items, count = parse_feed(url_of_feed, saved_search.frequency,
-                                      saved_search.jobs_per_email)
+            items, count = saved_search.get_feed_items()
         except HTTPError:
             items = None
             count = 0
@@ -683,6 +679,7 @@ def partner_view_full_feed(request):
         'company': company,
         'start_date': start_date,
         'count': count,
+        'new_jobs': len([item for item in items if item.get('new')]),
     }
 
     return render_to_response('mysearches/view_full_feed.html', ctx,

--- a/mysearches/models.py
+++ b/mysearches/models.py
@@ -122,7 +122,7 @@ class SavedSearch(models.Model):
 
     def get_feed_items(self, num_items=None):
         num_items = num_items or self.jobs_per_email
-        url_of_feed = url_sort_options(self.feed, self.sort_by)
+        url_of_feed = url_sort_options(self.feed, self.sort_by, self.frequency)
         url_of_feed = update_url_if_protected(url_of_feed, self.user)
         parse_feed_args = {
             'feed_url': url_of_feed,

--- a/templates/mysearches/view_full_feed.html
+++ b/templates/mysearches/view_full_feed.html
@@ -65,7 +65,7 @@
                 <a href="{{search.url}}" target="_blank">{{search.url|truncatechars:40}}</a>
             </span>
             <br/><br/>
-            <b>Source Codes & Campaigns</b>
+            <b>Source Codes &amp; Campaigns</b>
             <br/>
             <span>{% if search.url_extras %}{{ search.url_extras }}{% else %}None{% endif %}</span>
             <br/><br/>

--- a/templates/mysearches/view_full_feed.html
+++ b/templates/mysearches/view_full_feed.html
@@ -65,6 +65,10 @@
                 <a href="{{search.url}}" target="_blank">{{search.url|truncatechars:40}}</a>
             </span>
             <br/><br/>
+            <b>Source Codes & Campaigns</b>
+            <br/>
+            <span>{% if search.url_extras %}{{ search.url_extras }}{% else %}None{% endif %}</span>
+            <br/><br/>
             <b>Frequency</b>
             <br/>
             <span>
@@ -94,6 +98,10 @@
             <span>
                 {{search.email}}
             </span>
+            <br/><br/>
+            <b>Jobs per Email</b>
+            <br/>
+            <span>{{ search.jobs_per_email }}{% if new_jobs != search.jobs_per_email %} ({{ new_jobs }} new){% endif %}</span>
             <br/><br/>
             <b>Tags</b>
             <br/>


### PR DESCRIPTION
The number of new jobs is shown under "Jobs per Email" as long as it is different from what the member chose. In this picture, we tried to do 100 jobs per email but only 44 were new. In the event that there were 100 new jobs, the 100 would still be displayed but there would be no parenthesized number next to it.

Right now the number in the header and the number of new jobs are the same. I don't think that's a given, but I'm not sure.

![2015-02-25-085246_975x647_scrot](https://cloud.githubusercontent.com/assets/3379265/6371621/97ae682e-bccb-11e4-922a-7b567a26a105.png)

All tests pass.