### PR TITLE
Change the URL for the Disability and Veterans Resource Dir. PD-1186

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -55,7 +55,7 @@ PARTNER_LIBRARY_SOURCES = {
             'subreg': 'Download'
         }
     },
-    # http://www.dol-esa.gov/errd/resources.html
+    #  http://www.dol-esa.gov/errd/Resources.503VEVRAA.html
     'Disability and Veterans Community Resources Directory': {
         'url': 'http://www.dol-esa.gov/errd/resourcequery.jsp',
         'params': {

--- a/templates/mypartners/partner_library.html
+++ b/templates/mypartners/partner_library.html
@@ -16,7 +16,7 @@
             <small>
                 <i>
                     The partner(s) listed here are from the <a href="http://www.dol-esa.gov/errd/index.html" target="_blank" style="text-decoration: underline">Employment Referral Resource Directory</a>,
-                    the <a href="http://www.dol-esa.gov/errd/resources.html" target="_blank" style="text-decoration: underline">Disability and Veterans Community Resource Directory</a>, and other sources.
+                    the <a href="http://www.dol-esa.gov/errd/Resources.503VEVRAA.html" target="_blank" style="text-decoration: underline">Disability and Veterans Community Resource Directory</a>, and other sources.
             </small>
         </div>
     </div>


### PR DESCRIPTION
Updated the URL in the PRM Resource Library template file and the comment in tasks.py. In tasks.py, the source used to retrieve the data did NOT change.