### PR TITLE
Icon paths should be prefaced with a slash [PD-230]

### DIFF
--- a/social_links/models.py
+++ b/social_links/models.py
@@ -30,7 +30,7 @@ class SocialLinkType(models.Model):
             filename = 'unnamed_file'
 
         uid = uuid.uuid4()
-        location_template = 'social-icons/%s/%s/%s'
+        location_template = '/social-icons/%s/%s/%s'
         if (getattr(settings, 'DEFAULT_FILE_STORAGE') !=
                 'storages.backends.s3boto.S3BotoStorage'):
             location_template = 'files/' + location_template


### PR DESCRIPTION
The files are getting uploaded to the correct locations and default_storage is smart enough to correct the links when clicked in the admin, but this slash is missing when we prepend our cloudfront url.

All tests pass.