### PR TITLE
Remove report name from response.

### DIFF
--- a/myreports/views.py
+++ b/myreports/views.py
@@ -194,7 +194,7 @@ class ReportView(View):
 
             report.results.save('%s-%s.json' % (name, report.pk), results)
 
-            return HttpResponse(name)
+            return HttpResponse()
         else:
             raise Http404(
                 "This view is only reachable via a POST request.")


### PR DESCRIPTION
Without this, reporting is broken in quality control ever so slightly