### PR TITLE
[PD-1415] Fixed regenerate.

### DIFF
--- a/myreports/models.py
+++ b/myreports/models.py
@@ -66,8 +66,7 @@ class Report(models.Model):
     def regenerate(self):
         """Regenerate the report file if it doesn't already exist on disk."""
         if not self.results:
-            values = json.loads(self.values)
-            contents = serialize('json', self.queryset, values=values)
+            contents = serialize('json', self.queryset)
             results = ContentFile(contents)
 
             self.results.save('%s-%s.json' % (self.name, self.pk), results)

--- a/myreports/models.py
+++ b/myreports/models.py
@@ -38,13 +38,13 @@ class Report(models.Model):
 
     def __init__(self, *args, **kwargs):
         super(Report, self).__init__(*args, **kwargs)
+        self._results = '{}'
+
         if self.results:
             try:
                 self._results = self.results.read()
             except IOError:
                 self.results.delete()
-        else:
-            self._results = '{}'
 
     @property
     def json(self):

--- a/myreports/tests/test_views.py
+++ b/myreports/tests/test_views.py
@@ -1,6 +1,7 @@
 """Tests associated with myreports views."""
 
 import json
+import os
 
 from django.test import TestCase
 from django.core.urlresolvers import reverse
@@ -341,4 +342,29 @@ class TestRegenerate(MyReportsTestCase):
             'id': report.pk})
         report = Report.objects.get(name=report_name)
         self.assertEqual(response.status_code, 200)
+        self.assertTrue(report.results)
+
+    def test_regenerating_missing_file(self):
+        """Tests that a report can be regenerated when file is missing."""
+
+        # create a new report
+        response = self.client.post(
+            path=reverse('reports', kwargs={
+                'app': 'mypartners', 'model': 'contactrecord'}))
+
+        report_name = response.content
+        report = Report.objects.get(name=report_name)
+
+        # report should have results
+        self.assertTrue(report.results)
+
+        # delete physical file and ensure that json reflects the missing link
+        os.remove(report.results.file.name)
+        report = Report.objects.get(pk=report.pk)
+        self.assertFalse(report.results)
+        self.assertEqual(report.json, u'{}')
+        self.assertEqual(report.python, {})
+    
+        # regenerate the report even though the file is physically missing
+        report.regenerate()
         self.assertTrue(report.results)

--- a/myreports/tests/test_views.py
+++ b/myreports/tests/test_views.py
@@ -275,11 +275,17 @@ class TestDownloadReport(MyReportsTestCase):
             'app': 'mypartners', 'model': 'contactrecord'}))
         report_name = response.content
         report = Report.objects.get(name=report_name)
+        python = report.python
 
         # download the report
-        response = self.client.get(data={'id': report.pk})
+        response = self.client.get(data={
+            'id': report.pk,
+            'values': ['contact', 'contact_email', 'contact_phone']})
 
         self.assertEqual(response['Content-Type'], 'text/csv')
+
+        # specifying export values shouldn't modify the underlying report
+        self.assertEqual(len(python[0].keys()), len(report.python[0].keys()))
 
 
 class TestRegenerate(MyReportsTestCase):
@@ -298,12 +304,12 @@ class TestRegenerate(MyReportsTestCase):
         # company
         response = self.client.post(
             path=reverse('reports', kwargs={
-                'app': 'mypartners', 'model': 'contactrecord'}),
-            data={'values': ['partner', 'contact__name', 'contact_type']})
+                'app': 'mypartners', 'model': 'contactrecord'}))
 
         report_name = response.content
         report = Report.objects.get(name=report_name)
         results = report.results
+        python = report.python
 
         response = self.client.get(data={'id': report.id})
         self.assertEqual(response.status_code, 200)
@@ -323,3 +329,4 @@ class TestRegenerate(MyReportsTestCase):
         report = Report.objects.get(name=report_name)
         self.assertEqual(response.status_code, 200)
         self.assertTrue(report.results)
+


### PR DESCRIPTION
Didn't notice before because contactrecord report doesn't rely on json. The fix was to not pass values to the serialize function when regenerating. In other words, json represents all pristine records and should only be modified on export (which I thought I was doing but obviously wasnt).