### PR TITLE
Port Old Reports

### DIFF
--- a/default_settings.py
+++ b/default_settings.py
@@ -260,7 +260,6 @@ INSTALLED_APPS = (
     'saved_search',
     'taggit',
     'fsm',
-    'report_tools',
 )
 
 # Captcha SSL

--- a/mypartners/models.py
+++ b/mypartners/models.py
@@ -284,19 +284,6 @@ class Contact(models.Model):
         query_string = urlencode(params)
         return "%s?%s" % (base_urls[self.content_type.name], query_string)
 
-    @property
-    def contact_records(self):
-        return ContactRecord.objects.filter(
-            contact_name=self.name, contact_email=self.email)
-
-    @property
-    def communications(self):
-        return self.contact_records.exclude(contact_type='job')
-
-    @property
-    def referrals(self):
-        return self.contact_records.filter(contact_type='job')
-
 
 @receiver(pre_delete, sender=Contact, dispatch_uid='pre_delete_contact_signal')
 def delete_contact(sender, instance, using, **kwargs):
@@ -569,6 +556,9 @@ class ContactRecordQuerySet(SearchParameterQuerySet):
 
     @property
     def contacts(self):
+        return self.values('contact_name', 'contact_email').annotate(
+            count=models.Count('contact_name')).distinct()
+
         q = models.Q()
 
         for value in self.values('contact_name',

--- a/mypartners/models.py
+++ b/mypartners/models.py
@@ -571,7 +571,8 @@ class ContactRecordQuerySet(SearchParameterQuerySet):
     def contacts(self):
         q = models.Q()
 
-        for value in self.values('contact_name', 'contact_email').distinct():
+        for value in self.values('contact_name',
+                                 'contact_email').distinct().order_by():
             q |= models.Q(
                 name=value['contact_name'], email=value['contact_email'])
 

--- a/mypartners/models.py
+++ b/mypartners/models.py
@@ -559,15 +559,6 @@ class ContactRecordQuerySet(SearchParameterQuerySet):
         return self.values('contact_name', 'contact_email').annotate(
             count=models.Count('contact_name')).distinct()
 
-        q = models.Q()
-
-        for value in self.values('contact_name',
-                                 'contact_email').distinct().order_by():
-            q |= models.Q(
-                name=value['contact_name'], email=value['contact_email'])
-
-        return Contact.objects.filter(q)
-
 
 class ContactRecordManager(SearchParameterManager):
     def __init__(self, *args, **kwargs):

--- a/mypartners/models.py
+++ b/mypartners/models.py
@@ -289,11 +289,11 @@ class Contact(models.Model):
             contact_name=self.name, contact_email=self.email)
 
     @property
-    def communication_records(self):
+    def communications(self):
         return self.contact_records.exclude(contact_type='job')
 
     @property
-    def referral_records(self):
+    def referrals(self):
         return self.contact_records.filter(contact_type='job')
 
 

--- a/mypartners/views.py
+++ b/mypartners/views.py
@@ -930,14 +930,14 @@ def partner_main_reports(request):
     company, partner, _ = prm_worthy(request)
     params = parse_params(request.GET)
     records = filter_records(request, ContactRecord, params)
-    contacts = records.contacts.order_by('-count')
+    contacts = records.contacts
     # calculate 'All Others' in Top Contacts (when more than 3)
     total_others = 0
     if contacts.count() > 3:
         others = contacts[3:]
         contact_records = contacts[:3]
 
