### PR TITLE
[PD-1543] Partner Library Italics fix

### DIFF
--- a/templates/mypartners/partner_library.html
+++ b/templates/mypartners/partner_library.html
@@ -17,6 +17,7 @@
                 <i>
                     The partner(s) listed here are from the <a href="http://www.dol-esa.gov/errd/index.html" target="_blank" style="text-decoration: underline">Employment Referral Resource Directory</a>,
                     the <a href="http://www.dol-esa.gov/errd/Resources.503VEVRAA.html" target="_blank" style="text-decoration: underline">Disability and Veterans Community Resource Directory</a>, and other sources.
+                </i>
             </small>
         </div>
     </div>


### PR DESCRIPTION
Re-added ```</i>``` so DOM doesn't italic every element that comes after on Partner Library page. (the entire page pretty much)