### PR TITLE
Tried a different way of replacing a location slug.

### DIFF
--- a/seo/breadbox.py
+++ b/seo/breadbox.py
@@ -215,12 +215,13 @@ class Breadbox(object):
             if ending_slug in slugs and len(location_filters) < 2:
                 slugs.remove(ending_slug)
 
-            location_slugs = location_slug.split('/')
-            left = slugs.index(location_slugs[0])
-            right = left + len(location_slugs)
+            if location_slug in new_path:
+                location_slugs = location_slug.split('/')
+                left = slugs.index(location_slugs[0])
+                right = left + len(location_slugs)
 
-            new_path = '/'.join(slugs[:left] + location_filters[1:] + 
-                                slugs[right:])
+                new_path = '/'.join(slugs[:left] + location_filters[1:] + 
+                                    slugs[right:])
 
             kwargs = {
                 # This class name is different because of the way we used to

--- a/seo/breadbox.py
+++ b/seo/breadbox.py
@@ -198,7 +198,7 @@ class Breadbox(object):
         self.build_title_breadcrumbs_from_slugs()
 
     def build_location_breadcrumbs_from_slugs(self):
-        ending_slug = settings.SLUG_TAGS['location_slug']
+        ending_slug = settings.SLUG_TAGS['location_slug'].strip('/')
 
         if self.filters.get('location_slug'):
             location_slug = self.filters['location_slug'].strip('/')
@@ -211,11 +211,16 @@ class Breadbox(object):
 
             # If there's only a country then we can safely remove the
             # ending slug as well.
-            if len(location_filters) < 2:
-                new_path = new_path.replace(ending_slug, '')
+            slugs = new_path.split('/')
+            if ending_slug in slugs and len(location_filters) < 2:
+                slugs.remove(ending_slug)
 
-            new_location_slug = "/".join(location_filters[1:])
-            new_path = new_path.replace(location_slug, new_location_slug)
+            location_slugs = location_slug.split('/')
+            left = slugs.index(location_slugs[0])
+            right = left + len(location_slugs)
+
+            new_path = '/'.join(slugs[:left] + location_filters[1:] + 
+                                slugs[right:])
 
             kwargs = {
                 # This class name is different because of the way we used to

--- a/seo/tests/test_breadbox.py
+++ b/seo/tests/test_breadbox.py
@@ -98,6 +98,22 @@ class BreadboxTests(DirectSEOBase):
         self.assertEqual(breadbox.location_breadcrumbs[0].display_title,
                          'Indianapolis, IN')
 
+    def test_breadcrumbs_from_slugs(self):
+        """Tests that breadcrumb URLs aren't mangled on creation from slugs."""
+        path = 'deu/jobs/deutsche-bank/careers/'
+
+        self.filters['company_slug'] = 'deutsche-bank'
+        self.filters['location_slug'] = 'deu'
+
+        breadbox = Breadbox(path, self.filters, [], QueryDict(''))
+        breadbox.build_location_breadcrumbs_from_slugs()
+
+        # Before, the resulting URL would become '[tsche-bank/careers/', which
+        # is incorrect, as deu as a slug should be removed, rather than the
+        # company name being mangled
+        self.assertEqual(breadbox.location_breadcrumbs[0].url,
+                         'deutsche-bank/careers/')
+
     def test_moc_slug(self):
         moc = MocFactory()
 


### PR DESCRIPTION
Rather than replacing the location slug text, I find out where the location slug starts and ends and replace that (by converting the location and location slug to lists).

I contemplated using string.find for this, but thought it would result in a similar issue to what we have now. Now we strip all occurrences of a substring. Find would strip only the first, but could produce a false positive. The alternative might be to match substrings wrapped with slashes, but I wasn't sure if that would be reliable, hence why the current method.