### PR TITLE
[PD-1420] Black-listed colmns so they dont show up in reports.

### DIFF
--- a/myreports/views.py
+++ b/myreports/views.py
@@ -286,11 +286,17 @@ def downloads(request):
         report = get_object_or_404(
             get_model('myreports', 'report'), pk=report_id)
 
+        common_blacklist = ['pk', 'approval_status']
+        blacklist = {
+            'contactrecord': common_blacklist,
+            'contact': common_blacklist + ['archived_on', 'library', 'user'],
+            'partner': common_blacklist + ['library', 'owner']}
+
         if not report.results:
             report.regenerate()
 
         fields = sorted([field for field in report.python[0].keys()
-                         if field != 'pk'])
+                         if field not in blacklist[report.model]])
 
         values = json.loads(report.values) or fields
         fields = values + [field for field in fields if field not in values]


### PR DESCRIPTION
# Note
I based this off of #1579 since that PR also changes unit tests. You can either  merge that, then this, or merge this and close that.

The only changes relevant to this PR are [here](https://github.com/DirectEmployers/MyJobs/pull/1576/files#diff-eb9601953df6f5b354db064401d8015cR253) and [here](https://github.com/DirectEmployers/MyJobs/pull/1576/files#diff-ebd3cabe61d5dc9f762eb5c7c5138120R289)

Before:
![2015-06-05-074346_628x665_scrot](https://cloud.githubusercontent.com/assets/93686/8005337/fc1c878a-0b56-11e5-8a85-a918e2e80af4.png)
![2015-06-05-074400_636x425_scrot](https://cloud.githubusercontent.com/assets/93686/8005339/fc20b148-0b56-11e5-9c26-230cb8ed7190.png)
![2015-06-05-074418_625x321_scrot](https://cloud.githubusercontent.com/assets/93686/8005338/fc206b52-0b56-11e5-9558-a75e8a9d3659.png)

After:
![2015-06-05-074540_629x630_scrot](https://cloud.githubusercontent.com/assets/93686/8005342/038f18ac-0b57-11e5-9c08-ed00bc837ca1.png)
![2015-06-05-074553_628x280_scrot](https://cloud.githubusercontent.com/assets/93686/8005341/038d9496-0b57-11e5-9875-c9ea7fda602f.png)
![2015-06-05-074604_637x216_scrot](https://cloud.githubusercontent.com/assets/93686/8005343/039367f4-0b57-11e5-9be1-5822928c2704.png)

~~Still need to write a test to ensure that on the download page,  blacklisted columns don't show up, but I wanted this up to let it be known that this is being worked on.~~

Writing tests for this now will cause a merge conflict, so I'll write them once #1574 is merged.