### PR TITLE
[PD-1631] saved search - Can't create saved searches on network sites with a 'q' parameter

### DIFF
--- a/mysearches/helpers.py
+++ b/mysearches/helpers.py
@@ -91,7 +91,7 @@ def validate_dotjobs_url(search_url, user):
 
     try:
         page = urllib.urlopen(search_url).read()
-        soup = BeautifulSoup(page)
+        soup = BeautifulSoup(page, "html.parser")
     except Exception, e:
         print e
         return None, None

--- a/mysearches/helpers.py
+++ b/mysearches/helpers.py
@@ -91,7 +91,7 @@ def validate_dotjobs_url(search_url, user):
 
     try:
         page = urllib.urlopen(search_url).read()
-        soup = BeautifulSoup(page, "html.parser")
+        soup = BeautifulSoup(page)
     except Exception, e:
         print e
         return None, None

--- a/seo/views/search_views.py
+++ b/seo/views/search_views.py
@@ -752,7 +752,6 @@ def syndication_feed(request, filter_path, feed_type):
 
     job_count = jobs.count()
     num_items = min(num_items, max_items, job_count)
-    jobs[:num_items]
 
     if days_ago:
         now = datetime.datetime.utcnow()
@@ -773,6 +772,8 @@ def syndication_feed(request, filter_path, feed_type):
                      'date_new', 'description', 'location', 'reqid', 'state',
                      'state_short', 'title', 'uid', 'guid',
                      'is_posted')[offset:offset+num_items]
+    # jobs is being used for rss feeds for BreadBox
+    jobs = jobs[offset:offset+num_items]
 
     self_link = ExtraValue(name="link", content="",
                            attributes={'href': request.build_absolute_uri(),
@@ -840,7 +841,7 @@ def syndication_feed(request, filter_path, feed_type):
         selected = helpers.get_bread_box_headings(filters, jobs)
         rss.description = ''
 
-        if not any in selected.values():
+        if not any(selected.values()):
             selected = {'title_slug': request.GET.get('q'),
                         'location_slug': request.GET.get('location')}
 


### PR DESCRIPTION
For RSS feeds we use Breadbox to come up with title and a description. To figure out the title Breadbox would check the first job in a list and see if the title_slug_value (q parameter) would be equal to the title_slug. If it wasn't the Breadbox would then iterate through the rest of the list to find sometime that was equal.

Problem with that though is that the jobs list being sent to the Breadbox wasn't being sliced properly so in very generic searches like 'sales' breadbox would try to iterate over 620k jobs... Not any more. 