### PR TITLE
Ensures partner saved searches backfill properly [ST-1029]

### DIFF
--- a/mysearches/models.py
+++ b/mysearches/models.py
@@ -122,7 +122,8 @@ class SavedSearch(models.Model):
 
     def get_feed_items(self, num_items=None):
         num_items = num_items or self.jobs_per_email
-        url_of_feed = url_sort_options(self.feed, self.sort_by, self.frequency)
+        url_of_feed = url_sort_options(self.feed, self.sort_by, self.frequency,
+                                       hasattr(self, 'partnersavedsearch'))
         url_of_feed = update_url_if_protected(url_of_feed, self.user)
         parse_feed_args = {
             'feed_url': url_of_feed,


### PR DESCRIPTION
We shouldn't be adding days_ago to partner saved search feeds. We should also use the largest span of time available to us, either the last sent date or a value calculated based on today or the selected interval.

All tests pass.