### PR TITLE
[PD-1276] Update robots.txt files

### DIFF
--- a/cdn_files/src-nlx-org/robots.txt
+++ b/cdn_files/src-nlx-org/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Disallow: /
+

--- a/cdn_files/src-nlx-org/robots.txt
+++ b/cdn_files/src-nlx-org/robots.txt
@@ -1,3 +1,1 @@
 User-agent: *
-Disallow: /
-

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,16 +1,10 @@
-Sitemap: http://find.ibm.jobs/sitemap.xml
 User-agent: *
-Disallow: /login/
-Disallow: /logout/
 Disallow: /associate/
-Disallow: /done/
 Disallow: /error/
 Disallow: /admin/
 Disallow: /complete/
 Disallow: /admin/
 Disallow: /settings/
-Disallow: /files/
-Disallow: /style/
 Disallow: /openid/
 Disallow: /linkedin/
 Disallow: /twitter/

--- a/templates/robots.txt
+++ b/templates/robots.txt
@@ -1,10 +1,3 @@
 Sitemap: http://{{ host }}/sitemap.xml
 User-agent: *
 Disallow: /admin/
-Disallow: /ajax/
-Disallow: /feed/
-Disallow: /files/
-Disallow: /login/
-Disallow: /logout/
-Disallow: /style/
-Disallow: /*feed/


### PR DESCRIPTION
Strips most of the robots.txt disallow rules from robots.txt for my.jobs and S3. Once merged, the S3 robots file will be pushed to the root of src-nlx-org folder. It previously wasn't in any version control.