### PR TITLE
404 redirect correction seo <PD-287>

### DIFF
--- a/seo/breadbox.py
+++ b/seo/breadbox.py
@@ -156,6 +156,8 @@ class Breadbox(object):
     def build_company_breadcrumbs_from_slugs(self):
         company_slug_value = self.filters.get('company_slug')
         display_title = helpers.bread_box_company_heading(company_slug_value)
+        if not display_title:
+            display_title = company_slug_value
         breadcrumb = self.build_breadcrumb_for_slug_type('company_slug',
                                                          display_title)
         if breadcrumb:
@@ -219,7 +221,7 @@ class Breadbox(object):
             try:
                 left = slugs.index(location_slugs[0])
             except ValueError:
-                # location slug isn't part of the path 
+                # location slug isn't part of the path
                 pass
             else:
                 right = left + len(location_slugs)

--- a/seo/views/search_views.py
+++ b/seo/views/search_views.py
@@ -1747,7 +1747,6 @@ def search_by_results_and_slugs(request, *args, **kwargs):
         total_featured_jobs, total_default_jobs,
         num_jobs, site_config.percent_featured)
 
-    print facet_counts
     if not facet_counts:
         return redirect("/")
 

--- a/seo/views/search_views.py
+++ b/seo/views/search_views.py
@@ -1004,7 +1004,7 @@ class BusinessUnitAdminFilter(FSMView):
 
 class SeoSiteAdminFilter(FSMView):
     model = SeoSite
-    fields = ('domain__icontains',) 
+    fields = ('domain__icontains',)
 
     @method_decorator(login_required(login_url='/admin/'))
     def dispatch(self, *args, **kwargs):
@@ -1747,10 +1747,8 @@ def search_by_results_and_slugs(request, *args, **kwargs):
         total_featured_jobs, total_default_jobs,
         num_jobs, site_config.percent_featured)
 
+    print facet_counts
     if not facet_counts:
-        return redirect("/")
-
-    if num_default_jobs == 0 and num_featured_jobs == 0 and not query_path:
         return redirect("/")
 
     default_jobs = default_jobs[:num_default_jobs]
@@ -1760,7 +1758,7 @@ def search_by_results_and_slugs(request, *args, **kwargs):
     if query_path:
         for job in jobs:
             helpers.add_text_to_job(job)
-    
+
     breadbox = Breadbox(request.path, filters, jobs, request.GET)
 
     company_data = helpers.get_company_data(filters)

--- a/seo/views/search_views.py
+++ b/seo/views/search_views.py
@@ -1747,9 +1747,6 @@ def search_by_results_and_slugs(request, *args, **kwargs):
         total_featured_jobs, total_default_jobs,
         num_jobs, site_config.percent_featured)
 
-    if not facet_counts:
-        return redirect("/")
-
     default_jobs = default_jobs[:num_default_jobs]
     featured_jobs = featured_jobs[:num_featured_jobs]
 


### PR DESCRIPTION
Pardon the many modifications. My IDE had a linter installed and it went wild on some unneeded white space.

The changes made are in relation to the redirects on the my jobs search page. In short, if the member creates a request in an canonical order with erroneous search terms, the filters should be applied as usual and simply show a "0 results found" page. A 404 is returned when special characters are added to any search term and a 301 redirect will be issued when slugs are not in the canonical order. The 301 redirect reforms the URL in the proper order but otherwise returns the page as normal.