### PR TITLE
[PD-1381] Model Status

### DIFF
--- a/mypartners/models.py
+++ b/mypartners/models.py
@@ -39,6 +39,27 @@ ACTIVITY_TYPES = {
 }
 
 
+class Status(models.Model):
+    """ 
+    Keeps track of a particular model's approval status.
+    """
+    UNPROCESSED, APPROVED, DENIED = range(3)
+    STATUS_CODES = (
+        (UNPROCESSED, "Unprocessed"),
+        (APPROVED, "Approved"),
+        (DENIED, "Denied")
+    )
+    
+    code = models.PositiveSmallIntegerField(
+        default=UNPROCESSED, choices=STATUS_CODES, verbose_name="Status Code")
+    last_modified = models.DateTimeField(
+        null=False, verbose_name="Last Modified")
+
+    def save(self, *args, **kwargs):
+        self.last_modified = datetime.now()
+        super(Status, self).save(*args, **kwargs)
+
+
 class SearchParameterQuerySet(models.query.QuerySet):
     """
     Defines a query set with a `from_search` method for filtering by query
@@ -627,7 +648,7 @@ class ContactRecordManager(SearchParameterManager):
         return ContactRecordQuerySet(self.model, using=self._db)
 
     def communication_activity(self):
-        return self.get_query_set().communication_activity()
+        return self.get_query_set().communication_activity
 
 
 class ContactRecord(models.Model):
@@ -900,3 +921,5 @@ class Tag(models.Model):
     class Meta:
         unique_together = ('name', 'company')
         verbose_name = "tag"
+
+


### PR DESCRIPTION
*note: This isn't anywhere close to done, but I'm soliciting feedback because the answers to the following questions will greatly affect the end result. Please don't ignore this just because it's WIP.*

# Current Implementation
At the moment, I've implemented status as a separate table with code and last_modified columns. The reason I went for a separate model instead of a single (or pair of) new column(s) is that depending on how many models we need to "approve", doing so would mean that there are that many models that need to have new columns, each of which having custom code to handle approval status. While using a foreign key still means needing to add columns to all the affected models, if we decide that approval needs more information (such as a denial reason), we can do so in a single place, rather than all of the affected models.

# Concerns
While the current implementation includes the model (with the migration for it missing intentionally for the time being), I have a number of concerns before I feel comfortable continuing:

## Code Complexity
At the moment, this feature isn't being used, so implementing it now not only requires a lot of code to be written (eg. all forms relating to affected models will have to change), and the resulting queries generated by django will be potentially more complicated, all to check for a field that does nothing at the moment. This, of course, assuming that approval for current forms should be set to an "approved" status for now. See my text point for the case where "unprocessed" is the default.

## Lack of Gained Traction.
If approved is the default status, then we don't gain anything over not having the field to begin with, since records don't have to be processed. If "unprocessed" is the default status, then even more code will need to change, as we would have to change the approval status for all existing forms (since all existing forms assume a logged in company user). That seems like a lot of work for a future feature which, as far as I understand it, isn't even fleshed out. 

## Too Many Migrations
I would expect that once whatever feature requires this is implemented, we would either have to have yet another migration to accommodate those introduced models, or this model may change as we find it too flexible/rigid, which would increase the number of migrations. On one hand, it could be argued that more migrations means finer grained control over the exact state of the database, but we have historically not done so well will multiple migrations which are codependent, especially during deployment. As such, unless we have found a way to effectively deal with those deficiencies, it seems in our best interest to reduce the amount of migrations introduced. If I am right, that would entail waiting on this ticket until a feature that needs this is implemented.
# Alternatives
## Nullable Boolean
Hal originally mentioned using a nullable boolean field, [which Django supports](https://docs.djangoproject.com/en/1.6/ref/models/fields/#django.db.models.NullBooleanField), but @almathew objected to. The rationale there was that null would signify that the record hadn't been processed yet. I'm not sure what the objection was, other than perhaps nulls generally cause complications. 

## String
I may have not heard correctly, but I think there was an idea to use a string rather than a boolean (technically a small integer in MySQL). I think the logic here would have been that by using a string, we could give denial reasons, akin to what we provide for postajob postings. My objection here is along the lines of any argument against  [stringly typed code](https://www.google.com/search?q=stringly+typed&ie=utf-8&oe=utf-8). 