### PR TITLE
[PD-1235] Rudimentary UI for Column Selection Before Download

### DIFF
--- a/myreports/helpers.py
+++ b/myreports/helpers.py
@@ -112,23 +112,26 @@ def serialize(fmt, data, counts=None, values=None):
             data = [dict({'count': counts[record['pk']]}, **record)
                     for record in data]
 
-        # Cant' use a ValueQuerSet for serialize, which means we lose the
-        # ability to use distinct. As such, we fake it by doing so manually
-        if values:
-            records = []
-            haystack = []
+    # Cant' use a ValueQuerSet for serialize, which means we lose the
+    # ability to use distinct. As such, we fake it by doing so manually
+    if values:
+        # using a list comprehension to preserve order
+        values = [value for value in values if value in data[0].keys()]
+        records = []
+        haystack = []
 
-            for record in data:
-                needle = [record[value] for value in values] or record['pk']
+        for record in data:
+            needle = [record[value] for value in values] or record['pk']
 
-                if needle not in haystack:
-                    haystack.append(needle)
-                    # strip HTML tags from string values
-                    records.append({
-                        key: strip_tags(value) if isinstance(value, basestring)
-                        else value for key, value in record.items()})
+            if needle not in haystack:
+                haystack.append(needle)
+                # strip HTML tags from string values
+                records.append({
+                    key: strip_tags(record[key])
+                    if isinstance(record[key], basestring) else record[key]
+                    for key in values})
 
-            data = records
+        data = records
 
     if fmt == 'json':
         return json.dumps(data, cls=DjangoJSONEncoder)

--- a/myreports/models.py
+++ b/myreports/models.py
@@ -29,7 +29,14 @@ class Report(models.Model):
 
     @property
     def python(self):
-        return json.loads(self._results)
+        python = json.loads(self._results)
+        values = json.loads(self.values)
+
+        if values:
+            python = [{val: record[val] for val in values}
+                      for record in python]
+
+        return python
 
     @property
     def queryset(self):

--- a/myreports/models.py
+++ b/myreports/models.py
@@ -37,3 +37,6 @@ class Report(models.Model):
         params = json.loads(self.params)
 
         return model.objects.from_search(self.owner, params)
+
+    def __unicode__(self):
+        return self.name

--- a/myreports/models.py
+++ b/myreports/models.py
@@ -11,7 +11,7 @@ class Report(models.Model):
     app = models.CharField(default='mypartners', max_length=50)
     model = models.CharField(default='contactrecord', max_length=50)
     # included columns and sort order
-    values = models.CharField(null=True, max_length=500)
+    values = models.CharField(max_length=500, default='[]')
     # json encoded string of the params used to filter
     params = models.TextField()
     results = models.FileField(upload_to='reports')
@@ -29,33 +29,11 @@ class Report(models.Model):
 
     @property
     def python(self):
-        python = json.loads(self._results)
-        values = json.loads(self.values)
-
-        if values:
-            python = [{val: record[val] for val in values}
-                      for record in python]
-
-        return python
+        return json.loads(self._results)
 
     @property
     def queryset(self):
         model = get_model(self.app, self.model)
         params = json.loads(self.params)
-        values = json.loads(self.values)
 
-        queryset = model.objects.from_search(self.owner, params)
-
-        # If a report has values, we want specific columns, and rows which are
-        # distinct on those columns. However, we also want access to the other
-        # attributes of hte model, so `values()` isn't sufficient.
-        if values:
-            # Dear Django, please devise a way to do distinct on column with
-            # MySQL so I don't have to do such hackery
-            queryset = queryset.values(*values).distinct()
-            pks = [model.objects.filter(**query).first().pk
-                   for query in queryset]
-
-            queryset = model.objects.filter(pk__in=pks)
-
-        return queryset
+        return model.objects.from_search(self.owner, params)

