### PR TITLE
[PD-1225] Regenerate report contents on init if it is supposed to have results.

### DIFF
--- a/myreports/helpers.py
+++ b/myreports/helpers.py
@@ -103,6 +103,7 @@ def serialize(fmt, data, counts=None, values=None, order_by=None):
 
     * Currently, only count with values passed in manually through `counts`.
     """
+
     if isinstance(data, query.QuerySet):
         data = [dict({'pk': record['pk']}, **record['fields'])
                 for record in serializers.serialize(
@@ -144,7 +145,6 @@ def serialize(fmt, data, counts=None, values=None, order_by=None):
 
             d.append(o)
 
-        
         reverse = False
         if order_by:
             if '-' in order_by:


### PR DESCRIPTION
If a report has results, but the file associated with that result doesn't exist, I rerun the database query and store the results. 

Not sure if I should be checking that the location is writable in the first place, or if there is a canonical django way to do that. I assign contents to _results because it didn't make sense to have to re-read a file just to get at hte contents immediately after (via Report.python or Report.json)