### PR TITLE
[PD-1370] Contact View shows duplicate States

### DIFF
--- a/static/reporting.164-19.js
+++ b/static/reporting.164-19.js
@@ -1692,21 +1692,29 @@ function renderViewContact(id) {
     success: function(data) {
       var $span = $('<div class="span12"></div>'),
           $table = $('<table class="table table-striped report-table"><thead><tr>' +
-                     '<th>Partner</th><th>Name</th><th>Phone</th><th>Email</th><th>State</th></tr></thead></table>'),
+                     '<th>Partner</th><th>Name</th><th>Phone</th><th>Email</th><th>State(s)</th></tr></thead></table>'),
           $tbody = $('<tbody></tbody>'),
           $mainContainer = $("#main-container"),
           location;
 
-      $tbody.append(function() {
-        return '<tr class="record">' + data.map(function(record) {
-          location = record.locations.map(function(location) {
-            return location.split(',')[1];
-          }).join();
+      // Append content to Table's tbody.
+      $tbody.append('<tr class="record">' + data.map(function(record) {
+        // Create a list of States based off of locations
+        // in a format of City, State
+        location = record.locations.map(function(location) {
+            // for each location get state and trim whitespace
+            return (location.split(',')[1] || '').trim();
+            // Determine uniqueness
+          }).sort().filter(function(e, i, a) {
+            // Due to sort, duplicates will be together.
+            // Check to see if this element is not the same as the prior one.
+            return e !== a[i - 1];
+          }).join(', ');
 
-          return '<td>' + record.partner + '</td><td>' + record.name + '</td><td>' + record.phone + '</td>' +
-                 '<td>' + record.email + '</td><td>' + location + '</td>';
-        }).join('</tr><tr>') + '</tr>';
-      });
+        return '<td>' + record.partner + '</td><td>' + record.name + '</td><td>' + record.phone + '</td>' +
+               '<td>' + record.email + '</td><td>' + location + '</td>';
+        }).join('</tr><tr>') + '</tr>'
+      );
 
       $mainContainer.html("").append($span.append($table.append($tbody)));
     }

--- a/templates/myreports/reports.html
+++ b/templates/myreports/reports.html
@@ -26,7 +26,7 @@
 <![endif]-->
 <script src="{{ STATIC_URL }}bootstrap/bootstrap-modalmanager.js"></script>
 <script src="{{ STATIC_URL }}bootstrap/bootstrap-modal.js"></script>
-<script src="{{ STATIC_URL }}reporting.164-12.js"></script>
+<script src="{{ STATIC_URL }}reporting.164-19.js"></script>
 <script src="{{ STATIC_URL }}pickadate/picker.js"></script>
 <script src="{{ STATIC_URL }}pickadate/picker.date.js"></script>
 <script src="{{ STATIC_URL }}pickadate/legacy.js"></script>


### PR DESCRIPTION
When viewing a Contact Report. If a contact has multiple locations, for example: Zionsville, IN; Carmel, IN; Fishers, IN; Austin, TX. In the table it would show up as IN, IN, IN, TX instead of IN, TX.