### PR TITLE
Misc. Reporting Tweaks

### DIFF
--- a/myreports/helpers.py
+++ b/myreports/helpers.py
@@ -1,6 +1,7 @@
 from collections import OrderedDict
 from cStringIO import StringIO
 import csv
+from datetime import datetime
 import HTMLParser
 import json
 
@@ -104,6 +105,18 @@ def serialize(fmt, data, values=None, order_by=None):
 
     """
 
+    # helper function to deal with different value types in a dict
+    def convert(record, value):
+        val = record[value]
+        # strip html from strings
+        if isinstance(val, basestring) and val:
+            val = html.fromstring(val).text_content()
+        # convert datetime to pretty string
+        if isinstance(val, datetime):
+            val = val.strftime("%b %d, %Y %I:%M%p")
+
+        return val
+
     if isinstance(data, query.ValuesQuerySet):
         data = list(data)
     elif isinstance(data, query.QuerySet):
@@ -118,12 +131,8 @@ def serialize(fmt, data, values=None, order_by=None):
 
         # Convert data to a list of `OrderedDict`s,
         data = sorted([OrderedDict([(
-            # strip HTML from invidual values...
-            value, html.fromstring(record[value]).text_content()
-            # if they aren't empty strings.
-            if isinstance(record[value], basestring) and record[value].strip()
-            else record[value]) for value in values]) for record in data],
-                # and sort them by specified value (first column by default)
+            value, convert(record, value))
+            for value in values]) for record in data],
                 key=lambda record: record[order_by], reverse=bool(reverse))
 
     if fmt == 'json':

--- a/myreports/helpers.py
+++ b/myreports/helpers.py
@@ -132,10 +132,10 @@ def serialize(fmt, data, values=None, order_by=None):
         _, reverse, order_by = sorted(order_by.partition('-'))
 
         # Convert data to a list of `OrderedDict`s,
-        data = sorted([OrderedDict([(
-            value, convert(record, value))
-            for value in values]) for record in data],
-                key=lambda record: record[order_by], reverse=bool(reverse))
+        data = sorted(
+            [OrderedDict([(value, convert(record, value)) for value in values])
+             for record in data], key=lambda record: record[order_by],
+            reverse=bool(reverse))
 
     if fmt == 'json':
         return json.dumps(data, cls=DjangoJSONEncoder)

--- a/myreports/views.py
+++ b/myreports/views.py
@@ -12,7 +12,7 @@ from django.views.generic import View
 
 from myreports.helpers import humanize, parse_params, serialize
 from myreports.models import Report
-from postajob.location_data import states
+from postajob import location_data
 from universal.helpers import get_company_or_404
 from universal.decorators import company_has_access
 
@@ -23,18 +23,16 @@ def overview(request):
     company = get_company_or_404(request)
 
     success = 'success' in request.POST
-
     reports = Report.objects.filter(owner=company).order_by("-created_on")
     report_count = reports.count()
     past_reports = reports[:10]
-
-    for report in past_reports:
-        report.name = report.name.replace("_", " ")
+    states = OrderedDict(
+        sorted((v, k) for k, v in location_data.states.inv.iteritems()))
 
     ctx = {
         "company": company,
         "success": success,
-        "states": json.dumps(OrderedDict(sorted((v, k) for k, v in states.inv.iteritems()))),
+        "states": json.dumps(states),
         "past_reports": past_reports,
         "report_count": report_count
     }
@@ -56,9 +54,6 @@ def report_archive(request):
     if request.is_ajax():
         company = get_company_or_404(request)
         reports = Report.objects.filter(owner=company).order_by("-created_on")
-
-        for report in reports:
-            report.name = report.name.replace("_", " ")
 
         ctx = {
             "reports": reports
@@ -217,7 +212,7 @@ class ReportView(View):
 
         params.pop('csrfmiddlewaretoken', None)
         name = params.pop('report_name',
-                          str(datetime.now())).replace(' ', '_')
+                          str(datetime.now()))
         values = params.pop('values', None)
 
         records = get_model(app, model).objects.from_search(
@@ -350,7 +345,7 @@ def download_report(request):
     response = HttpResponse(content_type='text/csv')
     content_disposition = "attachment; filename=%s-%s.csv"
     response['Content-Disposition'] = content_disposition % (
-        report.name, report.pk)
+        report.name.replace(' ', '_'), report.pk)
 
     response.write(serialize('csv', records, values=values, order_by=order_by))
 


### PR DESCRIPTION
Just a few aesthetic improvements requested in the last month or so that didn't fit within the scope of other tickets.

- `datetime`s are now pretty printed instead of in UTC ISO format
- report name mangling* only happens on report download

This is ready to merge as soon as it's reviewed, but I'll keep adding things to it if it doesn't get merged. If you want less code to review, review it sooner. Don't say I didn't warn you.

* firefox doesn't recognize files with spaces in their name