### PR TITLE
[PD-1277] More efficient Record Traversal

### DIFF
--- a/myreports/helpers.py
+++ b/myreports/helpers.py
@@ -7,7 +7,7 @@ import json
 from django.core import serializers
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db.models import query
-from django.utils.html import strip_tags
+from lxml import html
 from mypartners.models import CONTACT_TYPES
 
 
@@ -128,11 +128,10 @@ def serialize(fmt, data, counts=None, values=None, order_by=None):
         data = records
 
         # strip HTML tags from string values
-        for index, record in enumerate(data[:]):
-            data[index] = {
-                key: strip_tags(record[key])
-                if isinstance(record[key], basestring) else value
-                for key, value in record.items()}
+        data = [{key: html.fromstring(value).text_content()
+                 if isinstance(value, basestring) and value else value
+                 for key, value in record.items()}
+                for record in data]
 
     if data:
         values = values or sorted(data[0].keys())

--- a/myreports/helpers.py
+++ b/myreports/helpers.py
@@ -136,25 +136,18 @@ def serialize(fmt, data, counts=None, values=None, order_by=None):
 
     if data:
         values = values or sorted(data[0].keys())
-        d = []
-        for record in data:
-            o = OrderedDict()
-            for value in values:
-                o[value] = record[value]
+        data = [OrderedDict([(value, record[value]) for value in values])
+                for record in data]
 
-            d.append(o)
-
-        
         reverse = False
         if order_by:
             if '-' in order_by:
                 order_by = order_by[1:]
                 reverse = True
 
-            d = sorted(
-                d, key=lambda record: record[order_by], reverse=bool(reverse))
-
-    data = d
+            data = sorted(
+                data, key=lambda record:
+                    record[order_by], reverse=bool(reverse))
 
     if fmt == 'json':
         return json.dumps(data, cls=DjangoJSONEncoder)

--- a/myreports/helpers.py
+++ b/myreports/helpers.py
@@ -139,12 +139,9 @@ def serialize(fmt, data, counts=None, values=None, order_by=None):
         data = [OrderedDict([(value, record[value]) for value in values])
                 for record in data]
 
-        reverse = False
         if order_by:
-            if '-' in order_by:
-                order_by = order_by[1:]
-                reverse = True
-
+            # if '-' isn't in order_by, reverse will be an empty string
+            _, reverse, order_by = sorted(order_by.partition('-'))
             data = sorted(
                 data, key=lambda record:
                     record[order_by], reverse=bool(reverse))

--- a/myreports/helpers.py
+++ b/myreports/helpers.py
@@ -113,16 +113,18 @@ def serialize(fmt, data, counts=None, values=None, order_by=None):
             data = [dict({'count': counts[record['pk']]}, **record)
                     for record in data]
 
-    # Convert data into an `OrderedDict`, remove fields not asked for, and
-    # strip HTML from all fields that remain.
     values = values or sorted(data[0].keys())
     order_by = order_by or values[0]
     _, reverse, order_by = sorted(order_by.partition('-'))
 
+    # Convert data to a list of `OrderedDict`s,
     data = sorted([OrderedDict([(
+        # strip HTML from invidual values...
         value, html.fromstring(record[value]).text_content()
+        # if they aren't empty strings.
         if isinstance(record[value], basestring) and record[value].strip()
         else record[value]) for value in values]) for record in data],
+            # and sort them by specified value (first column by default)
             key=lambda record: record[order_by], reverse=bool(reverse))
 
     if fmt == 'json':

--- a/myreports/helpers.py
+++ b/myreports/helpers.py
@@ -7,7 +7,7 @@ import json
 from django.core import serializers
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db.models import query
-from lxml.html.soupparser import fromstring
+from lxml import html
 from mypartners.models import CONTACT_TYPES
 
 
@@ -128,8 +128,8 @@ def serialize(fmt, data, counts=None, values=None, order_by=None):
         data = records
 
         # strip HTML tags from string values