--- a/myreports/urls.py
+++ b/myreports/urls.py
@@ -5,6 +5,7 @@ urlpatterns = patterns(
     'myreports.views',
     url(r'^view/overview$', 'overview', name='overview'),
     url(r'^view/archive$', 'report_archive', name='report_archive'),
+    url(r'view/downloads$', 'downloads', name='downloads'),
     url(r'view/(?P<app>\w+)/(?P<model>\w+)$', ReportView.as_view(),
         name='reports'),
     url(r'^ajax/get-states', 'get_states', name='get_states'),
@@ -12,6 +13,6 @@ urlpatterns = patterns(
         'view_records',
         {'app': 'mypartners'},
         name='view_records'),
-    url(r'ajax/get-inputs', 'get_inputs', name='get_inputs'),
     url(r'download$', 'download_report', name='download_report'),
+    url(r'ajax/get-inputs', 'get_inputs', name='get_inputs'),
 )

--- a/myreports/views.py
+++ b/myreports/views.py
@@ -207,21 +207,29 @@ class ReportView(View):
 
 
 @company_has_access('prm_access')
-def download_report(request):
-    """Download report as csv."""
+def downloads(request):
     report_id = request.GET.get('id', 0)
     report = get_object_or_404(
         get_model('myreports', 'report'), pk=report_id)
 
     ctx = {'columns': [column.replace('_', ' ').title()
                        for column in report.python[0].keys()]}
+
     return render_to_response('myreports/report-download.html', ctx,
                               RequestContext(request))
 
-    """
+
+@company_has_access('prm_access')
+def download_report(request):
+    """Download report as csv."""
+
     report_id = request.GET.get('id', 0)
+    values = request.GET.getlist('values', None)
+
     report = get_object_or_404(
         get_model('myreports', 'report'), pk=report_id)
+    report.values = json.dumps(values)
+    report.save()
 
     response = HttpResponse(content_type='text/csv')
     content_disposition = "attachment; filename=%s-%s.csv"
@@ -232,4 +240,3 @@ def download_report(request):
     response.write(serialize('csv', records))
 
     return response
-    """

--- a/myreports/views.py
+++ b/myreports/views.py
@@ -233,13 +233,9 @@ def download_report(request):
     report = get_object_or_404(
         get_model('myreports', 'report'), pk=report_id)
 
-    #records = report.python
-
     if values:
         report.values = json.dumps(values)
         report.save()
-
-        #records = [{val: record[val] for val in values} for record in records]
 
     records = humanize(report.python)
 

--- a/myreports/views.py
+++ b/myreports/views.py
@@ -209,7 +209,16 @@ class ReportView(View):
 @company_has_access('prm_access')
 def download_report(request):
     """Download report as csv."""
+    report_id = request.GET.get('id', 0)
+    report = get_object_or_404(
+        get_model('myreports', 'report'), pk=report_id)
 
+    ctx = {'columns': [column.replace('_', ' ').title()
+                       for column in report.python[0].keys()]}
+    return render_to_response('myreports/report-download.html', ctx,
+                              RequestContext(request))
+
+    """
     report_id = request.GET.get('id', 0)
     report = get_object_or_404(
         get_model('myreports', 'report'), pk=report_id)
@@ -223,3 +232,4 @@ def download_report(request):
     response.write(serialize('csv', records))
 
     return response
+    """

--- a/static/my.jobs.162-26.css
+++ b/static/my.jobs.162-26.css
@@ -1464,6 +1464,21 @@ div[id$="-wrapper"] + div[id$="-wrapper"] > .list-header {
     width: 206px;
 }
 
