### PR TITLE
Reporting Refactor

### DIFF
--- a/default_settings.py
+++ b/default_settings.py
@@ -260,7 +260,6 @@ INSTALLED_APPS = (
     'saved_search',
     'taggit',
     'fsm',
-    'report_tools',
 )
 
 # Captcha SSL

--- a/mypartners/models.py
+++ b/mypartners/models.py
@@ -289,11 +289,11 @@ class Contact(models.Model):
             contact_name=self.name, contact_email=self.email)
 
     @property
-    def communication_records(self):
+    def communications(self):
         return self.contact_records.exclude(contact_type='job')
 
     @property
-    def referral_records(self):
+    def referrals(self):
         return self.contact_records.filter(contact_type='job')
 
 

--- a/myreports/helpers.py
+++ b/myreports/helpers.py
@@ -6,16 +6,15 @@ from itertools import chain
 from django.core import serializers
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db.models.loading import get_model
+from django.db.models.query import QuerySet
 from mypartners.models import CONTACT_TYPE_CHOICES
 
 
-def serialize(fmt, records, output=None, counts=None, as_is=False):
+def serialize(fmt, data, output=None, counts=None):
     # TODO: see if i can preserve annotations using `values`
-    if as_is:
-        data = records
-    else:
+    if isinstance(data, QuerySet):
         data = [dict({'pk': record['pk']}, **record['fields'])
-                for record in serializers.serialize('python', records)]
+                for record in serializers.serialize('python', data)]
 
         if counts:
             data = [dict({'count': counts[record['pk']]}, **record)
@@ -64,7 +63,7 @@ def humanize(records):
     # * allow other models to be humanized, maybe generalize the things being
     # * humanized and create a Humanize object?
 
-    # convert tag ids to values
+    # convert tag ids to names
     contact_types = dict(CONTACT_TYPE_CHOICES)
     tag_ids = set(chain.from_iterable(record['tags'] for record in records))
     tags = dict(get_model('mypartners', 'tag').objects.filter(

--- a/myreports/migrations/0001_initial.py
+++ b/myreports/migrations/0001_initial.py
@@ -17,7 +17,7 @@ class Migration(SchemaMigration):
             ('created_on', self.gf('django.db.models.fields.DateTimeField')(auto_now_add=True, blank=True)),
             ('app', self.gf('django.db.models.fields.CharField')(max_length=50)),
             ('model', self.gf('django.db.models.fields.CharField')(max_length=50)),
-            ('params', self.gf('django.db.models.fields.CharField')(max_length=255)),
+            ('params', self.gf('django.db.models.fields.TextField')()),
             ('results', self.gf('django.db.models.fields.files.FileField')(max_length=100)),
         ))
         db.send_create_signal(u'myreports', ['Report'])
@@ -86,7 +86,7 @@ class Migration(SchemaMigration):
             'model': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
             'name': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
             'owner': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['seo.Company']"}),
-            'params': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'params': ('django.db.models.fields.TextField', [], {}),
             'results': ('django.db.models.fields.files.FileField', [], {'max_length': '100'})
         },
         u'postajob.package': {

--- a/myreports/migrations/0001_initial.py
+++ b/myreports/migrations/0001_initial.py
@@ -11,11 +11,12 @@ class Migration(SchemaMigration):
         # Adding model 'Report'
         db.create_table(u'myreports_report', (
             (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
-            ('name', self.gf('django.db.models.fields.CharField')(max_length=100)),
+            ('name', self.gf('django.db.models.fields.CharField')(max_length=50)),
             ('created_by', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['myjobs.User'])),
             ('owner', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['seo.Company'])),
             ('created_on', self.gf('django.db.models.fields.DateTimeField')(auto_now_add=True, blank=True)),
-            ('path', self.gf('django.db.models.fields.CharField')(max_length=255)),
+            ('app', self.gf('django.db.models.fields.CharField')(max_length=50)),
+            ('model', self.gf('django.db.models.fields.CharField')(max_length=50)),
             ('params', self.gf('django.db.models.fields.CharField')(max_length=255)),
             ('results', self.gf('django.db.models.fields.files.FileField')(max_length=100)),
         ))