-    total_others = sum(contact['count'] for contact in others)
+    total_others = sum(contact['records'] for contact in others)
 
     ctx = {
         'admin_id': request.REQUEST.get('admin'),

--- a/mypartners/views.py
+++ b/mypartners/views.py
@@ -929,8 +929,6 @@ def get_uploaded_file(request):
 def partner_main_reports(request):
     company, partner, user = prm_worthy(request)
     dt_range, date_str, records = get_records_from_request(request)
-    total_records_wo_followup = records.exclude(contact_type='job').count()
-    referral = records.filter(contact_type='job').count()
 
     # need to order_by -count to keep the "All Contacts" list in proper order
     all_contacts_with_records = records\
@@ -990,13 +988,14 @@ def partner_main_reports(request):
         for contact in others:
             total_others += contact['count']
 
+    contacts = records.contacts
+
     ctx = {
         'admin_id': request.REQUEST.get('admin'),
+        'records': records,
         'partner': partner,
         'company': company,
         'contacts': contacts,
-        'total_records': total_records_wo_followup,
-        'referral': referral,
         'top_contacts': contact_records,
         'others': total_others,
         'view_name': 'PRM',

--- a/mypartners/views.py
+++ b/mypartners/views.py
@@ -1007,6 +1007,7 @@ def partner_main_reports(request):
                               RequestContext(request))
 
 
+# TODO: HERE
 @company_has_access('prm_access')
 def partner_get_records(request):
     if request.method == 'GET':

--- a/mypartners/views.py
+++ b/mypartners/views.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict
 from datetime import date, timedelta
 from email.parser import HeaderParser
 from email.utils import getaddresses
@@ -21,7 +22,6 @@ from django.core.urlresolvers import reverse
 from django.utils.html import strip_tags
 from django.utils.text import force_text
 from django.utils.timezone import localtime, now
-from django.utils.datastructures import SortedDict
 from django.views.decorators.csrf import csrf_exempt
 from urllib2 import HTTPError
 
@@ -963,10 +963,9 @@ def partner_get_records(request):
 
         dt_range, date_str, records = get_records_from_request(request)
         records = records.exclude(contact_type='job')
-        email = records.filter(contact_type='email').count()
-        email += records.filter(contact_type='pssemail').count()
-        phone = records.filter(contact_type='phone').count()
-        meetingorevent = records.filter(contact_type='meetingorevent').count()
+        email = records.emails + records.saved_searches
+        phone = records.phone_calls
+        meetingorevent = records.meetings
 
         # figure names
         if email != 1:
@@ -982,15 +981,12 @@ def partner_get_records(request):
         else:
             meetingorevent_name = 'Meetings & Events'
 
-        data = SortedDict()
-
-        data['email'] = {"count": email, "name": email_name,
-                         'typename': 'email'}
-        data['phone'] = {"count": phone, "name": phone_name,
-                         'typename': 'phone'}
-        data['meetingorevent'] = {"count": meetingorevent,
-                                  "name": meetingorevent_name,
-                                  "typename": "meetingorevent"}
+        data = OrderedDict(
+            email={'count': email, 'name': email_name, 'typename': 'email'},
+            phone={'count': phone, "name": phone_name, 'typename': 'phone'},
+            meetingorevent={'count': meetingorevent,
+                            'name': meetingorevent_name,
+                            'typename': 'meetingorevent'})
 
         return HttpResponse(json.dumps(data))
     else:

--- a/myreports/helpers.py
+++ b/myreports/helpers.py
@@ -6,16 +6,15 @@ from itertools import chain
 from django.core import serializers
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db.models.loading import get_model
+from django.db.models.query import QuerySet
 from mypartners.models import CONTACT_TYPE_CHOICES
 
 
-def serialize(fmt, records, output=None, counts=None, as_is=False):
+def serialize(fmt, data, output=None, counts=None):
     # TODO: see if i can preserve annotations using `values`
-    if as_is:
-        data = records
-    else:
+    if isinstance(data, QuerySet):
         data = [dict({'pk': record['pk']}, **record['fields'])
-                for record in serializers.serialize('python', records)]
+                for record in serializers.serialize('python', data)]
 
         if counts:
             data = [dict({'count': counts[record['pk']]}, **record)
@@ -64,7 +63,7 @@ def humanize(records):
     # * allow other models to be humanized, maybe generalize the things being
     # * humanized and create a Humanize object?
 
-    # convert tag ids to values
+    # convert tag ids to names
     contact_types = dict(CONTACT_TYPE_CHOICES)
     tag_ids = set(chain.from_iterable(record['tags'] for record in records))
     tags = dict(get_model('mypartners', 'tag').objects.filter(

--- a/myreports/migrations/0001_initial.py
+++ b/myreports/migrations/0001_initial.py
@@ -11,11 +11,12 @@ class Migration(SchemaMigration):
         # Adding model 'Report'
         db.create_table(u'myreports_report', (
             (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
-            ('name', self.gf('django.db.models.fields.CharField')(max_length=100)),
+            ('name', self.gf('django.db.models.fields.CharField')(max_length=50)),
             ('created_by', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['myjobs.User'])),
             ('owner', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['seo.Company'])),
             ('created_on', self.gf('django.db.models.fields.DateTimeField')(auto_now_add=True, blank=True)),
-            ('path', self.gf('django.db.models.fields.CharField')(max_length=255)),
+            ('app', self.gf('django.db.models.fields.CharField')(max_length=50)),
+            ('model', self.gf('django.db.models.fields.CharField')(max_length=50)),
             ('params', self.gf('django.db.models.fields.CharField')(max_length=255)),
             ('results', self.gf('django.db.models.fields.files.FileField')(max_length=100)),
         ))
@@ -78,13 +79,14 @@ class Migration(SchemaMigration):
         },
         u'myreports.report': {
             'Meta': {'object_name': 'Report'},
+            'app': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
             'created_by': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['myjobs.User']"}),
             'created_on': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
-            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
             'owner': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['seo.Company']"}),
             'params': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
-            'path': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
             'results': ('django.db.models.fields.files.FileField', [], {'max_length': '100'})
         },
         u'postajob.package': {

--- a/myreports/models.py
+++ b/myreports/models.py
@@ -1,5 +1,6 @@
 import json
 from django.db import models
+from django.db.models.loading import get_model
 
 
 class Report(models.Model):
@@ -7,8 +8,8 @@ class Report(models.Model):
     created_by = models.ForeignKey('myjobs.User')
     owner = models.ForeignKey('seo.Company')
     created_on = models.DateTimeField(auto_now_add=True)
-    # path used to generate the report; identifies the app and model queried on
-    path = models.CharField(max_length=255)
+    app = models.CharField(max_length=50)
+    model = models.CharField(max_length=50)
     # json encoded string of the params used to filter
     params = models.CharField(max_length=255)
     results = models.FileField(upload_to='reports')
@@ -27,3 +28,8 @@ class Report(models.Model):
     @property
     def python(self):
         return json.loads(self._results)
+
+    @property
+    def queryset(self):
+        pks = [record['pk'] for record in self.python]
+        return get_model(self.app, self.model).objects.filter(pk__in=pks)

--- a/myreports/urls.py
+++ b/myreports/urls.py
@@ -13,7 +13,7 @@ urlpatterns = patterns(
         'create_report',
         {'app': 'mypartners'},
         name='create_report'),
-    url(r'ajax/get-report', 'get_report', name='get_report'),
+    url(r'ajax/get-report', 'view_report', name='get_report'),
     url(r'ajax/get-inputs', 'get_inputs', name='get_inputs'),
     url(r'^download$', 'download_report', name='download_report'),
 )

--- a/myreports/views.py
+++ b/myreports/views.py
@@ -33,7 +33,6 @@ def reports(request):
 
     reports = Report.objects.filter(owner=company).order_by("-created_on")
     report_count = reports.count()
-    print report_count
     past_reports = reports[:10]
 
     ctx = {
@@ -180,7 +179,7 @@ def create_report(request, app, model):
     return HttpResponse()
 
 
-def get_report(request):
+def view_report(request):
     if request.is_ajax() and request.method == "POST":
         report_id = request.POST['report']
         report = Report.objects.get(id=report_id)

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,5 +46,4 @@ requests==2.3.0
 selenium==2.42.1
 unicodecsv==0.9.4
 bidict==0.3.1
-django-report-tools==0.2.2
 validate-email==1.2

--- a/templates/mypartners/partner_reports.html
+++ b/templates/mypartners/partner_reports.html
@@ -46,24 +46,24 @@
             <h4>All Contacts</h4>
             {% for contact in contacts %}
             <table class="all-contacts-table">
-                <tr onclick="window.document.location='{% url 'partner_records' %}?partner={{ partner.id }}&contact={{ contact.name }}&date_start={{ date_start|date:'m/d/Y' }}&date_end={{ date_end|date:'m/d/Y' }}{%if admin_id %}&admin={{ admin_id }}{% endif %}';">
+                <tr onclick="window.document.location='{% url 'partner_records' %}?partner={{ partner.id }}&contact={{ contact.contact_name }}&date_start={{ date_start|date:'m/d/Y' }}&date_end={{ date_end|date:'m/d/Y' }}{%if admin_id %}&admin={{ admin_id }}{% endif %}';">
                     <td>
-                        <span>{% get_nonuser_gravatar contact.name '55' %}</span>
+                        <span>{% get_nonuser_gravatar contact.contact_name '55' %}</span>
                     </td>
                     <td>
-                        {{ contact.name }}<br>
-                        {{ contact.email }}
+                        {{ contact.contact_name }}<br>
+                        {{ contact.contact_email }}
                     </td>
                     <td>
-                        <a class="chart-box-link" href="{% url 'partner_records' %}?partner={{ partner.id }}&contact={{ contact.name }}&contact_type=job&date_start={{ date_start|date:'m/d/Y' }}&date_end={{ date_end|date:'m/d/Y' }}{%if admin_id %}&admin={{ admin_id }}{% endif %}">
+                        <a class="chart-box-link" href="{% url 'partner_records' %}?partner={{ partner.id }}&contact={{ contact.contact_name }}&contact_type=job&date_start={{ date_start|date:'m/d/Y' }}&date_end={{ date_end|date:'m/d/Y' }}{%if admin_id %}&admin={{ admin_id }}{% endif %}">
                             <div class="chart-box small-chart-box inline-box">
-                                <div class="big-num">{{ contact.referrals.count }}</div>
+                                <div class="big-num">{{ contact.count }}</div>
                                 <div class="reports-record-type">Referral Records</div>
                             </div>
                         </a>
-                        <a class="chart-box-link" href="{% url 'partner_records' %}?partner={{ partner.id }}&contact={{ contact.name }}&date_start={{ date_start|date:'m/d/Y' }}&date_end={{ date_end|date:'m/d/Y' }}{%if admin_id %}&admin={{ admin_id }}{% endif %}">
+                        <a class="chart-box-link" href="{% url 'partner_records' %}?partner={{ partner.id }}&contact={{ contact.contact_name }}&date_start={{ date_start|date:'m/d/Y' }}&date_end={{ date_end|date:'m/d/Y' }}{%if admin_id %}&admin={{ admin_id }}{% endif %}">
                             <div class="chart-box small-chart-box inline-box">
-                                <div class="big-num">{{ contact.communications.count }}</div>
+                                <div class="big-num">{{ contact.count }}</div>
                                 <div class="reports-record-type">Contact Records</div>
                             </div>
                         </a>

--- a/templates/mypartners/partner_reports.html
+++ b/templates/mypartners/partner_reports.html
@@ -57,13 +57,13 @@
                     <td>
                         <a class="chart-box-link" href="{% url 'partner_records' %}?partner={{ partner.id }}&contact={{ contact.contact_name }}&contact_type=job&date_start={{ date_start|date:'m/d/Y' }}&date_end={{ date_end|date:'m/d/Y' }}{%if admin_id %}&admin={{ admin_id }}{% endif %}">
                             <div class="chart-box small-chart-box inline-box">
-                                <div class="big-num">{{ contact.count }}</div>
+                                <div class="big-num">{{ contact.referrals }}</div>
                                 <div class="reports-record-type">Referral Records</div>
                             </div>
                         </a>
                         <a class="chart-box-link" href="{% url 'partner_records' %}?partner={{ partner.id }}&contact={{ contact.contact_name }}&date_start={{ date_start|date:'m/d/Y' }}&date_end={{ date_end|date:'m/d/Y' }}{%if admin_id %}&admin={{ admin_id }}{% endif %}">
                             <div class="chart-box small-chart-box inline-box">
-                                <div class="big-num">{{ contact.count }}</div>
+                                <div class="big-num">{{ contact.records }}</div>
                                 <div class="reports-record-type">Contact Records</div>
                             </div>
                         </a>
@@ -86,7 +86,7 @@
                 {% for contact in top_contacts %}
                 <a class="chart-box-link" href="{% url 'partner_records' %}?partner={{ partner.id }}&contact={{ contact.contact_name }}&date_start={{ date_start|date:'m/d/Y' }}&date_end={{ date_end|date:'m/d/Y' }}{%if admin_id %}&admin={{ admin_id }}{% endif %}">
                     <div class="chart-box inline-box">
-                        <div class="big-num">{{ contact.count }}</div>
+                        <div class="big-num">{{ contact.records }}</div>
                         <div class="reports-record-type">{{ contact.contact_name|truncatechars:13 }}</div>
                     </div>
                 </a>

--- a/templates/mypartners/partner_reports.html
+++ b/templates/mypartners/partner_reports.html
@@ -57,13 +57,13 @@
                     <td>
                         <a class="chart-box-link" href="{% url 'partner_records' %}?partner={{ partner.id }}&contact={{ contact.name }}&contact_type=job&date_start={{ date_start|date:'m/d/Y' }}&date_end={{ date_end|date:'m/d/Y' }}{%if admin_id %}&admin={{ admin_id }}{% endif %}">
                             <div class="chart-box small-chart-box inline-box">
-                                <div class="big-num">{{ contact.ref_count }}</div>
+                                <div class="big-num">{{ contact.referrals.count }}</div>
                                 <div class="reports-record-type">Referral Records</div>
                             </div>
                         </a>
                         <a class="chart-box-link" href="{% url 'partner_records' %}?partner={{ partner.id }}&contact={{ contact.name }}&date_start={{ date_start|date:'m/d/Y' }}&date_end={{ date_end|date:'m/d/Y' }}{%if admin_id %}&admin={{ admin_id }}{% endif %}">
                             <div class="chart-box small-chart-box inline-box">
-                                <div class="big-num">{{ contact.cr_count }}</div>
+                                <div class="big-num">{{ contact.communications.count }}</div>
                                 <div class="reports-record-type">Contact Records</div>
                             </div>
                         </a>
@@ -110,8 +110,8 @@
     google.load("visualization", "1", {packages:["corechart"]});
 </script>
 <script>
-var total_records = {{ total_records }};
-var total_ref = {{ referral }};
+var total_records = {{ records.communication_activity.count }};
+var total_ref = {{ records.referrals }};
 var company_id = {{ company.id }};
 var company = {{ company.id }};
 var partner = {{ partner.id }};


### PR DESCRIPTION
In testing the viability of the new reporting app's backend, I wanted to see how practical and performant the new API is. I was able to convert arbitrary functions to use some of the new tools developed during myreports development. If you take a peek at the diffs, it should be clear what improvements were made. 

This is a work-in-progress proof-of-concept kind of thing, hence why everything hasn't been ported. I'll probably finish working on it after the new reporting template that @galitskyd  is working on is finished. 

[This](https://github.com/DirectEmployers/MyJobs/compare/gcharts-js...port-old-reports) is probably more interesting, as it only shows what's changed between #1340  and this.