### PR TITLE
[PD-1442][PD-1440][PD-1443] Makes sure password change is required after invitation accepted

### DIFF
--- a/registration/tests/test_views.py
+++ b/registration/tests/test_views.py
@@ -159,6 +159,21 @@ class RegistrationViewTests(MyJobsBase):
         user = User.objects.get(pk=self.user.pk)
         self.assertFalse(user.is_active)
 
+    def test_invitation_asks_for_password_change(self):
+        """
+        When activating an account via an invitation, the user should still be
+        prompted to change their password.
+        """
+        invitation = InvitationFactory(inviting_user=self.user)
+        key = invitation.invitee.activationprofile_set.first().activation_key
+        response = self.client.get(
+            reverse('invitation_activate', kwargs={'activation_key': key}),
+            data={'verify-email': invitation.invitee_email})
+
+        invitee = User.objects.get(pk=invitation.invitee.pk)
+
+        self.assertTrue(invitee.password_change)
+
     def test_accept_invitation_already_activated(self):
         """
         Since invitations use the same keys as activations, we should ensure

--- a/registration/views.py
+++ b/registration/views.py
@@ -99,6 +99,9 @@ def activate(request, activation_key, invitation=False):
                 activated.in_reserve = False
                 password = User.objects.make_random_password()
                 activated.set_password(password)
+                # Without this, user isn't prompted for a new password when
+                # invited to use My.jobs. See PD-1444
+                activated._User__original_password = activated.password
                 activated.save()
                 ctx['password'] = password
     template = 'registration/%s/activate.html' % settings.PROJECT

--- a/templates/registration/myjobs/activate.html
+++ b/templates/registration/myjobs/activate.html
@@ -30,12 +30,14 @@ Used to check if registration was successful.
             {% else %}
             {% trans "Your account has been successfully activated, but you need to login before you use it."%}
             {% endif %}
-            {% if password %}
-                {% blocktrans %}
-                    Your temporary password is {{ password }}. Please change it at your convenience.
-                {% endblocktrans %}
-            {% endif %}
             </p>
+            {% if password %}
+                <p>
+                {% blocktrans %}
+                Your temporary password is <strong>{{ password }}</strong>.
+                {% endblocktrans %}
+                </p>
+            {% endif %}
         </div>
 
         {% if logged_in %}


### PR DESCRIPTION
Basically, when a user accepts an invitation, they are given a temporary password, but never asked to change it. This corrects that. As for the hackish nature of how I accomplish that, please refer to the associated tickets. It's more of a stop-gap measure, given how much work *really* fixing account activation would be.

# new account activation template
![2015-06-12-164539_1052x1056_scrot](https://cloud.githubusercontent.com/assets/93686/8139542/907db464-1122-11e5-9c1c-401a3ce9daa0.png)