@@ -78,13 +79,14 @@ class Migration(SchemaMigration):
         },
         u'myreports.report': {
             'Meta': {'object_name': 'Report'},
+            'app': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
             'created_by': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['myjobs.User']"}),
             'created_on': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
-            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
             'owner': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['seo.Company']"}),
             'params': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
-            'path': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
             'results': ('django.db.models.fields.files.FileField', [], {'max_length': '100'})
         },
         u'postajob.package': {

--- a/myreports/models.py
+++ b/myreports/models.py
@@ -11,7 +11,7 @@ class Report(models.Model):
     app = models.CharField(max_length=50)
     model = models.CharField(max_length=50)
     # json encoded string of the params used to filter
-    params = models.CharField(max_length=255)
+    params = models.TextField()
     results = models.FileField(upload_to='reports')
 
     def __init__(self, *args, **kwargs):

--- a/myreports/models.py
+++ b/myreports/models.py
@@ -1,5 +1,6 @@
 import json
 from django.db import models
+from django.db.models.loading import get_model
 
 
 class Report(models.Model):
@@ -7,8 +8,8 @@ class Report(models.Model):
     created_by = models.ForeignKey('myjobs.User')
     owner = models.ForeignKey('seo.Company')
     created_on = models.DateTimeField(auto_now_add=True)
-    # path used to generate the report; identifies the app and model queried on
-    path = models.CharField(max_length=255)
+    app = models.CharField(max_length=50)
+    model = models.CharField(max_length=50)
     # json encoded string of the params used to filter
     params = models.CharField(max_length=255)
     results = models.FileField(upload_to='reports')
@@ -27,3 +28,8 @@ class Report(models.Model):
     @property
     def python(self):
         return json.loads(self._results)
+
+    @property
+    def queryset(self):
+        pks = [record['pk'] for record in self.python]
+        return get_model(self.app, self.model).objects.filter(pk__in=pks)

--- a/myreports/urls.py
+++ b/myreports/urls.py
@@ -15,5 +15,6 @@ urlpatterns = patterns(
         name='create_report'),
     url(r'ajax/get-report', 'view_report', name='get_report'),
     url(r'ajax/get-inputs', 'get_inputs', name='get_inputs'),
+    url(r'ajax/get-counts', 'get_counts', name='get_counts'),
     url(r'^download$', 'download_report', name='download_report'),
 )

--- a/myreports/urls.py
+++ b/myreports/urls.py
@@ -13,7 +13,7 @@ urlpatterns = patterns(
         'create_report',
         {'app': 'mypartners'},
         name='create_report'),
-    url(r'ajax/get-report', 'get_report', name='get_report'),
+    url(r'ajax/get-report', 'view_report', name='get_report'),
     url(r'ajax/get-inputs', 'get_inputs', name='get_inputs'),
     url(r'^download$', 'download_report', name='download_report'),
 )

--- a/myreports/views.py
+++ b/myreports/views.py
@@ -222,7 +222,8 @@ def get_counts(request):
         'referrals': records.referrals,
         'contacts': list(records.contacts)}
 
-    return HttpResponse(json.dumps(ctx, indent=4), content_type='application/json')
+    return HttpResponse(
+        json.dumps(ctx), content_type='application/json; charset=utf-8')
 
 
 def download_report(request):

--- a/myreports/views.py
+++ b/myreports/views.py
@@ -33,7 +33,6 @@ def reports(request):
 
     reports = Report.objects.filter(owner=company).order_by("-created_on")
     report_count = reports.count()
-    print report_count
     past_reports = reports[:10]
 
     ctx = {
@@ -180,7 +179,7 @@ def create_report(request, app, model):
     return HttpResponse()
 
 
-def get_report(request):
+def view_report(request):
     if request.is_ajax() and request.method == "POST":
         report_id = request.POST['report']
         report = Report.objects.get(id=report_id)

--- a/myreports/views.py
+++ b/myreports/views.py
@@ -206,6 +206,25 @@ def get_inputs(request):
         return Http404("This view is only reachable via an AJAX POST request.")
 
 
+def get_counts(request):
+    report_id = request.GET['report']
+    report = Report.objects.get(id=report_id)
+
+    records = report.queryset
+    ctx = {
+        'emails': records.emails,
+        'calls': records.phone_calls,
+        'meetings': records.meetings,
+        'applications': records.applications,
+        'interviews': records.interviews,
+        'hires': records.hires,
+        'communications': records.communication_activity.count(),
+        'referrals': records.referrals,
+        'contacts': list(records.contacts)}
+
+    return HttpResponse(json.dumps(ctx, indent=4), content_type='application/json')
+
+
 def download_report(request):
     report_id = request.GET.get('report', 0)
     report = get_object_or_404(get_model('myreports', 'report'), pk=report_id)

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,5 +46,4 @@ requests==2.3.0
 selenium==2.42.1
 unicodecsv==0.9.4
 bidict==0.3.1
-django-report-tools==0.2.2
 validate-email==1.2


### PR DESCRIPTION
Some minor refactoring before I begin working on generating chart data for the new reports template. I'm putting this up now because I'd like to get the model changes in before they hit production (so that we don't have two migrations). Speaking of which, @JLMcLaugh  would you be opposed to me working these changes as a hotfix against staging? Alternatively, since (as far as I understand) myreports isn't being released until the end of this sprint, we could do a zero migration before moving forward for myreports.

## Model Changes
- added a new manager to `ContactRecord` which will allow us to get at numbers more easily: `emails`, `phone_calls`, `meetings`, `applications`, `interviews`, `hires`, and the not so aptly labeled `records`.\
- added new properties to `Contact` instances in a similar vein: `communications`, 'referrals`, `contact_records`.
- `path` has been replaced by `app` and `model`
- It is now possible to get the records queryset by accessing a `Report` instance's `queryset` property
- changed params to text field with unlimited length to prevent truncation

## View Changes
- renamed `get_records` to `view_records`