### PR TITLE
[PD-1335] Reports - add regeneration as 4th column in report lists

### DIFF
--- a/myreports/helpers.py
+++ b/myreports/helpers.py
@@ -110,7 +110,7 @@ def serialize(fmt, data, values=None, order_by=None):
     def convert(record, value):
         val = record[value]
         # strip html from strings
-        if isinstance(val, basestring) and val:
+        if isinstance(val, basestring) and val.strip():
             val = html.fromstring(val).text_content()
         # convert datetime to pretty string
         if isinstance(val, datetime):

--- a/myreports/models.py
+++ b/myreports/models.py
@@ -65,10 +65,12 @@ class Report(models.Model):
 
     def regenerate(self):
         """Regenerate the report file if it doesn't already exist on disk."""
-        if not self.results:
-            values = json.loads(self.values)
-            contents = serialize('json', self.queryset, values=values)
-            results = ContentFile(contents)
+        values = json.loads(self.values)
+        contents = serialize('json', self.queryset, values=values)
+        results = ContentFile(contents)
 
-            self.results.save('%s-%s.json' % (self.name, self.pk), results)
-            self._results = contents
+        if self.results:
+            self.results.delete()
+
+        self.results.save('%s-%s.json' % (self.name, self.pk), results)
+        self._results = contents

--- a/myreports/tests/test_views.py
+++ b/myreports/tests/test_views.py
@@ -303,12 +303,11 @@ class TestRegenerate(MyReportsTestCase):
 
         report_name = response.content
         report = Report.objects.get(name=report_name)
-        results = report.results
 
         response = self.client.get(data={'id': report.id})
         self.assertEqual(response.status_code, 200)
 
-        # remove report results and ensure we can still get a resonable
+        # remove report results and ensure we can still get a reasonable
         # response
         report.results.delete()
         report.save()
@@ -323,3 +322,12 @@ class TestRegenerate(MyReportsTestCase):
         report = Report.objects.get(name=report_name)
         self.assertEqual(response.status_code, 200)
         self.assertTrue(report.results)
+
+        # regenerate report without deleting the report prior
+        # see if it overwrites other report.
+        results = report.results
+        response = self.client.get(path=reverse('regenerate'), data={
+            'id': report.pk})
+        report = Report.objects.get(name=report_name)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(results.name, report.results.name)

--- a/myreports/views.py
+++ b/myreports/views.py
@@ -279,7 +279,9 @@ def downloads(request):
         report_id = request.GET.get('id', 0)
         report = get_object_or_404(
             get_model('myreports', 'report'), pk=report_id)
-        report.regenerate()
+
+        if not report.results:
+            report.regenerate()
 
         fields = sorted([field for field in report.python[0].keys()
                          if field != 'pk'])

--- a/static/my.jobs.165-01.css
+++ b/static/my.jobs.165-01.css
@@ -1641,7 +1641,7 @@ h3.bottom-bordered {
     display: block;
     overflow: hidden;
     text-overflow: ellipsis;
-    width: 210px;
+    width: 185px;
     white-space: nowrap;
 }
 
