### PR TITLE
[PD-1431] Membership should be checked against slugs, not path

### DIFF
--- a/seo/breadbox.py
+++ b/seo/breadbox.py
@@ -215,12 +215,12 @@ class Breadbox(object):
             if ending_slug in slugs and len(location_filters) < 2:
                 slugs.remove(ending_slug)
 
-            if location_slug in new_path:
+            if location_slug in slugs:
                 location_slugs = location_slug.split('/')
                 left = slugs.index(location_slugs[0])
                 right = left + len(location_slugs)
 
-                new_path = '/'.join(slugs[:left] + location_filters[1:] + 
+                new_path = '/'.join(slugs[:left] + location_filters[1:] +
                                     slugs[right:])
 
             kwargs = {

--- a/seo/breadbox.py
+++ b/seo/breadbox.py
@@ -215,13 +215,14 @@ class Breadbox(object):
             if ending_slug in slugs and len(location_filters) < 2:
                 slugs.remove(ending_slug)
 
-            if location_slug in slugs:
-                location_slugs = location_slug.split('/')
+            location_slugs = location_slug.split('/')
+            try:
                 left = slugs.index(location_slugs[0])
                 right = left + len(location_slugs)
-
                 new_path = '/'.join(slugs[:left] + location_filters[1:] +
                                     slugs[right:])
+            except ValueError:
+                pass
 
             kwargs = {
                 # This class name is different because of the way we used to

--- a/seo/breadbox.py
+++ b/seo/breadbox.py
@@ -218,11 +218,13 @@ class Breadbox(object):
             location_slugs = location_slug.split('/')
             try:
                 left = slugs.index(location_slugs[0])
+            except ValueError:
+                # location slug isn't part of the path 
+                pass
+            else:
                 right = left + len(location_slugs)
                 new_path = '/'.join(slugs[:left] + location_filters[1:] +
                                     slugs[right:])
-            except ValueError:
-                pass
 
             kwargs = {
                 # This class name is different because of the way we used to

--- a/seo/tests/test_breadbox.py
+++ b/seo/tests/test_breadbox.py
@@ -100,12 +100,13 @@ class BreadboxTests(DirectSEOBase):
 
     def test_breadcrumbs_from_slugs(self):
         """Tests that breadcrumb URLs aren't mangled on creation from slugs."""
-        path = 'deu/jobs/deutsche-bank/careers/'
+        path = u'deu/jobs/deutsche-bank/careers/'
 
         self.filters['company_slug'] = 'deutsche-bank'
         self.filters['location_slug'] = 'deu'
+        query_dict = QueryDict('')
 
-        breadbox = Breadbox(path, self.filters, [], QueryDict(''))
+        breadbox = Breadbox(path, self.filters, [], query_dict)
         breadbox.build_location_breadcrumbs_from_slugs()
 
         # Before, the resulting URL would become '[tsche-bank/careers/', which
@@ -113,6 +114,11 @@ class BreadboxTests(DirectSEOBase):
         # company name being mangled
         self.assertEqual(breadbox.location_breadcrumbs[0].url,
                          'deutsche-bank/careers/')
+
+        # location slug not being part of the path shouldn't raise an error
+        path = '/jobs/deutsche-bank/careers/'
+        breadbox = Breadbox(path, self.filters, [], query_dict)
+        breadbox.build_location_breadcrumbs_from_slugs()
 
     def test_moc_slug(self):
         moc = MocFactory()


### PR DESCRIPTION
The location slug may already have been removed from the path, so we shouldn't check against the path for membership before finding out where to try and remove said location slug.

Extended unit test to expand to this case. If you run the tests on master without the changes to the view, you'll see a failure similar to what's currently exhibited on production.