### PR TITLE
Fix for ETL monitoring problems.

### DIFF
--- a/seo/monitoring.py
+++ b/seo/monitoring.py
@@ -14,7 +14,7 @@ class TaskMonitoringCam(Polaroid):
         """
         
         interval = timedelta(seconds=self.freq)
-        if len(list(state.tasks_by_type('task_etl_to_solr'))) == 0:
+        if len(list(state.tasks_by_type('task.etl_to_solr'))) == 0 and len(list(state.tasks_by_type('task.priority_etl_to_solr'))) == 0:
             print "No etl_to_solr tasks discovered."
             send_mail('Celery tasks do not appear to be executing', 
                       'Warning, no task_etl_to_solr tasks have been recorded for the last %s.  ' % (str(interval)),


### PR DESCRIPTION
ETL monitoring is producing false positives because the `state.tasks_by_type` function uses the name defined in the `@task(name=...`  rather than the name of the function.  Also added to monitoring the priority_etl_to_solr tasks.