@@ -1653,7 +1653,7 @@ h3.bottom-bordered {
     position: absolute;
     right: 0;
     top: 3px;
-    width: 65px;
+    width: 90px;
 }
 
 .icon-set i {
@@ -1808,7 +1808,8 @@ h3.bottom-bordered {
 
 .view-report:hover,
 .clone-report:hover,
-.export-report:hover {
+.export-report:hover,
+.regenerate-report:hover {
     cursor: pointer;
 }
 
@@ -1818,6 +1819,16 @@ h3.bottom-bordered {
 
 .export-report a:hover {
     text-decoration: none;
+}
+
+.export-report.disabled,
+.fa-download.disabled {
+    color: #999;
+}
+
+.export-report.disabled:hover,
+.fa-download.disabled:hover {
+    cursor: not-allowed;
 }
 
 span.small {

--- a/static/reporting.165-01.js
+++ b/static/reporting.165-01.js
@@ -1137,7 +1137,7 @@ $(document).ready(function() {
     renderNavigation();
   });
 
-  subpage.on("click", ".fa-download, .export-report", function() {
+  subpage.on("click", ".fa-download:not(.disabled), .export-report:not(.disabled)", function() {
     var report_id = $(this).parents("tr, .report").data("report");
 
     if (modernBrowser) {
@@ -1179,11 +1179,12 @@ $(document).ready(function() {
         $icon.addClass("fa-spin");
       },
       success: function() {
-        $icon.removeClass("fa-refresh fa-spin").addClass("fa-download");
+        $icon.removeClass("fa-spin");
 
         if (archive) {
-          $div.removeClass("regenerate-report").addClass("export-report");
-          $div.html($icon.prop("outerHTML") + " Export Report");
+          $div.parents('tr').find('.export-report').removeClass('disabled');
+        } else {
+          $icon.next().removeClass('disabled');
         }
       }
     });

--- a/static/reporting.165-01.js
+++ b/static/reporting.165-01.js
@@ -158,7 +158,7 @@ Report.prototype.createCloneReport = function(json) {
         date = this.findField("date");
         $.extend(date.defaultVal, phony);
       } else {
-        this.findField(key === "name" ? "contact" : key).defaultVal = value;
+        this.findField(key === "contact__name" ? "contact" : key).defaultVal = value;
       }
     }
   }

--- a/templates/base.html
+++ b/templates/base.html
@@ -20,7 +20,7 @@
     {% block meta-extra %}{% endblock %}
 
     <link href="{{ STATIC_URL }}def.ui.152-21.css{{ gz }}" rel="stylesheet" type="text/css">
-    <link href="{{ STATIC_URL }}my.jobs.164-07.css{{ gz }}" rel="stylesheet" type="text/css">
+    <link href="{{ STATIC_URL }}my.jobs.165-01.css{{ gz }}" rel="stylesheet" type="text/css">
     <!--[if IE]>
     <link href="{{ STATIC_URL }}my.jobs.ie.163-29.css{{ gz }}" rel="stylesheet" type="text/css">
     <![endif]-->

--- a/templates/myreports/includes/report-archive.html
+++ b/templates/myreports/includes/report-archive.html
@@ -19,15 +19,14 @@
                     </div>
                 </td>
                 <td>
-                    {% if report.results %}
-                    <div title="Export Report" class="export-report">
-                        <i class="fa fa-download"></i> Export Report
-                    </div>
-                    {% else %}
                     <div title="Regenerate Report" class="regenerate-report">
                         <i class="fa fa-refresh"></i> Regenerate Report
                     </div>
-                    {% endif %}
+                </td>
+                <td>
+                    <div title="Export Report" class="export-report {% if not report.results %}disabled{% endif %}">
+                        <i class="fa fa-download"></i> Export Report
+                    </div>
                 </td>
             </tr>
             {% endfor %}

--- a/templates/myreports/includes/report-sidebar.html
+++ b/templates/myreports/includes/report-sidebar.html
@@ -2,9 +2,9 @@
     <h2 class="top">Past Reports</h2>
     {% for report in past_reports %}
         <div class="report" data-report="{{ report.id }}" data-model="{{ report.model }}">
-            <a>{{ report.name }}</a>
+            <a title="View Report">{{ report.name }}</a>
             <div class="icon-set">
-                <i id="view-{{ report.id }}" class="fa fa-eye" title="View"></i>
+                <i id="view-{{ report.id }}" class="fa fa-eye" title="View Report"></i>
                 <i id="clone-{{ report.id }}" class="fa fa-copy" title="Clone Report"></i>
                 <i id="regen-{{ report.id }}" class="fa fa-refresh" title="Regenerate Report"></i>
                 <i id="export-{{ report.id }}" class="fa fa-download {% if not report.results %}disabled{% endif %}" title="Export Report"></i>

--- a/templates/myreports/includes/report-sidebar.html
+++ b/templates/myreports/includes/report-sidebar.html
@@ -6,7 +6,8 @@
             <div class="icon-set">
                 <i id="view-{{ report.id }}" class="fa fa-eye" title="View"></i>
                 <i id="clone-{{ report.id }}" class="fa fa-copy" title="Clone Report"></i>
-                <i id="export-{{ report.id }}" class="fa {% if report.results %}fa-download{% else %}fa-refresh{% endif %}" title="{% if report.results %}Export Report{% else %}Regenerate Report{% endif %}"></i>
+                <i id="regen-{{ report.id }}" class="fa fa-refresh" title="Regenerate Report"></i>
+                <i id="export-{{ report.id }}" class="fa fa-download {% if not report.results %}disabled{% endif %}" title="Export Report"></i>
             </div>
         </div>
     {% empty %}

--- a/templates/myreports/reports.html
+++ b/templates/myreports/reports.html
@@ -26,7 +26,7 @@
 <![endif]-->
 <script src="{{ STATIC_URL }}bootstrap/bootstrap-modalmanager.js"></script>
 <script src="{{ STATIC_URL }}bootstrap/bootstrap-modal.js"></script>
-<script src="{{ STATIC_URL }}reporting.164-20.js"></script>
+<script src="{{ STATIC_URL }}reporting.165-01.js"></script>
 <script src="{{ STATIC_URL }}pickadate/picker.js"></script>
 <script src="{{ STATIC_URL }}pickadate/picker.date.js"></script>
 <script src="{{ STATIC_URL }}pickadate/legacy.js"></script>


### PR DESCRIPTION
- Added new column for regenerate and updated JS to handle new rules
- Edit regenerate functionality to always regenerate (as opposed to checking to see if the file already exists and ignore the request) and delete the old report file if it already exists.

Sidebar:
![regenerate](https://cloud.githubusercontent.com/assets/4359673/7922755/4610f1c4-087c-11e5-86a4-96cab368d6dd.gif)

Archive:
![screen shot 2015-06-01 at 4 23 34 pm](https://cloud.githubusercontent.com/assets/4359673/7922778/6fd27942-087c-11e5-9fe0-320e11075a63.png)
