### PR TITLE
[PD-1327] Google charts errors on IE8

### DIFF
--- a/static/my.jobs.ie.163-29.css
+++ b/static/my.jobs.ie.163-29.css
@@ -53,3 +53,7 @@
 .row-filler input {
     display: none;
 }
+
+.small-chart .piehole {
+    left: 21.5%;
+}

--- a/static/partner-reports.163-29.js
+++ b/static/partner-reports.163-29.js
@@ -374,7 +374,7 @@ function update_query(key, value, url) {
     }
 }
 
-// Checks to see if browser is IE. If it is then get version.
+// Checks to see if browser is IE8.
 function isIE8() {
     var myNav = navigator.userAgent.toLowerCase();
     if (myNav.indexOf('msie') !== -1) {

--- a/static/partner-reports.163-29.js
+++ b/static/partner-reports.163-29.js
@@ -303,11 +303,11 @@ function donut_options(height, width, chartArea_top, chartArea_left, chartArea_h
 
 
 function fill_piehole(totalrecs, size){
-    var doughnut = $("#donutchart");
-    var piediv = doughnut.children(":first-child").children(":first-child");
+    var doughnut = $("#donutchart"),
+        piediv = isIE8() ? doughnut.children(":first") : doughnut.find('div[dir="ltr"]');
+
     if(size === 'big'){
         piediv.prepend('<div class="piehole"><div class="piehole-big">'+String(totalrecs)+'</div><div class="piehole-topic">Contact Records</div><div class="piehole-filter"><a class="btn primary" id="reports-view-all">View All</a></div></div>');
-
     } else {
         piediv.prepend('<div class="piehole"><div class="piehole-big">'+String(totalrecs)+'</div><div class="piehole-topic">Contact Records</div><div class="piehole-filter">30 Days</div></div>');
     }
@@ -372,4 +372,15 @@ function update_query(key, value, url) {
         else
             return url;
     }
+}
+
+// Checks to see if browser is IE. If it is then get version.
+function isIE8() {
+    var myNav = navigator.userAgent.toLowerCase();
+    if (myNav.indexOf('msie') !== -1) {
+        if (parseInt(myNav.split('msie')[1]) === 8) {
+            return true;
+        }
+    }
+    return false;
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -22,7 +22,7 @@
     <link href="{{ STATIC_URL }}def.ui.152-21.css{{ gz }}" rel="stylesheet" type="text/css">
     <link href="{{ STATIC_URL }}my.jobs.163-29.css{{ gz }}" rel="stylesheet" type="text/css">
     <!--[if IE]>
-    <link href="{{ STATIC_URL }}my.jobs.ie.155-14.css{{ gz }}" rel="stylesheet" type="text/css">
+    <link href="{{ STATIC_URL }}my.jobs.ie.163-29.css{{ gz }}" rel="stylesheet" type="text/css">
     <![endif]-->
     <link href="{{ STATIC_URL }}bootstrap/bootstrap-modal.css{{ gz }}" rel="stylesheet" type="text/css">
 </head>

--- a/templates/mypartners/overview.html
+++ b/templates/mypartners/overview.html
@@ -81,7 +81,7 @@
 {% endblock %}
 
 {% block extra-js %}
-<script src="{{ STATIC_URL }}partner-reports.157-24.js{{ gz }}"></script>
+<script src="{{ STATIC_URL }}partner-reports.163-29.js{{ gz }}"></script>
 
 <script type="text/javascript" src="https://www.google.com/jsapi"></script>
 <script type="text/javascript">

--- a/templates/mypartners/partner_reports.html
+++ b/templates/mypartners/partner_reports.html
@@ -103,7 +103,7 @@
 {% endblock %}
 
 {% block extra-js %}
-<script src="{{ STATIC_URL }}partner-reports.157-24.js{{ gz }}"></script>
+<script src="{{ STATIC_URL }}partner-reports.163-29.js{{ gz }}"></script>
 
 <script type="text/javascript" src="https://www.google.com/jsapi"></script>
 <script type="text/javascript">


### PR DESCRIPTION
fill_piehole function was selecting an iframe and trying to do jQuery functions on it which was cause permission denied errors. The iframe is only rendered on IE8 because google charts uses SVGs but IE8 doesn't support SVGs so their fallback is VML inside said iframe.

Before:
![screen shot 2015-04-29 at 9 41 24 am](https://cloud.githubusercontent.com/assets/4359673/7398786/5e656f5a-ee7f-11e4-8594-4bbca45485fa.png)
![screen shot 2015-04-29 at 9 41 47 am](https://cloud.githubusercontent.com/assets/4359673/7398789/60da11aa-ee7f-11e4-9c72-d8d48ef96aaf.png)

After:
![screen shot 2015-04-29 at 2 36 52 pm](https://cloud.githubusercontent.com/assets/4359673/7398794/65541f3c-ee7f-11e4-919b-dab5893b3710.png)
![screen shot 2015-04-29 at 2 37 00 pm](https://cloud.githubusercontent.com/assets/4359673/7398795/67e31cf8-ee7f-11e4-817e-e7db413654ee.png)
