### PR TITLE
[ST-1258] more button work around for job listing

### DIFF
--- a/myblocks/models.py
+++ b/myblocks/models.py
@@ -302,7 +302,7 @@ class MoreButtonBlock(Block):
         }
 
     def required_js(self):
-        return ['%spager.163-24.js' % settings.STATIC_URL]
+        return ['%spager.164-21.js' % settings.STATIC_URL]
 
 
 class RegistrationBlock(Block):

--- a/static/filter_carousel.js
+++ b/static/filter_carousel.js
@@ -14,7 +14,7 @@ window.onload = function() {
         }
     }).done(function() {
         if (typeof Pager == "undefined") {
-            $.getScript("//d2e48ltfsb5exy.cloudfront.net/content_ms/files/pager.163-24.js");
+            $.getScript("//d2e48ltfsb5exy.cloudfront.net/content_ms/files/pager.164-21.js");
         }
     });
 };

--- a/static/pager.164-21.js
+++ b/static/pager.164-21.js
@@ -216,7 +216,6 @@ Pager.prototype = {
 };
 
 $(document).ready(function(){
-  $(".more_less_links_container").css("margin-left", "25px");
 	var pager = new Pager();
     var total_clicks = parseInt(window.location.hash.slice(1, 10));
     if (!isNaN(total_clicks)) {

--- a/static/pager.164-21.js
+++ b/static/pager.164-21.js
@@ -155,13 +155,18 @@ Pager.prototype = {
         // ajax call.
         var alsoThis = this;
         var url = this._build_url(type);
-        $.get(
-            url,
-            data,
-            function(html) {
-                alsoThis._getItemsSuccessHandler(url ? html : "", parent);
-            }
-        );
+
+        if (url) {
+            $.get(
+                url,
+                data,
+                function(html) {
+                    alsoThis._getItemsSuccessHandler(html, parent);
+                }
+            );
+        } else {
+            alsoThis._getItemsSuccessHandler("", parent);
+        }
     },
 
     _build_url: function(type){

--- a/static/pager.164-21.js
+++ b/static/pager.164-21.js
@@ -159,7 +159,7 @@ Pager.prototype = {
             url,
             data,
             function(html) {
-                alsoThis._getItemsSuccessHandler(html, parent);
+                alsoThis._getItemsSuccessHandler(url ? html : "", parent);
             }
         );
     },
@@ -216,6 +216,7 @@ Pager.prototype = {
 };
 
 $(document).ready(function(){
+  $(".more_less_links_container").css("margin-left", "25px");
 	var pager = new Pager();
     var total_clicks = parseInt(window.location.hash.slice(1, 10));
     if (!isNaN(total_clicks)) {

--- a/templates/def.ui.dotjobs.css
+++ b/templates/def.ui.dotjobs.css
@@ -1132,7 +1132,7 @@ a#sponsor-dotjobs:hover{
 .direct_dotjobsFilterContainer a:hover{
     color: #900;
 }
-.direct_dotjobsFilterContainer a.direct_optionsMore{
+.direct_dotjobsFilterContainer .more_less_links_container {
     margin-left: 25px;
 }
 .ui-autocomplete .ui-state-hover,

--- a/templates/includes/more_less_links.html
+++ b/templates/includes/more_less_links.html
@@ -1,3 +1,5 @@
 {% load i18n %}
-<a class="direct_optionsMore" href="#" rel="nofollow">{% blocktrans %}More{% endblocktrans %}</a>
-<a class="direct_optionsLess"  href="#" rel="nofollow">{% blocktrans %}Less{% endblocktrans %}</a>
+<div class="more_less_links_container">
+    <a class="direct_optionsMore" href="#" rel="nofollow">{% blocktrans %}More{% endblocktrans %}</a>
+    <a class="direct_optionsLess"  href="#" rel="nofollow">{% blocktrans %}Less{% endblocktrans %}</a>
+</div>

--- a/templates/seo_base.html
+++ b/templates/seo_base.html
@@ -37,7 +37,7 @@
       var pager_num_items = {{ site_config.num_subnav_items_to_show }};
     </script>
 
-    <script type="text/javascript" src="{{ STATIC_URL }}pager.163-24.js"></script>
+    <script type="text/javascript" src="{{ STATIC_URL }}pager.164-21.js"></script>
 
     {% block ga_js %}{% include "ga.html"%}{% endblock %}
 


### PR DESCRIPTION
The issue is that there is no url for featured companies. The proper fix would involve touching pager.js, seo/urls/search_urls.py, seo/views/search_views.py, seo/helpers.py, and seo/filters.py at a bare minimum (I stopped digging once I realized there were this many things to change). 

As this template is only used by one company, I decided on a work around instead, which takes advantage of the fact that the second result set is already loaded. Thus, if a request comes for more companies, those companies are simply loaded. The implication of this work around is that there may be at a maximum, 20 featured companies, until a proper fix is implemented. 