### PR TITLE
[PD-885] imports - can't switch from etl imported business unit to seoxml

### DIFF
--- a/import_jobs.py
+++ b/import_jobs.py
@@ -390,6 +390,9 @@ def update_solr(buid, download=True, force=True, set_title=False,
                          (buid, list(solr_del_uids)))
             conn.delete(q=delete_chunk)
 
+    # Delete jobs that don't have UIDs, on the basis that they are from a etl_to_solr import, not this task.
+    conn.delete(q='buid:%s AND -uid:* AND -is_posted:true' % buid) 
+
     #Update business unit information: title, dates, and associated_jobs
     if set_title or not bu.title or (bu.title != jobfeed.job_source_name and
                                      jobfeed.job_source_name):

--- a/seo/tests/test_import_jobs.py
+++ b/seo/tests/test_import_jobs.py
@@ -158,7 +158,7 @@ class ImportJobsTestCase(DirectSEOBase):
         etl_ids = set([d['id'] for d in etl_jobs])
         ids = set([d['id'] for d in self.solr.search('*:*').docs])
         self.assertGreater(len(ids), 0, "No jobs were found for the business unit.")
-        self.assertTrue(len(etl_ids & ids) == 0, "Jobs without uids are not being removed.")
+        self.assertEqual(len(etl_ids & ids), 0, "Jobs without uids are not being removed.")
 
 
 class LoadETLTestCase(DirectSEOBase):

--- a/seo/tests/test_import_jobs.py
+++ b/seo/tests/test_import_jobs.py
@@ -148,6 +148,18 @@ class ImportJobsTestCase(DirectSEOBase):
             ids = [d['id'] for d in self.solr.search('*:*').docs]
             self.assertTrue([5, 6, 7, 8, 9, 10] not in ids)
 
+    def test_remove_jobs_from_etl(self):
+        etl_jobs = [{'id': 'seo.%s' % i, 'buid': self.buid_id} for i in range(2, 10)]
+        self.solr.add(etl_jobs)
+        self.solr.commit()
+        
+        update_solr(self.buid_id)
+        
+        etl_ids = set([d['id'] for d in etl_jobs])
+        ids = set([d['id'] for d in self.solr.search('*:*').docs])
+        self.assertGreater(len(ids), 0, "No jobs were found for the business unit.")
+        self.assertTrue(len(etl_ids & ids) == 0, "Jobs without uids are not being removed.")
+
 
 class LoadETLTestCase(DirectSEOBase):
     def setUp(self):


### PR DESCRIPTION
Fix for jobs from etl_to_solr being left behind when the business unit is imported via seoxml.