### PR TITLE
[PD-1273] Cleaned up the value and order_by specific bits of serialization

### DIFF
--- a/myreports/helpers.py
+++ b/myreports/helpers.py
@@ -136,25 +136,18 @@ def serialize(fmt, data, counts=None, values=None, order_by=None):
 
     if data:
         values = values or sorted(data[0].keys())
-        d = []
-        for record in data:
-            o = OrderedDict()
-            for value in values:
-                o[value] = record[value]
+        data = [OrderedDict([(value, record[value]) for value in values])
+                for record in data]
 
-            d.append(o)
-
-        
         reverse = False
         if order_by:
             if '-' in order_by:
                 order_by = order_by[1:]
                 reverse = True
 
-            d = sorted(
-                d, key=lambda record: record[order_by], reverse=bool(reverse))
-
-    data = d
+            data = sorted(
+                data, key=lambda record:
+                    record[order_by], reverse=bool(reverse))
 
     if fmt == 'json':
         return json.dumps(data, cls=DjangoJSONEncoder)

--- a/myreports/helpers.py
+++ b/myreports/helpers.py
@@ -139,12 +139,9 @@ def serialize(fmt, data, counts=None, values=None, order_by=None):
         data = [OrderedDict([(value, record[value]) for value in values])
                 for record in data]
 
-        reverse = False
         if order_by:
-            if '-' in order_by:
-                order_by = order_by[1:]
-                reverse = True
-
+            # if '-' isn't in order_by, reverse will be an empty string
+            _, reverse, order_by = sorted(order_by.partition('-'))
             data = sorted(
                 data, key=lambda record:
                     record[order_by], reverse=bool(reverse))

--- a/myreports/helpers.py
+++ b/myreports/helpers.py
@@ -135,7 +135,7 @@ def serialize(fmt, data, counts=None, values=None, order_by=None):
                 for key, value in record.items()}
 
     if data:
-        values = values or data[0].keys()
+        values = values or sorted(data[0].keys())
         d = []
         for record in data:
             o = OrderedDict()

--- a/myreports/tests/test_helpers.py
+++ b/myreports/tests/test_helpers.py
@@ -68,6 +68,22 @@ class TestHelpers(MyReportsTestCase):
 
         self.assertEqual(data[0].keys(), values)
 
+    def test_serialize_order_by(self):
+        """
+        Test that if the `order_by` parameter is specified, records are 
+        ordered by that parameter's value.
+        """
+
+        data = helpers.serialize(
+            'python', self.records, order_by='-date_time')
+
+        datetimes = [record['date_time'] for record in data]
+        # make sure the earliest time is first
+        self.assertTrue(max(datetimes) == datetimes[0])
+        # make sure that the latest time is last
+        self.assertTrue(min(datetimes) == datetimes[-1])
+
+
     def test_serialize_csv(self):
         """Test that serializing to CSV creates the correct number of rows."""
 

--- a/myreports/tests/test_helpers.py
+++ b/myreports/tests/test_helpers.py
@@ -48,6 +48,26 @@ class TestHelpers(MyReportsTestCase):
 
         self.assertEqual(len(data), self.records.count())
 
+    def test_serialize_values(self):
+        """
+        Test that if the `values` parameter is specified, column
+        inclusion/exclusion as well as column ordering is respected.
+        """
+
+        # by default, all fields except pk should be inclued, and columns
+        # should be sorted alphabetically
+        data = helpers.serialize('python', self.records)
+        values = data[-1].keys()
+
+        self.assertEqual(data[0].keys(), sorted(values))
+
+        # when values are specified, output records should respec the nubmer
+        # and order of fields specified
+        values = ['contact_name', 'contact_email', 'tags']
+        data = helpers.serialize('python', self.records, values=values)
+
+        self.assertEqual(data[0].keys(), values)
+
     def test_serialize_csv(self):
         """Test that serializing to CSV creates the correct number of rows."""
 


### PR DESCRIPTION
I've created a feature branch for this so that I can keep these changes together without having to worry about being out of sync between master and quality-control (eg, numerous hotfixes).

- Performance improvements are minimal, but I'm happier with this implementation as it doesn't require intermediate variables
- Added unit tests to validate functionality
- You'll note that this doesn't work for json output. Reason for that is that Json objects aren't ordered. I plan to address this at a later date with a different ticket (perhaps not part of this refactoring, though). Luckily, I use the serialized Python to do CSV export, so not much is lost by omitting this.

In short, it's written in a less imperative and more functional style.
