### PR TITLE
[PD-1331] OFCCP disability button unchecks on page load

### DIFF
--- a/static/my.jobs.163-29.css
+++ b/static/my.jobs.163-29.css
@@ -492,8 +492,8 @@ h1 > small > a:hover {
 .partner-tag.female.button { box-shadow: 2px 2px 0 #2B9CBC; }
 .partner-tag.minority { background-color: #FAA732; }
 .partner-tag.minority.button { box-shadow: 2px 2px 0 #DE860A; }
-.partner-tag.disabled { background-color: #808A9A; }
-.partner-tag.disabled.button { box-shadow: 2px 2px 0 #5F6D83; }
+.partner-tag.disability { background-color: #808A9A; }
+.partner-tag.disability.button { box-shadow: 2px 2px 0 #5F6D83; }
 .partner-tag.disabled-veteran { background-color: #659274; }
 .partner-tag.disabled-veteran.button { box-shadow: 2px 2px 0 #467B58; }
 .partner-tag.disabled-tag { background-color: #BCBCC2; }

--- a/templates/mypartners/includes/partner_card.html
+++ b/templates/mypartners/includes/partner_card.html
@@ -94,7 +94,7 @@
                 <div class="partner-tag minority">Minority</div>
             {% endif %}
             {% if partner.is_disabled %}
-                <div class="partner-tag disabled">Disability</div>
+                <div class="partner-tag disability">Disability</div>
             {% endif %}
             {% if partner.is_disabled_veteran %}
                 <div class="partner-tag disabled-veteran">Disabled Veteran</div>

--- a/templates/mypartners/includes/partner_sidebar.html
+++ b/templates/mypartners/includes/partner_sidebar.html
@@ -23,7 +23,7 @@
             <div class="partner-tag veteran button disabled-tag" title="Click to filter">Veteran</div>
             <div class="partner-tag female button disabled-tag" title="Click to filter">Female</div>
             <div class="partner-tag minority button disabled-tag" title="Click to filter">Minority</div>
-            <div class="partner-tag disabled button disabled-tag" title="Click to filter">Disability</div>
+            <div class="partner-tag disability button disabled-tag" title="Click to filter">Disability</div>
             <div class="partner-tag disabled-veteran button disabled-tag" title="Click to filter">Disabled Veteran</div>
             <div class="partner-tag unspecified button disabled-tag" title="Click to filter">Unspecified</div>
         </div>


### PR DESCRIPTION
Way back when we went from "Disabled" to "Disability" we forgot to change the class associated which broke the function that handles what is/isn't checked. Only affected modern browsers when the user loaded OFCCP page with a URL containing special_interest=disability.  But made IE8 and 9 unable to filter the OFCCP page by disability.

Fix: Changed class disabled to disability