+/* Report Download */
+.field-card {
+    border: 1px solid black;
+    margin: 5px;
+}
+
+.field-card > .fa {
+    margin: 5px;
+}
+
+.field-card > .enable-column {
+    margin: 5px;
+    margin-left: 0;
+}
+
 .show-modal-holder {
     margin-top: 20px;
     text-align: center;

--- a/static/my.jobs.162-26.css
+++ b/static/my.jobs.162-26.css
@@ -1470,13 +1470,8 @@ div[id$="-wrapper"] + div[id$="-wrapper"] > .list-header {
     margin: 5px;
 }
 
-.field-card > .fa {
-    margin: 5px;
-}
-
 .field-card > .enable-column {
     margin: 5px;
-    margin-left: 0;
 }
 
 .show-modal-holder {

--- a/static/reporting.162-26.js
+++ b/static/reporting.162-26.js
@@ -819,7 +819,7 @@ function renderDownload(report_id) {
       $("#download-report").attr("href", "download?" + $.param(ctx));
 
       $(".card-holder").sortable({
-        //"handle": "span.fa-bars",
+        "handle": "span.fa-bars",
         "axis": "y",
         "update": function(e, ui) {
           values = $.map($(".enable-column:checked"), function(item, index) {

--- a/static/reporting.162-26.js
+++ b/static/reporting.162-26.js
@@ -996,3 +996,18 @@ function renderArchive(callback) {
     }
   });
 }
+
+function renderDownload(callback) {
+  $.ajax({
+    type: "GET",
+    url: "download",
+    data: {},
+    success: function(data) {
+      $("#main-container").html(data);
+    }
+  }).complete(function() {
+    if (typeof callback === "function") {
+      callback();
+    }
+  });
+}

--- a/static/reporting.162-26.js
+++ b/static/reporting.162-26.js
@@ -819,7 +819,6 @@ function renderDownload(report_id) {
       $("#download-report").attr("href", "download?" + $.param(ctx));
 
       $(".card-holder").sortable({
-        "handle": "span.fa-bars",
         "axis": "y",
         "update": function(e, ui) {
           values = $.map($(".enable-column:checked"), function(item, index) {

--- a/static/reporting.162-26.js
+++ b/static/reporting.162-26.js
@@ -21,6 +21,8 @@ window.onpopstate = function(event) {
     renderGraphs(state.reportId);
   } else if (state.page && state.page === 'report-archive') {
     renderArchive();
+  } else if (state.page && state.page === 'report-download') {
+    renderDownload(state.reportId);
   } else if (state.page && state.page === 'clone') {
     historyClone = function() {
       inputs = state.inputs;
@@ -658,7 +660,7 @@ $(document).ready(function() {
   subpage.on("click", ".report > a, .fa-download", function() {
     var report_id = $(this).attr("id").split("-")[1];
 
-    //history.pushState({'page': 'view-report', 'reportId': report_id}, 'View Report');
+    history.pushState({'page': 'report-download', 'reportId': report_id}, 'Download Report');
 
     renderDownload(report_id);
   });
@@ -809,14 +811,22 @@ function renderDownload(report_id) {
     url: "downloads",
     data: data,
     success: function(data) {
-      $("#main-container").html(data);
+      var sidebarNavigation = $(".sidebar .navigation");
+
+      $("#container").removeClass("rpt-container").html(data);
+
+      if (!sidebarNavigation.length) {
+        $(".sidebar").append("<h2>Navigation</h2>" +
+                             "<div class='navigation'>" +
+                             "<a class='btn' id='download-csv'>Download CSV</a>");
+      }
 
       var values = $.map($(".enable-column:checked"), function(item, index) {
         return $(item).val();
       });
 
       var ctx = {'id': report_id, 'values': values};
-      $("#download-report").attr("href", "download?" + $.param(ctx));
+      $("#download-csv").attr("href", "download?" + $.param(ctx));
 
       $(".card-holder").sortable({
         "axis": "y",
@@ -827,7 +837,7 @@ function renderDownload(report_id) {
 
           var data = {'id': report_id, 'values': values};
 
-          $("#download-report").attr("href", "download?" + $.param(data));
+          $("#download-csv").attr("href", "download?" + $.param(data));
         }
       });
 
@@ -837,7 +847,7 @@ function renderDownload(report_id) {
         });
 
         var ctx = {'id': report_id, 'values': values};
-        $("#download-report").attr("href", "download?" + $.param(ctx));
+        $("#download-csv").attr("href", "download?" + $.param(ctx));
       });
     }
   });

--- a/static/reporting.162-26.js
+++ b/static/reporting.162-26.js
@@ -655,6 +655,14 @@ $(document).ready(function() {
     renderGraphs(report_id);
   });
 
+  subpage.on("click", ".report > a, .fa-download", function() {
+    var report_id = $(this).attr("id").split("-")[1];
+
+    //history.pushState({'page': 'view-report', 'reportId': report_id}, 'View Report');
+
+    renderDownload(report_id);
+  });
+
 
   // Clone Report
   subpage.on("click", ".fa-copy", function() {
@@ -788,6 +796,50 @@ function renderOverview(callback) {
   }).complete(function() {
     if (typeof callback === "function") {
       callback();
+    }
+  });
+}
+
+function renderDownload(report_id) {
+  var data = {'id': report_id};
+
+  $.ajaxSettings.traditional = true;
+  $.ajax({
+    type: "GET",
+    url: "downloads",
+    data: data,
+    success: function(data) {
+      $("#main-container").html(data);
+
+      var values = $.map($(".enable-column:checked"), function(item, index) {
+        return $(item).val();
+      });
+
+      var ctx = {'id': report_id, 'values': values};
+      $("#download-report").attr("href", "download?" + $.param(ctx));
+
+      $(".card-holder").sortable({
+        //"handle": "span.fa-bars",
+        "axis": "y",
+        "update": function(e, ui) {
+          values = $.map($(".enable-column:checked"), function(item, index) {
+            return $(item).val();
+          });
+
+          var data = {'id': report_id, 'values': values};
+
+          $("#download-report").attr("href", "download?" + $.param(data));
+        }
+      });
+
+      $("input.enable-column").on("click", function() {
+        values = $.map($(".enable-column:checked"), function(item, index) {
+          return $(item).val();
+        });
+
+        var ctx = {'id': report_id, 'values': values};
+        $("#download-report").attr("href", "download?" + $.param(ctx));
+      });
     }
   });
 }
@@ -997,17 +1049,3 @@ function renderArchive(callback) {
   });
 }
 
-function renderDownload(callback) {
-  $.ajax({
-    type: "GET",
-    url: "download",
-    data: {},
-    success: function(data) {
-      $("#main-container").html(data);
-    }
-  }).complete(function() {
-    if (typeof callback === "function") {
-      callback();
-    }
-  });
-}

--- a/templates/myreports/includes/report-sidebar.html
+++ b/templates/myreports/includes/report-sidebar.html
@@ -6,7 +6,7 @@
             <div class="icon-set">
                 <i id="view-{{ report.id }}" class="fa fa-eye" title="View"></i>
                 <i id="clone-{{ report.id }}" class="fa fa-copy" title="Clone Report"></i>
-                <a class="icon-link" href="/reports/download?id={{ report.id }}"><i id="export-{{ report.id }}" class="fa fa-download" title="Export"></i></a>
+                <i id="export-{{ report.id }}" class="fa fa-download" title="Export"></i>
             </div>
         </div>
     {% empty %}

--- a/templates/myreports/report-download.html
+++ b/templates/myreports/report-download.html
@@ -10,7 +10,7 @@
 </div>
 <div class="span4">
     <div class="sidebar">
-        <h2 class="top">Navigation</h2>
+        <h2 class="top">Export</h2>
         <div class="navigation">
             <a id="download-report" class="btn">Download CSV</a>
         </div>

--- a/templates/myreports/report-download.html
+++ b/templates/myreports/report-download.html
@@ -1,0 +1,25 @@
+<script type="text/javascript" src="{{ STATIC_URL }}custom.154-10.js{{ gz }}"></script>
+
+<script type="text/javascript">
+$(document).on("ready", function() {
+    $(".cardHolder").sortable({
+    });
+});
+</script>
+
+<style>
+.fieldCard {
+    border: 1px solid black;
+    margin: 5px;
+}
+</style>
+
+<div class="span8">
+    <div class="cardHolder">
+        {% for col in columns %}
+        <div class="fieldCard" id="{{ col.split|join:"_"|lower }}">
+            {{ col }}
+        </div>
+        {% endfor %}
+    </div>
+</div>

--- a/templates/myreports/report-download.html
+++ b/templates/myreports/report-download.html
@@ -2,7 +2,6 @@
     <div class="card-holder">
         {% for col in columns %}
         <div class="field-card" id="{{ col.split|join:"_"|lower }}">
-            <span class="fa fa-bars" title="Sort"></span>
             <input class="enable-column" type="checkbox" value="{{ col.split|join:"_"|lower }}"/>{{ col }}
         </div>
         {% endfor %}

--- a/templates/myreports/report-download.html
+++ b/templates/myreports/report-download.html
@@ -1,29 +1,18 @@
-<script type="text/javascript" src="{{ STATIC_URL }}custom.154-10.js{{ gz }}"></script>
-
-<script type="text/javascript">
-$(document).on("ready", function() {
-    var columns = [];
-    $(".cardHolder").sortable({
-        'update': function(e, ui) {
-            columns = $(this).sortable("toArray");
-        }
-    });
-});
-</script>
-
-<style>
-.fieldCard {
-    border: 1px solid black;
-    margin: 5px;
-}
-</style>
-
 <div class="span8">
-    <div class="cardHolder">
+    <div class="card-holder">
         {% for col in columns %}
-        <div class="fieldCard" id="{{ col.split|join:"_"|lower }}">
-            {{ col }}
+        <div class="field-card" id="{{ col.split|join:"_"|lower }}">
+            <span class="fa fa-bars" title="Sort"></span>
+            <input class="enable-column" type="checkbox" value="{{ col.split|join:"_"|lower }}"/>{{ col }}
         </div>
         {% endfor %}
+    </div>
+</div>
+<div class="span4">
+    <div class="sidebar">
+        <h2 class="top">Navigation</h2>
+        <div class="navigation">
+            <a id="download-report" class="btn">Download CSV</a>
+        </div>
     </div>
 </div>

--- a/templates/myreports/report-download.html
+++ b/templates/myreports/report-download.html
@@ -1,8 +1,8 @@
 <div class="span8">
     <div class="card-holder">
-        {% for col in columns %}
+        {% for name, checked in columns.items %}
         <div class="field-card" id="{{ col.split|join:"_"|lower }}">
-            <input class="enable-column" type="checkbox" value="{{ col.split|join:"_"|lower }}"/>{{ col }}
+            <input class="enable-column" type="checkbox" value="{{ name.split|join:"_"|lower }}"{% if checked %}checked{% endif %} />{{ name }}
         </div>
         {% endfor %}
     </div>

--- a/templates/myreports/report-download.html
+++ b/templates/myreports/report-download.html
@@ -2,7 +2,11 @@
 
 <script type="text/javascript">
 $(document).on("ready", function() {
+    var columns = [];
     $(".cardHolder").sortable({
+        'update': function(e, ui) {
+            columns = $(this).sortable("toArray");
+        }
     });
 });
 </script>

--- a/templates/myreports/report-download.html
+++ b/templates/myreports/report-download.html
@@ -1,17 +1,7 @@
-<div class="span8">
-    <div class="card-holder">
-        {% for name, checked in columns.items %}
-        <div class="field-card" id="{{ col.split|join:"_"|lower }}">
-            <input class="enable-column" type="checkbox" value="{{ name.split|join:"_"|lower }}"{% if checked %}checked{% endif %} />{{ name }}
-        </div>
-        {% endfor %}
+<div class="card-holder">
+    {% for name, checked in columns.items %}
+    <div class="field-card" id="{{ col.split|join:"_"|lower }}">
+        <input class="enable-column" type="checkbox" value="{{ name.split|join:"_"|lower }}"{% if checked %}checked{% endif %} />{{ name }}
     </div>
-</div>
-<div class="span4">
-    <div class="sidebar">
-        <h2 class="top">Export</h2>
-        <div class="navigation">
-            <a id="download-report" class="btn">Download CSV</a>
-        </div>
-    </div>
+    {% endfor %}
 </div>


### PR DESCRIPTION
The draggable items could still use some styling, but I wanted to get the basic functionality in there first. 
![2015-04-08-155910_1916x1056_scrot](https://cloud.githubusercontent.com/assets/93686/7054060/f0880a10-de07-11e4-83f4-9c0cdff73b41.png)

- while you can visually re-order columns, they don't persist between downloads (back-end change required which is part of a different ticket
- column selection *is* persisted between downloads
- pop state implemented (though @galitskyd  has informed me that other changes are required for IE, which we plan to tackle separately, as it requires some of his changes).

As a result of these requested changes, it should be noted that:
- the json saved to disk is larger, as I was asked not to prune unused data (deselected columns) from the results
- as such, that also means that downloading of complex reports takes longer
- deselecting columns does mean less data needs to be transferred and thus has a positive impact on resulting CSV size.

I'm intentionally ignoring the possibility of other export formats for now, as I have a lot of other things on my plate.