### PR TITLE
Faster reports

### DIFF
--- a/mypartners/models.py
+++ b/mypartners/models.py
@@ -576,7 +576,7 @@ class ContactRecordQuerySet(SearchParameterQuerySet):
     @property
     def contacts(self):
         contacts = self.exclude(contact_type='job').values(
-            'contact_name', 'contact_email').annotate(
+            'partner__name', 'partner', 'contact_name', 'contact_email').annotate(
                 records=models.Count('contact_name')).distinct().order_by(
                     '-records')
 

--- a/myreports/helpers.py
+++ b/myreports/helpers.py
@@ -82,7 +82,7 @@ def parse_params(querydict):
 # TODO:
 #   * find a better way to handle counts
 #   * do something other than isinstance checks (duck typing anyone?)
-def serialize(fmt, data, counts=None, values=None, order_by=None):
+def serialize(fmt, data, values=None, order_by=None):
     """
     Like `django.core.serializers.serialize`, but produces a simpler structure
     and retains annotated fields*.
@@ -91,9 +91,6 @@ def serialize(fmt, data, counts=None, values=None, order_by=None):
         :fmt: The format to serialize to. Currently recognizes 'csv', 'json',
               and 'python'.
         :data: The data to be serialized.
-        :counts: A dictionary mapping primary keys to actual counts. This is a
-                 cludge which should be deprecated in later version of this
-                 function if at all possible.
 
     Outputs:
         Either a Python object or a string represention of the requested
@@ -108,10 +105,6 @@ def serialize(fmt, data, counts=None, values=None, order_by=None):
         data = [dict({'pk': record['pk']}, **record['fields'])
                 for record in serializers.serialize(
                     'python', data, use_natural_keys=True, fields=values)]
-
-        if counts:
-            data = [dict({'count': counts[record['pk']]}, **record)
-                    for record in data]
 
     values = values or sorted(data[0].keys())
     order_by = order_by or values[0]

--- a/myreports/views.py
+++ b/myreports/views.py
@@ -94,17 +94,11 @@ def view_records(request, app, model):
         params = parse_params(request.GET)
 
         # remove non-query related params
-        count = params.pop('count', None)
         values = params.pop('values', [])
         order_by = params.pop('order_by', None)
 
         records = get_model(app, model).objects.from_search(
             company, params)
-
-        counts = {}
-        if count:
-            records = records.annotate(count=Count(count, distinct=True))
-            counts = {record.pk: record.count for record in records}
 
         if values:
             records = records.values(*values)
@@ -115,7 +109,7 @@ def view_records(request, app, model):
 
             records = records.order_by(*order_by)
 
-        ctx = serialize('json', records, counts=counts, values=values)
+        ctx = serialize('json', records, values=values)
 
         response = HttpResponse(
             ctx, content_type='application/json; charset=utf-8')

--- a/myreports/views.py
+++ b/myreports/views.py
@@ -109,6 +109,9 @@ def view_records(request, app, model):
             company, params)
 
         if values:
+            if not hasattr(values, '__iter__'):
+                values = [values]
+
             records = records.values(*values)
 
         if order_by:
@@ -228,6 +231,9 @@ class ReportView(View):
                 company, params)
 
             if values:
+                if not hasattr(values, '__iter__'):
+                    values = [values]
+
                 records = records.values(*values)
 
             contents = serialize('json', records, values=values)

--- a/myreports/views.py
+++ b/myreports/views.py
@@ -102,7 +102,7 @@ def view_records(request, app, model):
         params = parse_params(request.GET)
 
         # remove non-query related params
-        values = params.pop('values', [])
+        values = params.pop('values', None)
         order_by = params.pop('order_by', None)
 
         records = get_model(app, model).objects.from_search(

--- a/static/my.jobs.163-21.css
+++ b/static/my.jobs.163-21.css
@@ -854,6 +854,10 @@ input.datepicker {
     cursor: pointer;
 }
 
+tr.report {
+    cursor: pointer;
+}
+
 .sidebar a.selected.btn {
     background: white none no-repeat right top;
     border: 1px solid #5E6C82 !important;

--- a/static/reporting.163-20.js
+++ b/static/reporting.163-20.js
@@ -1439,7 +1439,7 @@ function renderGraphs(report_id, callback) {
             // Just run for the first 3 contacts.
             for (i = 0; i < topLength; i++) {
               // remove first contact in array, returns the removed contact.
-              contact = contacts.shift();
+              contact = contacts[i];
               name = contact.contact_name;
               email = contact.contact_email;
               cReferrals = contact.referrals;
@@ -1464,17 +1464,28 @@ function renderGraphs(report_id, callback) {
             restRow = $('<div class="row"></div>').append(function() {
               var div = $('<div class="span12"></div>'),
                   table = $('<table class="table table-striped report-table"><thead><tr><th>Name</th>' +
-                            '<th>Email</th><th>Contact Records</th><th>Referral Reocrds</th>' +
+                            '<th>Email</th><th>Partner</th><th>Contact Records</th><th>Referral Reocrds</th>' +
                             '</tr></thead></table>'),
                   tbody = $('<tbody></tbody>');
               tbody.append(function() {
                 // turn each element into cells of a table then join each group of cells with rows.
-                return "<tr>" + contacts.map(function(contact) {
-                  return "<td>" + contact.contact_name + "</td><td>" + contact.contact_email +
-                         "</td><td>" + contact.records + "</td><td>" + contact.referrals + "</td>";
-                }).join('</tr><tr>') + "</tr>";
+                return "<tr class='report'>" + contacts.map(function(contact) {
+                  return "<td data-name='" + contact.contact_name + "' data-email='" + contact.contact_email + "' data-partner='" + contact.partner + "'>" + contact.contact_name + "</td><td>" + contact.contact_email +
+                         "</td><td>" + contact.partner__name + "</td><td>" + contact.records + "</td><td>" + contact.referrals + "</td>";
+                }).join('</tr><tr class="report">') + "</tr>";
               });
+							tbody.find("tr").on("click", function(e) {
+								var row = e.currentTarget,
+										$td = $(row).find("td:first"),
+										name = $td.data("name"),
+										email = $td.data("email"),
+										partner = $td.data("partner");
+								
+								window.open("/prm/view/records?partner=" + partner + "&contact=" + name + "&keywords=" + email, "_blank");
+							});
+
               return div.append(table.append(tbody));
+
             });
           } else {
             // Make sure topThreeRow didn't run before saying there are no records.

--- a/static/reporting.163-20.js
+++ b/static/reporting.163-20.js
@@ -693,7 +693,7 @@ TagField.prototype.bindEvents = function() {
         type: "GET",
         url: "/reports/ajax/mypartners/tag",
 				//TODO: New backend changes will fix this monstrocity
-				data: {name: keyword, values: ["name", "pk"], order_by: "name"},
+				data: {name: keyword, values: ["name"], order_by: "name"},
         success: function(data) {
           suggestions = data.filter(function(d) {
             // Don't suggest things that are already selected.

--- a/static/reporting.163-20.js
+++ b/static/reporting.163-20.js
@@ -776,10 +776,10 @@ FilteredList.prototype.filter = function() {
 
   if (this.id === "partner") {
     // annotate how many records a partner has.
-    $.extend(filterData, {count: "contactrecord",
-                    values: ["pk", "name", "count"],
-                    order_by: "name"}
-    );
+    $.extend(filterData, {
+			values: ["pk", "name"],
+			order_by: "name"
+		});
   } else if (this.id === "contact") {
     $.extend(filterData, {values: ["pk", "name", "email"], order_by: "name"});
   }
@@ -794,8 +794,7 @@ FilteredList.prototype.filter = function() {
       $recordCount = $('#' + filteredList.id + '-header').find(".record-count");
       $('.list-body#' + filteredList.id).html("");
       $('.list-body#' + filteredList.id).append('<ul><li>' + data.map(function(element) {
-        return '<label><input type="checkbox" data-pk="' + element.pk + '" checked /> ' + element.name + 
-               '<span class="pull-right">' + (filteredList.id === 'partner' ? element.count : "") + '</label>';
+        return '<label><input type="checkbox" data-pk="' + element.pk + '" checked /> ' + element.name + '</label>';
       }).join("</li><li>") + '</li></ul>').removeClass("no-show");
 
       $recordCount.text(filteredList.currentVal().length);


### PR DESCRIPTION
Reduces query time (compared to production) from ~20 seconds to ~4.

@galitskyd  - This basically just removes the `count` option from API calls. Feel free to wait until #1469 is merged and you've re-synced with quality control (which is why the changes seem so extensive).