### PR TITLE
[PD-1326] PRM Forms IE8 alignment fix

### DIFF
--- a/static/my.jobs.163-29.css
+++ b/static/my.jobs.163-29.css
@@ -1500,7 +1500,7 @@ div[id$="-wrapper"] + div[id$="-wrapper"] > .list-header {
     cursor: move;
 }
 
-.placeholder {
+.column-container .placeholder {
     background-color: #F0FDD2;
     margin-right: 5px;
     border-bottom: 1px solid #E5E5E5;

--- a/templates/base.html
+++ b/templates/base.html
@@ -20,7 +20,7 @@
     {% block meta-extra %}{% endblock %}
 
     <link href="{{ STATIC_URL }}def.ui.152-21.css{{ gz }}" rel="stylesheet" type="text/css">
-    <link href="{{ STATIC_URL }}my.jobs.163-13.css{{ gz }}" rel="stylesheet" type="text/css">
+    <link href="{{ STATIC_URL }}my.jobs.163-29.css{{ gz }}" rel="stylesheet" type="text/css">
     <!--[if IE]>
     <link href="{{ STATIC_URL }}my.jobs.ie.155-14.css{{ gz }}" rel="stylesheet" type="text/css">
     <![endif]-->


### PR DESCRIPTION
.placeholder styling for reporting was adding 5px margin to the right of IE8 fields because of placeholder.js.

Fixed this:
![screen shot 2015-04-29 at 9 30 35 am](https://cloud.githubusercontent.com/assets/4359673/7394800/ef92cc0a-ee63-11e4-8599-8bdbd682be71.png)
