### PR TITLE
[PD-1372] Editing a contact record now goes back to the correct record.

### DIFF
--- a/mypartners/views.py
+++ b/mypartners/views.py
@@ -747,6 +747,7 @@ def prm_records(request):
 def prm_edit_records(request):
     company, partner, user = prm_worthy(request)
     record_id = request.GET.get('id', None)
+    page = request.GET.get('page', 1)
 
     try:
         instance = ContactRecord.objects.get(pk=record_id)
@@ -766,8 +767,8 @@ def prm_edit_records(request):
         if form.is_valid():
             form.save(user, partner)
             return HttpResponseRedirect(reverse('record_view') +
-                                        '?partner=%d&id=%d' %
-                                        (partner.id, form.instance.id))
+                                        '?partner=%d&page=%s' %
+                                        (partner.id, page))
     else:
         form = ContactRecordForm(partner=partner, instance=instance)
 
@@ -775,7 +776,7 @@ def prm_edit_records(request):
         'company': company,
         'partner': partner,
         'content_type': ContentType.objects.get_for_model(ContactRecord).id,
-        'object_id': record_id,
+        'item_id': record_id,
         'form': form,
     }
     return render_to_response('mypartners/edit_record.html', ctx,

--- a/templates/mypartners/view_record.html
+++ b/templates/mypartners/view_record.html
@@ -90,7 +90,8 @@
             </div>
         </div>
         <div class="span3">
-            <a class="btn one-hundred-percent-button-border-boxed" href="{% url 'partner_edit_record' %}?company={{ company.id }}&partner={{ partner.id }}&id={{ record.id }}">Edit</a>
+            <a class="btn one-hundred-percent-button-border-boxed" 
+               href="{% url 'partner_edit_record' %}?company={{ company.id }}&partner={{ partner.id }}&id={{ record.id }}&page={{ page }}">Edit</a>
             <div class="tip-box" id="record-history">
             <h5>Record History</h5>
                 <div class="tip-content">
@@ -106,7 +107,7 @@
             <div class="tip-box">
                 <h5>Tags</h5>
                 <div class="tip-content">
-                    {% if not record.tags %}
+                    {% if not record.tags.count %}
                     No tags for this record.
                     {% else %}
                         {% for tag in record.tags.all %}


### PR DESCRIPTION
Basically, the view record page is determined by the page the record was on in the results, not the id of the record. 

I also made sure the proper verbiage was shown when editing vs viewing a record. This also enables the default text for records without tags.