### PR TITLE
Delete job location instances from Solr [PD-939]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,9 @@ static/redirect.css
 .tmp*
 content_226
 .coverage
+.ropeproject
 *.swp
+*.swo
 
 # Secret Stuff
 secrets*

--- a/postajob/__init__.py
+++ b/postajob/__init__.py
@@ -1,0 +1,1 @@
+import signals

--- a/postajob/models.py
+++ b/postajob/models.py
@@ -8,6 +8,7 @@ from django.contrib.auth.models import Group
 from django.contrib.contenttypes.models import ContentType
 from django.core.validators import MinValueValidator
 from django.db import models, DEFAULT_DB_ALIAS
+from django.db.models import Count
 from django.db.models.query import QuerySet
 from django.db.models.signals import pre_delete
 from django.template.loader import render_to_string
@@ -252,7 +253,6 @@ class Job(BaseModel):
 
     def remove_from_solr(self):
         from import_jobs import delete_by_guid
-
         guids = [location.guid for location in self.locations.all()]
         delete_by_guid(guids)
 

--- a/postajob/signals.py
+++ b/postajob/signals.py
@@ -1,0 +1,19 @@
+from django.db.models import Count
+from django.db.models.signals import post_save
+
+from postajob.models import Job, JobLocation
+
+def remove_orphaned_job_locations(sender, **kwargs):
+    # If there are no Jobs related to a JobLocation, it shouldn't exist in Solr
+    #
+    # change_m2m signals detecting job locations being removed
+    # were complicated and unreliable. We're trying to enforce a foriegn key
+    # with cascade delete from JobLocation to Job in the index, but not the
+    # database
+    from import_jobs import delete_by_guid
+    orphaned_job_locations = JobLocation.objects.annotate(
+                                job_count=Count('jobs')
+                                ).filter(job_count=0)
+    delete_by_guid([location.guid for location in orphaned_job_locations])
+
+post_save.connect(remove_orphaned_job_locations, Job)

--- a/postajob/tests/test_models.py
+++ b/postajob/tests/test_models.py
@@ -89,6 +89,12 @@ class ModelTests(MyJobsBase):
         locations = JobLocationFactory.create_batch(2)
         job.locations = locations
         job.save()
+
+        guid = locations[0].guid
+        locations[0].delete()
+        self.assertEqual(self.ms_solr.search('guid:%s' % guid).hits, 0)
+        self.assertEqual(self.ms_solr.search('guid:%s' % locations[1].guid).hits, 1)
+
         job.remove_from_solr()
 
         guids = " OR ".join(job.guids())
@@ -161,7 +167,7 @@ class ModelTests(MyJobsBase):
         exp_date = date.today() + timedelta(self.product.posting_window_length)
         self.assertEqual(self.purchased_product.expiration_date, exp_date)
         return PurchasedJobFactory(
-            owner=self.company, created_by=self.user, 
+            owner=self.company, created_by=self.user,
             purchased_product=self.purchased_product, pk=pk)
 
     def test_purchased_job_add(self):
@@ -309,7 +315,7 @@ class ModelTests(MyJobsBase):
 
         # Already approved jobs should not generate an additional request.
         PurchasedJobFactory(
-            owner=self.company, created_by=self.user, 
+            owner=self.company, created_by=self.user,
             purchased_product=self.purchased_product, is_approved=True)
 
         self.assertEqual(PurchasedJob.objects.all().count(), 2)
@@ -337,7 +343,7 @@ class ModelTests(MyJobsBase):
         for x in range(1, 15):
             PurchasedProduct.objects.all().delete()
             OfflineProduct.objects.all().delete()
-            OfflineProductFactory(product=product, 
+            OfflineProductFactory(product=product,
                                   offline_purchase=offline_purchase,
                                   product_quantity=x)
             OfflineProductFactory(product=product_two,


### PR DESCRIPTION
When a JobLocation is removed from a Job, it wasn't cleared from Solr. This is a post_save signal on Job that clears ALL orphaned locations from Solr. We're treating the relationship as a foreign key in Solr, but a m2m in the database/admin. This seemed like the simplest way to enforce that relationship, but I'd be up for a better solution.