-        data = [{key: fromstring(value).text_content()
-                 if isinstance(value, basestring) and value else value
+        data = [{key: html.fromstring(value).text_content()
+                 if isinstance(value, basestring) and value.strip() else value
                  for key, value in record.items()}
                 for record in data]
 

--- a/myreports/helpers.py
+++ b/myreports/helpers.py
@@ -135,7 +135,7 @@ def serialize(fmt, data, counts=None, values=None, order_by=None):
                 for key, value in record.items()}
 
     if data:
-        values = values or data[0].keys()
+        values = values or sorted(data[0].keys())
         d = []
         for record in data:
             o = OrderedDict()

--- a/myreports/helpers.py
+++ b/myreports/helpers.py
@@ -7,7 +7,7 @@ import json
 from django.core import serializers
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db.models import query
-from lxml import html
+from lxml.html.soupparser import fromstring
 from mypartners.models import CONTACT_TYPES
 
 
@@ -128,7 +128,7 @@ def serialize(fmt, data, counts=None, values=None, order_by=None):
         data = records
 
         # strip HTML tags from string values
-        data = [{key: html.fromstring(value).text_content()
+        data = [{key: fromstring(value).text_content()
                  if isinstance(value, basestring) and value else value
                  for key, value in record.items()}
                 for record in data]

--- a/myreports/tests/test_helpers.py
+++ b/myreports/tests/test_helpers.py
@@ -74,14 +74,18 @@ class TestHelpers(MyReportsTestCase):
         Test that HTML is properly stripped from fields when being serialized.
         """
 
-        notes = """
+        # Only adding notes to one recod so that we can test that empty notes
+        # are parsed correctly as well
+        record = self.records[0]
+        record.notes = """
         <div class="tip-content">
             Saved Search Notification<br />
             <a href="https://secure.my.jobs">My.jobs</a>
             <p>Saved search was created on your behalf</p>
         </div>
         """
-        self.records.update(notes=notes)
+        record.save()
+
         data = helpers.serialize('python', self.records)
 
         for record in data:

--- a/myreports/tests/test_helpers.py
+++ b/myreports/tests/test_helpers.py
@@ -123,9 +123,6 @@ class TestHelpers(MyReportsTestCase):
             # ensure tags were converted
             self.assertEqual(record['tags'], 'test, stuff, working')
 
-            # ensure pk was removed
-            self.assertFalse('pk' in record.keys())
-
             # ensure contact type was converted
             self.assertTrue(record['contact_type'] == 'Email')
 

--- a/myreports/tests/test_helpers.py
+++ b/myreports/tests/test_helpers.py
@@ -68,6 +68,22 @@ class TestHelpers(MyReportsTestCase):
 
         self.assertEqual(data[0].keys(), values)
 
+    def test_serialize_order_by(self):
+        """
+        Test that if the `order_by` parameter is specified, records are 
+        ordered by that parameter's value.
+        """
+
+        data = helpers.serialize(
+            'python', self.records, order_by='-date_time')
+
+        datetimes = [record['date_time'] for record in data]
+        # make sure the earliest time is first
+        self.assertTrue(max(datetimes) == datetimes[0])
+        # make sure that the latest time is last
+        self.assertTrue(min(datetimes) == datetimes[-1])
+
+
     def test_serialize_csv(self):
         """Test that serializing to CSV creates the correct number of rows."""
 

--- a/myreports/tests/test_helpers.py
+++ b/myreports/tests/test_helpers.py
@@ -48,6 +48,26 @@ class TestHelpers(MyReportsTestCase):
 
         self.assertEqual(len(data), self.records.count())
 
+    def test_serialize_values(self):
+        """
+        Test that if the `values` parameter is specified, column
+        inclusion/exclusion as well as column ordering is respected.
+        """
+
+        # by default, all fields except pk should be inclued, and columns
+        # should be sorted alphabetically
+        data = helpers.serialize('python', self.records)
+        values = data[-1].keys()
+
+        self.assertEqual(data[0].keys(), sorted(values))
+
+        # when values are specified, output records should respec the nubmer
+        # and order of fields specified
+        values = ['contact_name', 'contact_email', 'tags']
+        data = helpers.serialize('python', self.records, values=values)
+
+        self.assertEqual(data[0].keys(), values)
+
     def test_serialize_csv(self):
         """Test that serializing to CSV creates the correct number of rows."""
 

--- a/myreports/views.py
+++ b/myreports/views.py
@@ -106,6 +106,9 @@ def view_records(request, app, model):
             records = records.annotate(count=Count(count, distinct=True))
             counts = {record.pk: record.count for record in records}
 
+        if values:
+            records = records.values(*values)
+
         if order_by:
             if not hasattr(order_by, '__iter__'):
                 order_by = [order_by]

--- a/static/reporting.163-10.js
+++ b/static/reporting.163-10.js
@@ -1006,7 +1006,6 @@ function renderDownload(report_id) {
     success: function(data) {
       var ctx,
           values,
-          dragged,
           $order,
           $column,
           $columnNames,
@@ -1053,11 +1052,9 @@ function renderDownload(report_id) {
         tolerance: "pointer",
         distance: 10,
         start: function(e, ui) {
-          dragged = true;
           ui.item.addClass("drag");
         },
         stop: function(e, ui) {
-          dragged = false;
           ui.item.removeClass("drag");
         },
         update: updateValues
@@ -1085,21 +1082,6 @@ function renderDownload(report_id) {
 
       $("#column-choices").on("change", updateValues);
       $(".sort-order").on("change", updateValues);
-
-      $(".enable-column").on("change", function(e) {
-        updateValues();
-      });
-
-      $(".enable-column").on("click", function(e) {
-        e.stopPropagation();
-      });
-
-      $(".column-wrapper").on("mouseup", function() {
-        if (!dragged) {
-          var $checkbox = $(this).children(".enable-column");
-          $checkbox.prop("checked", !$checkbox.prop("checked")).change();
-        }
-      });
     }
   });
 }

--- a/templates/myreports/includes/report-download.html
+++ b/templates/myreports/includes/report-download.html
@@ -29,9 +29,10 @@
     </div>
     <div class="column-container">
         {% for name, checked in columns.items %}
-        <div class="column-wrapper" id="{{ col.split|join:"_"|lower }}">
-            <input class="enable-column" type="checkbox" value="{{ name.split|join:"_"|lower }}"{% if checked %}checked{% endif %} />{{ name }}
-        </div>
+        <label for="{{ name.split|join:"_"|lower }}" class="column-wrapper">
+            <input id="{{ name.split|join:"_"|lower }}" class="enable-column" type="checkbox"
+                   value="{{ name.split|join:"_"|lower }}"{% if checked %}checked{% endif %} />{{ name }}
+        </label>
         {% endfor %}
     </div>
 </div>


### PR DESCRIPTION
# Optimizations
- rather than traverse records 5 times, I do so once
- use lxml (c based) instead of django (pure python) to strip HTML
- the presence of the downloads page deprecates the need to remove pk in `humanize`
- on the download page, I replaced divs with labels, which allowed me to reduce the number of bound events on that page

# Bug Fixes
While I was at it, I 
- fixed regression that caused field checkboxes on the downloads page to not be clickable
- protected the download page from regular GET requests, as doing so meant events werent bound and styling wasn't applied

# Tests
Before making each of the above optimization,  I created a unit test to ensure integrity of previous behavior:
- ensure order_by is respected
- ensure column order and presence is respected (python serialization only)
- ensured html is stripped from exported values