### PR TITLE
Removal of is_site_family boolean <PD-1606>

### DIFF
--- a/seo/admin.py
+++ b/seo/admin.py
@@ -51,15 +51,15 @@ class GroupListFilter(admin.SimpleListFilter):
     Limits group filter selection and results to only groups the user is a
     member of unless the user is a superadmin.
     """
-    
+
     title = _('Group')
     parameter_name = 'filtered_groups'
-    
+
     def lookups(self, request, model_admin):
         """
         Limits filter selection.
         """
-        
+
         if request.user.is_superuser:
             return [(group.name, group.name) for group in Group.objects.all()]
         return [(group.name, group.name) for group in request.user.groups.all()]
@@ -68,7 +68,7 @@ class GroupListFilter(admin.SimpleListFilter):
         """
         Limits query results.
         """
-        
+
         if not self.value():
             return queryset
         return queryset.filter(group__name=self.value())
@@ -116,13 +116,13 @@ class ConfigurationAdmin (admin.ModelAdmin):
         return actions
 
     actions = ['clone_objects', ]
-    
+
     def queryset(self, request):
         qs = super(ConfigurationAdmin, self).queryset(request)
         if request.user.is_superuser:
             return qs
         return qs.filter(group__in=request.user.groups.all())
-        
+
     def clone_objects(self, request, queryset):
         def clone(from_object):
             args = dict([(fld.name, getattr(from_object, fld.name))
@@ -143,7 +143,7 @@ class ConfigurationAdmin (admin.ModelAdmin):
             obj.save()
             objs.append(obj)
     clone_objects.short_description = "Copy the selected configurations"
-        
+
     def get_form(self, request, obj=None, **kwargs):
         this = super(ConfigurationAdmin, self).get_form(request, obj, **kwargs)
         my_group_fieldset = [('title', 'group', 'status', 'percent_featured'),
@@ -220,11 +220,11 @@ class ConfigurationAdmin (admin.ModelAdmin):
                         id__in=request.user.groups.all())
         return this
 
-    @check_message_queue        
+    @check_message_queue
     def delete_model(self, request, *args, **kwargs):
         super(ConfigurationAdmin, self).delete_model(request, *args, **kwargs)
 
-    @check_message_queue        
+    @check_message_queue
     def save_model(self, request, obj, form, change):
         if obj.status == [1, 2]:
             #Force an evaluation of obj site keys. When obj.seosite_set was used
@@ -244,7 +244,7 @@ class ConfigurationAdmin (admin.ModelAdmin):
             obj.group = request.user.groups.all()[0]
         obj.save()
 
-      
+
 class BusinessUnitAdmin(admin.ModelAdmin):
     list_display = ('__unicode__', 'show_sites', 'associated_jobs',
                     'date_crawled', 'date_updated')
@@ -272,19 +272,19 @@ class BusinessUnitAdmin(admin.ModelAdmin):
         """
         for business_unit in queryset:
             tasks.task_update_solr.delay(business_unit.id, force=True)
-            
+
         messages.info(request, u"{alljobs} {busiunitid} {reprocess}".format(
             alljobs=_("All jobs for Business Unit:"),
             busiunitid=(business_unit.id),
             reprocess=_("will be re-processed shortly."))
         )
     reset_jobs.short_description = _("Refresh all jobs in business unit")
-    
+
     def clear(self, request, queryset):
         for jsid in queryset:
             tasks.task_clear.delay(jsid)
             tasks.task_clear_solr.delay(jsid.id)
-            
+
         messages.info(request, u"{alljobs} {jsident} {remove}".format(
             alljobs=_("All jobs for Business Unit:"),
             jsident=(jsid.id),
@@ -303,11 +303,11 @@ class BusinessUnitAdmin(admin.ModelAdmin):
         )
     force_create.short_description = _("Force creation of business unit feed")
 
-    
+
 class MyUserAdmin(UserAdmin):
     filter_horizontal = ('user_permissions', 'groups')
 
-        
+
 class GoogleAnalyticsForm(forms.ModelForm):
     sites = MyModelMultipleChoiceField(SeoSite.objects.all(), my_model=SeoSite,
                                        required=False,
@@ -316,7 +316,7 @@ class GoogleAnalyticsForm(forms.ModelForm):
                                                                        False)))
     group = MyModelChoiceField(Group.objects.order_by('name'), my_model=Group,
                                required=False)
-          
+
     def save(self, commit=True):
         added_sites = set()
         ga = forms.ModelForm.save(self, commit)
@@ -333,19 +333,19 @@ class GoogleAnalyticsForm(forms.ModelForm):
     class Meta:
         model = GoogleAnalytics
 
-        
+
 class GoogleAnalyticsAdmin(admin.ModelAdmin):
-    
-    form = GoogleAnalyticsForm    
+
+    form = GoogleAnalyticsForm
     list_display = ('web_property_id', 'group', 'show_sites')
     search_fields = ['seosite__domain', 'seosite__name', 'web_property_id']
-    
+
     def queryset(self, request):
         qs = super(GoogleAnalyticsAdmin, self).queryset(request)
         if request.user.is_superuser:
             return qs
         return qs.filter(group__in=request.user.groups.all())
-        
+
     def get_form(self, request, obj=None, **kwargs):
         this = super(GoogleAnalyticsAdmin, self).get_form(request, obj,
                                                           **kwargs)
@@ -379,7 +379,7 @@ class GoogleAnalyticsAdmin(admin.ModelAdmin):
                     this.base_fields['group'].queryset = Group.objects.filter(
                         id__in=request.user.groups.all())
         return this
-        
+
     def save_model(self, request, obj, form, change):
         if (not request.user.is_superuser and
             request.user.groups.count() is 1 and
@@ -396,10 +396,10 @@ class RowPermissionsAdmin(admin.ModelAdmin):
     passed to the form. By overriding the add_view and change_view
     methods, we can then pass that data to our RowPermissionForm, and use
     it to filter results as appropriate.
-    
+
     """
     form = RowPermissionsForm
-    
+
     def queryset(self, request):
         qs = super(RowPermissionsAdmin, self).queryset(request)
 
@@ -461,7 +461,7 @@ class RowPermissionsAdmin(admin.ModelAdmin):
         context.update(extra_context or {})
         return self.render_change_form(request, context, form_url=form_url,
                                        add=True)
-        
+
     @csrf_protect_m
     @transaction.commit_on_success
     def change_view(self, request, object_id, extra_context=None):
@@ -526,7 +526,7 @@ class RowPermissionsAdmin(admin.ModelAdmin):
             request.user.groups.count() is 1 and
             not obj.group):
             obj.group = request.user.groups.all()[0]
-        obj.save()         
+        obj.save()
 
 
 class CustomFacetAdmin(RowPermissionsAdmin):
@@ -558,7 +558,7 @@ class CustomFacetAdmin(RowPermissionsAdmin):
             cache.set(cache_key, results_count, 600)
         return results_count
     results.short_description = 'Results Count'
-        
+
     def last_updated(self, obj):
         return str(obj.date_created)
     last_updated.short_description = 'Last Updated'
@@ -575,15 +575,15 @@ class CustomPageAdmin(RowPermissionsAdmin):
                               'fields': ('enable_comments',
                                          'registration_required',
                                          'template_name', 'meta')}),
-    ) 
+    )
     list_filter = (GroupListFilter, 'enable_comments', 'registration_required')
     search_fields = ('url', 'title')
 
-    
+
 class BillboardHotspotInline(admin.StackedInline):
     model = BillboardHotspot
     extra = 0
-    can_delete = True 
+    can_delete = True
     fieldsets = (
         (None, {'fields': [('title', 'url', 'display_url'), 'text']}),
         (None, {'fields': [('offset_x', 'offset_y')]}),
@@ -791,7 +791,7 @@ class BillboardImageAdmin(RowPermissionsAdmin):
             form = self.form(user=request.user, instance=obj)
             prefixes = {}
             self.inline_instances = check_inline_instance(self, request)
-            for FormSet, inline in zip(self.get_formsets(request, obj), 
+            for FormSet, inline in zip(self.get_formsets(request, obj),
                                        self.inline_instances):
                 prefix = FormSet.get_default_prefix()
                 prefixes[prefix] = prefixes.get(prefix, 0) + 1
@@ -831,7 +831,7 @@ class BillboardImageAdmin(RowPermissionsAdmin):
         context.update(extra_context or {})
         return self.render_change_form(request, context, change=True, obj=obj)
 
-    
+
 class SeoSiteRedirectAdmin(admin.ModelAdmin):
     model = SeoSiteRedirect
     list_display = ('redirect_url', 'seosite')
@@ -843,13 +843,13 @@ class SeoSiteRedirectAdmin(admin.ModelAdmin):
             return True
         else:
             return False
-    
+
     def has_add_permission(self, request, obj=None):
         if request.user.is_superuser:
             return True
         else:
             return False
-            
+
     def has_delete_permission(self, request, obj=None):
         if request.user.is_superuser:
             return True
@@ -874,14 +874,14 @@ class SeoSiteFacetAdmin(admin.ModelAdmin):
         """
         Returns the ChangeList class for use on the changelist page.
         """
-        return UnorderedChangeList 
+        return UnorderedChangeList
 
 
 class SeoSiteAdmin(admin.ModelAdmin):
     form = SeoSiteForm
     save_on_top = True
     filter_horizontal = ('configurations', 'google_analytics',
-                         'business_units', 'ats_source_codes', 
+                         'business_units', 'ats_source_codes',
                          'billboard_images', 'special_commitments',
                          'site_tags', 'featured_companies', )
     list_display = ('name', 'domain', 'group', )
@@ -927,7 +927,7 @@ class SeoSiteAdmin(admin.ModelAdmin):
                 new_object = self.model()
             prefixes = {}
             self.inline_instances = check_inline_instance(self, request)
-            for FormSet, inline in zip(self.get_formsets(request), 
+            for FormSet, inline in zip(self.get_formsets(request),
                                        self.inline_instances):
                 prefix = FormSet.get_default_prefix()
                 prefixes[prefix] = prefixes.get(prefix, 0) + 1
@@ -1061,7 +1061,7 @@ class SeoSiteAdmin(admin.ModelAdmin):
             form = self.form(user=request.user, instance=obj)
             prefixes = {}
             self.inline_instances = check_inline_instance(self, request)
-            for FormSet, inline in zip(self.get_formsets(request, obj), 
+            for FormSet, inline in zip(self.get_formsets(request, obj),
                                        self.inline_instances):
                 prefix = FormSet.get_default_prefix()
                 prefixes[prefix] = prefixes.get(prefix, 0) + 1
@@ -1094,24 +1094,24 @@ class SeoSiteAdmin(admin.ModelAdmin):
             'is_popup': "_popup" in request.REQUEST,
             'media': mark_safe(media),
             'inline_admin_formsets': inline_admin_formsets,
-            'errors': helpers.AdminErrorList(form, formsets),  
+            'errors': helpers.AdminErrorList(form, formsets),
             'app_label': opts.app_label,
         }
         context.update(extra_context or {})
-        return self.render_change_form(request, context, change=True, obj=obj)    
+        return self.render_change_form(request, context, change=True, obj=obj)
 
     def queryset(self, request):
         qs = super(SeoSiteAdmin, self).queryset(request)
         if request.user.is_superuser:
             return qs
         return qs.filter(group__in=request.user.groups.all())
-        
+
     def has_add_permission(self, request, obj=None):
         if request.user.is_superuser:
             return True
         else:
             return False
-            
+
     def has_delete_permission(self, request, obj=None):
         if request.user.is_superuser:
             return True
@@ -1159,11 +1159,10 @@ class SpecialCommitmentAdmin(admin.ModelAdmin):
 
 
 class SiteTagAdmin(admin.ModelAdmin):
-    form = SiteTagForm 
+    form = SiteTagForm
     save_on_top = True
     fieldsets = [
-        (None, {'fields': ['site_tag', 'tag_navigation',
-                           ('is_site_family', 'parent')]}),
+        (None, {'fields': ['site_tag', 'tag_navigation','parent']}),
     ]
 
 
@@ -1229,18 +1228,18 @@ except NotRegistered:
 
 def check_inline_instance(obj, req):
     """
-    This method checks if the inline_instances attribute is set. If it is not, 
+    This method checks if the inline_instances attribute is set. If it is not,
     it calls get_inline_instances and eturns the value to the callling location.
-    If it is set, it returns the existing value. This is neededed because of a 
-    change in Django 1.4 that modified when this attribute is available. 
+    If it is set, it returns the existing value. This is neededed because of a
+    change in Django 1.4 that modified when this attribute is available.
     12/5/12 Jason Sole.
-    
+
     Inputs:
         :obj:   The object to test. Usually "self"
         :req:   Django request object
     Returns:
         obj.inline_instances object
-        
+
     """
     if not hasattr(obj, 'inline_instances'):
         return obj.get_inline_instances(req)

--- a/seo/admin.py
+++ b/seo/admin.py
@@ -1162,7 +1162,7 @@ class SiteTagAdmin(admin.ModelAdmin):
     form = SiteTagForm
     save_on_top = True
     fieldsets = [
-        (None, {'fields': ['site_tag', 'tag_navigation','parent']}),
+        (None, {'fields': ['site_tag', 'tag_navigation']}),
     ]
 
 

--- a/seo/migrations/0019_auto__del_field_sitetag_is_site_family.py
+++ b/seo/migrations/0019_auto__del_field_sitetag_is_site_family.py
@@ -1,0 +1,412 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Deleting field 'SiteTag.is_site_family'
+        db.delete_column(u'seo_sitetag', 'is_site_family')
+
+
+    def backwards(self, orm):
+        # Adding field 'SiteTag.is_site_family'
+        db.add_column(u'seo_sitetag', 'is_site_family',
+                      self.gf('django.db.models.fields.BooleanField')(default=False),
+                      keep_default=False)
+
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'flatpages.flatpage': {
+            'Meta': {'ordering': "(u'url',)", 'object_name': 'FlatPage', 'db_table': "u'django_flatpage'"},
+            'content': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'enable_comments': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'registration_required': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'sites': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['sites.Site']", 'symmetrical': 'False'}),
+            'template_name': ('django.db.models.fields.CharField', [], {'max_length': '70', 'blank': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'url': ('django.db.models.fields.CharField', [], {'max_length': '100', 'db_index': 'True'})
+        },
+        u'myjobs.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'deactivate_type': ('django.db.models.fields.CharField', [], {'default': "'none'", 'max_length': '11'}),
+            'email': ('django.db.models.fields.EmailField', [], {'unique': 'True', 'max_length': '255', 'db_index': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'gravatar': ('django.db.models.fields.EmailField', [], {'db_index': 'True', 'max_length': '255', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'in_reserve': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_disabled': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_verified': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'last_response': ('django.db.models.fields.DateField', [], {'default': 'datetime.datetime.now', 'blank': 'True'}),
+            'opt_in_employers': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'opt_in_myjobs': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'password_change': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'profile_completion': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'source': ('django.db.models.fields.CharField', [], {'default': "'https://secure.my.jobs'", 'max_length': '255'}),
+            'timezone': ('django.db.models.fields.CharField', [], {'default': "'America/New_York'", 'max_length': '255'}),
+            'user_guid': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '100', 'db_index': 'True'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"})
+        },
+        u'postajob.package': {
+            'Meta': {'object_name': 'Package'},
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        },
+        u'postajob.sitepackage': {
+            'Meta': {'object_name': 'SitePackage', '_ormbases': [u'postajob.Package']},
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['seo.Company']", 'null': 'True', 'blank': 'True'}),
+            u'package_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['postajob.Package']", 'unique': 'True', 'primary_key': 'True'}),
+            'sites': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['seo.SeoSite']", 'null': 'True', 'symmetrical': 'False'})
+        },
+        u'seo.atssourcecode': {
+            'Meta': {'object_name': 'ATSSourceCode'},
+            'ats_name': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '200'}),
+            'group': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.Group']", 'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '200'}),
+            'value': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '200'})
+        },
+        u'seo.billboardhotspot': {
+            'Meta': {'object_name': 'BillboardHotspot'},
+            'billboard_image': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['seo.BillboardImage']"}),
+            'border_color': ('django.db.models.fields.CharField', [], {'default': "'FFFFFF'", 'max_length': '6'}),
+            'display_url': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'font_color': ('django.db.models.fields.CharField', [], {'default': "'FFFFFF'", 'max_length': '6'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'offset_x': ('django.db.models.fields.IntegerField', [], {}),
+            'offset_y': ('django.db.models.fields.IntegerField', [], {}),
+            'primary_color': ('django.db.models.fields.CharField', [], {'default': "'5A6D81'", 'max_length': '6'}),
+            'text': ('django.db.models.fields.CharField', [], {'max_length': '140'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'})
+        },
+        u'seo.billboardimage': {
+            'Meta': {'object_name': 'BillboardImage'},
+            'copyright_info': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'group': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.Group']", 'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'image_url': ('django.db.models.fields.URLField', [], {'max_length': '200'}),
+            'logo_url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'source_url': ('django.db.models.fields.URLField', [], {'max_length': '200'}),
+            'sponsor_url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '200'})
+        },
+        u'seo.businessunit': {
+            'Meta': {'object_name': 'BusinessUnit'},
+            'associated_jobs': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'date_crawled': ('django.db.models.fields.DateTimeField', [], {}),
+            'date_updated': ('django.db.models.fields.DateTimeField', [], {}),
+            'enable_markdown': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'federal_contractor': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'id': ('django.db.models.fields.IntegerField', [], {'max_length': '10', 'primary_key': 'True'}),
+            'ignore_includeinindex': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'site_packages': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['postajob.SitePackage']", 'null': 'True', 'blank': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '500', 'null': 'True', 'blank': 'True'}),
+            'title_slug': ('django.db.models.fields.SlugField', [], {'max_length': '500', 'null': 'True', 'blank': 'True'})
+        },
+        u'seo.city': {
+            'Meta': {'object_name': 'City'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'}),
+            'nation': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['seo.Country']"})
+        },
+        u'seo.company': {
+            'Meta': {'ordering': "['name']", 'unique_together': "(('name', 'user_created'),)", 'object_name': 'Company'},
+            'admins': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['myjobs.User']", 'through': u"orm['seo.CompanyUser']", 'symmetrical': 'False'}),
+            'canonical_microsite': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'company_slug': ('django.db.models.fields.SlugField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'digital_strategies_customer': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'enhanced': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'job_source_ids': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['seo.BusinessUnit']", 'symmetrical': 'False'}),
+            'linkedin_id': ('django.db.models.fields.CharField', [], {'max_length': '20', 'null': 'True', 'blank': 'True'}),
+            'logo_url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'member': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'og_img': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'posting_access': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'prm_access': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'prm_saved_search_sites': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['seo.SeoSite']", 'null': 'True', 'blank': 'True'}),
+            'product_access': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'site_package': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['postajob.SitePackage']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
+            'user_created': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        u'seo.companyuser': {
+            'Meta': {'unique_together': "(('user', 'company'),)", 'object_name': 'CompanyUser', 'db_table': "'mydashboard_companyuser'"},
+            'company': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['seo.Company']"}),
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'group': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['myjobs.User']"})
+        },
+        u'seo.configuration': {
+            'Meta': {'object_name': 'Configuration'},
+            'backgroundColor': ('django.db.models.fields.CharField', [], {'max_length': '6', 'null': 'True', 'blank': 'True'}),
+            'body': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'browse_city_order': ('django.db.models.fields.IntegerField', [], {'default': '5'}),
+            'browse_city_show': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'browse_city_text': ('django.db.models.fields.CharField', [], {'default': "'City'", 'max_length': '50'}),
+            'browse_company_order': ('django.db.models.fields.IntegerField', [], {'default': '7'}),
+            'browse_company_show': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'browse_company_text': ('django.db.models.fields.CharField', [], {'default': "'Company'", 'max_length': '50'}),
+            'browse_country_order': ('django.db.models.fields.IntegerField', [], {'default': '3'}),
+            'browse_country_show': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'browse_country_text': ('django.db.models.fields.CharField', [], {'default': "'Country'", 'max_length': '50'}),
+            'browse_facet_order': ('django.db.models.fields.IntegerField', [], {'default': '2'}),
+            'browse_facet_order_2': ('django.db.models.fields.IntegerField', [], {'default': '2'}),
+            'browse_facet_order_3': ('django.db.models.fields.IntegerField', [], {'default': '2'}),
+            'browse_facet_show': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'browse_facet_show_2': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'browse_facet_show_3': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'browse_facet_text': ('django.db.models.fields.CharField', [], {'default': "'Job Profiles'", 'max_length': '50'}),
+            'browse_facet_text_2': ('django.db.models.fields.CharField', [], {'default': "'Job Profiles'", 'max_length': '50'}),
+            'browse_facet_text_3': ('django.db.models.fields.CharField', [], {'default': "'Job Profiles'", 'max_length': '50'}),
+            'browse_moc_order': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'browse_moc_show': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'browse_moc_text': ('django.db.models.fields.CharField', [], {'default': "'Military Titles'", 'max_length': '50'}),
+            'browse_state_order': ('django.db.models.fields.IntegerField', [], {'default': '4'}),
+            'browse_state_show': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'browse_state_text': ('django.db.models.fields.CharField', [], {'default': "'State'", 'max_length': '50'}),
+            'browse_title_order': ('django.db.models.fields.IntegerField', [], {'default': '6'}),
+            'browse_title_show': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'browse_title_text': ('django.db.models.fields.CharField', [], {'default': "'Title'", 'max_length': '50'}),
+            'company_tag': ('django.db.models.fields.CharField', [], {'default': "'careers'", 'max_length': '50'}),
+            'defaultBlurb': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'defaultBlurbTitle': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'directemployers_link': ('django.db.models.fields.URLField', [], {'default': "'http://directemployers.org'", 'max_length': '200'}),
+            'facet_tag': ('django.db.models.fields.CharField', [], {'default': "'new-jobs'", 'max_length': '50'}),
+            'fontColor': ('django.db.models.fields.CharField', [], {'default': "'666666'", 'max_length': '6'}),
+            'footer': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'group': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.Group']", 'null': 'True'}),
+            'header': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'home_page_template': ('django.db.models.fields.CharField', [], {'default': "'home_page/home_page_listing.html'", 'max_length': '200'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'location_tag': ('django.db.models.fields.CharField', [], {'default': "'jobs'", 'max_length': '50'}),
+            'meta': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'moc_helptext': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'moc_label': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'moc_placeholder': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'moc_tag': ('django.db.models.fields.CharField', [], {'default': "'vet-jobs'", 'max_length': '50'}),
+            'num_filter_items_to_show': ('django.db.models.fields.IntegerField', [], {'default': '10'}),
+            'num_job_items_to_show': ('django.db.models.fields.IntegerField', [], {'default': '15'}),
+            'num_subnav_items_to_show': ('django.db.models.fields.IntegerField', [], {'default': '9'}),
+            'percent_featured': ('django.db.models.fields.DecimalField', [], {'default': "'0.5'", 'max_digits': '3', 'decimal_places': '2'}),
+            'primaryColor': ('django.db.models.fields.CharField', [], {'default': "'990000'", 'max_length': '6'}),
+            'publisher': ('django.db.models.fields.CharField', [], {'max_length': '50', 'blank': 'True'}),
+            'revision': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'show_home_microsite_carousel': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'show_home_social_footer': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'show_saved_search_widget': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'show_social_footer': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'status': ('django.db.models.fields.IntegerField', [], {'default': '1', 'null': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True'}),
+            'title_tag': ('django.db.models.fields.CharField', [], {'default': "'jobs-in'", 'max_length': '50'}),
+            'view_all_jobs_detail': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'what_helptext': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'what_label': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'what_placeholder': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'where_helptext': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'where_label': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'where_placeholder': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'wide_footer': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'wide_header': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'})
+        },
+        u'seo.country': {
+            'Meta': {'object_name': 'Country'},
+            'abbrev': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'abbrev_short': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'})
+        },
+        u'seo.customfacet': {
+            'Meta': {'object_name': 'CustomFacet'},
+            'always_show': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'blurb': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'business_units': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['seo.BusinessUnit']", 'null': 'True', 'blank': 'True'}),
+            'city': ('django.db.models.fields.CharField', [], {'max_length': '800', 'null': 'True', 'blank': 'True'}),
+            'company': ('django.db.models.fields.CharField', [], {'max_length': '800', 'null': 'True', 'blank': 'True'}),
+            'country': ('django.db.models.fields.CharField', [], {'max_length': '800', 'null': 'True', 'blank': 'True'}),
+            'date_created': ('django.db.models.fields.DateField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'group': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.Group']", 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name_slug': ('django.db.models.fields.SlugField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'onet': ('django.db.models.fields.CharField', [], {'max_length': '10', 'null': 'True', 'blank': 'True'}),
+            'querystring': ('django.db.models.fields.CharField', [], {'max_length': '2000', 'null': 'True', 'blank': 'True'}),
+            'saved_querystring': ('django.db.models.fields.CharField', [], {'max_length': '10000', 'blank': 'True'}),
+            'show_blurb': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'show_production': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'state': ('django.db.models.fields.CharField', [], {'max_length': '800', 'null': 'True', 'blank': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '800', 'null': 'True', 'blank': 'True'}),
+            'url_slab': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'})
+        },
+        u'seo.custompage': {
+            'Meta': {'ordering': "(u'url',)", 'object_name': 'CustomPage', '_ormbases': [u'flatpages.FlatPage']},
+            u'flatpage_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['flatpages.FlatPage']", 'unique': 'True', 'primary_key': 'True'}),
+            'group': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.Group']", 'null': 'True', 'blank': 'True'}),
+            'meta': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'meta_description': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'})
+        },
+        u'seo.featuredcompany': {
+            'Meta': {'object_name': 'FeaturedCompany'},
+            'company': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['seo.Company']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_featured': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'seosite': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['seo.SeoSite']"})
+        },
+        u'seo.googleanalytics': {
+            'Meta': {'object_name': 'GoogleAnalytics'},
+            'group': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.Group']", 'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'web_property_id': ('django.db.models.fields.CharField', [], {'max_length': '20'})
+        },
+        u'seo.googleanalyticscampaign': {
+            'Meta': {'object_name': 'GoogleAnalyticsCampaign'},
+            'campaign_content': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '200'}),
+            'campaign_medium': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '200'}),
+            'campaign_name': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '200'}),
+            'campaign_source': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '200'}),
+            'campaign_term': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '200'}),
+            'group': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.Group']", 'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '200'})
+        },
+        u'seo.joblisting': {
+            'Meta': {'object_name': 'jobListing'},
+            'city': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'citySlug': ('django.db.models.fields.SlugField', [], {'max_length': '50', 'null': 'True', 'blank': 'True'}),
+            'country': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'countrySlug': ('django.db.models.fields.SlugField', [], {'max_length': '50', 'null': 'True', 'blank': 'True'}),
+            'country_short': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '3', 'null': 'True', 'blank': 'True'}),
+            'date_new': ('django.db.models.fields.DateTimeField', [], {}),
+            'date_updated': ('django.db.models.fields.DateTimeField', [], {}),
+            'description': ('django.db.models.fields.TextField', [], {}),
+            'hitkey': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'link': ('django.db.models.fields.URLField', [], {'max_length': '200'}),
+            'location': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'reqid': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True', 'blank': 'True'}),
+            'state': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'stateSlug': ('django.db.models.fields.SlugField', [], {'max_length': '50', 'null': 'True', 'blank': 'True'}),
+            'state_short': ('django.db.models.fields.CharField', [], {'max_length': '3', 'null': 'True', 'blank': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'titleSlug': ('django.db.models.fields.SlugField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'uid': ('django.db.models.fields.IntegerField', [], {'unique': 'True', 'db_index': 'True'}),
+            'zipcode': ('django.db.models.fields.CharField', [], {'max_length': '15', 'null': 'True', 'blank': 'True'})
+        },
+        u'seo.seosite': {
+            'Meta': {'ordering': "(u'domain',)", 'object_name': 'SeoSite', '_ormbases': [u'sites.Site']},
+            'ats_source_codes': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['seo.ATSSourceCode']", 'null': 'True', 'blank': 'True'}),
+            'billboard_images': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['seo.BillboardImage']", 'null': 'True', 'blank': 'True'}),
+            'business_units': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['seo.BusinessUnit']", 'null': 'True', 'blank': 'True'}),
+            'canonical_company': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'canonical_company_for'", 'null': 'True', 'on_delete': 'models.SET_NULL', 'to': u"orm['seo.Company']"}),
+            'configurations': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['seo.Configuration']", 'symmetrical': 'False', 'blank': 'True'}),
+            'email_domain': ('django.db.models.fields.CharField', [], {'default': "'my.jobs'", 'max_length': '255'}),
+            'facets': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['seo.CustomFacet']", 'null': 'True', 'through': u"orm['seo.SeoSiteFacet']", 'blank': 'True'}),
+            'featured_companies': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['seo.Company']", 'null': 'True', 'blank': 'True'}),
+            'google_analytics': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['seo.GoogleAnalytics']", 'null': 'True', 'blank': 'True'}),
+            'google_analytics_campaigns': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['seo.GoogleAnalyticsCampaign']", 'null': 'True', 'blank': 'True'}),
+            'group': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.Group']", 'null': 'True'}),
+            'microsite_carousel': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['social_links.MicrositeCarousel']", 'null': 'True', 'on_delete': 'models.SET_NULL', 'blank': 'True'}),
+            'postajob_filter_type': ('django.db.models.fields.CharField', [], {'default': "'this site only'", 'max_length': '255'}),
+            'site_description': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '200', 'blank': 'True'}),
+            'site_heading': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '200', 'blank': 'True'}),
+            'site_package': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['postajob.SitePackage']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
+            u'site_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['sites.Site']", 'unique': 'True', 'primary_key': 'True'}),
+            'site_tags': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['seo.SiteTag']", 'null': 'True', 'blank': 'True'}),
+            'site_title': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '200', 'blank': 'True'}),
+            'special_commitments': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['seo.SpecialCommitment']", 'null': 'True', 'blank': 'True'}),
+            'view_sources': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['seo.ViewSource']", 'null': 'True', 'blank': 'True'})
+        },
+        u'seo.seositefacet': {
+            'Meta': {'object_name': 'SeoSiteFacet'},
+            'boolean_operation': ('django.db.models.fields.CharField', [], {'default': "'or'", 'max_length': '3', 'db_index': 'True'}),
+            'customfacet': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['seo.CustomFacet']"}),
+            'facet_group': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'facet_type': ('django.db.models.fields.CharField', [], {'default': "'STD'", 'max_length': '4', 'db_index': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'seosite': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['seo.SeoSite']"})
+        },
+        u'seo.seositeredirect': {
+            'Meta': {'unique_together': "(['redirect_url', 'seosite'],)", 'object_name': 'SeoSiteRedirect'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'redirect_url': ('django.db.models.fields.CharField', [], {'max_length': '100', 'db_index': 'True'}),
+            'seosite': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['seo.SeoSite']"})
+        },
+        u'seo.sitetag': {
+            'Meta': {'object_name': 'SiteTag'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'parent': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['seo.SeoSite']", 'null': 'True', 'blank': 'True'}),
+            'site_tag': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '100'}),
+            'tag_navigation': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        u'seo.specialcommitment': {
+            'Meta': {'object_name': 'SpecialCommitment'},
+            'commit': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200'})
+        },
+        u'seo.state': {
+            'Meta': {'unique_together': "(('name', 'nation'),)", 'object_name': 'State'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'}),
+            'nation': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['seo.Country']"})
+        },
+        u'seo.viewsource': {
+            'Meta': {'object_name': 'ViewSource'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '200'}),
+            'view_source': ('django.db.models.fields.IntegerField', [], {'default': "''", 'max_length': '20'})
+        },
+        u'sites.site': {
+            'Meta': {'ordering': "(u'domain',)", 'object_name': 'Site', 'db_table': "u'django_site'"},
+            'domain': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'social_links.micrositecarousel': {
+            'Meta': {'object_name': 'MicrositeCarousel'},
+            'carousel_title': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'display_rows': ('django.db.models.fields.IntegerField', [], {}),
+            'group': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.Group']", 'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'include_all_sites': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'link_sites': ('django.db.models.fields.related.ManyToManyField', [], {'blank': 'True', 'related_name': "'linked_carousel'", 'null': 'True', 'symmetrical': 'False', 'to': u"orm['seo.SeoSite']"})
+        }
+    }
+
+    complete_apps = ['seo']

--- a/seo/migrations/0019_auto__del_field_sitetag_parent__del_field_sitetag_is_site_family.py
+++ b/seo/migrations/0019_auto__del_field_sitetag_parent__del_field_sitetag_is_site_family.py
@@ -8,11 +8,19 @@ from django.db import models
 class Migration(SchemaMigration):
 
     def forwards(self, orm):
+        # Deleting field 'SiteTag.parent'
+        db.delete_column(u'seo_sitetag', 'parent_id')
+
         # Deleting field 'SiteTag.is_site_family'
         db.delete_column(u'seo_sitetag', 'is_site_family')
 
 
     def backwards(self, orm):
+        # Adding field 'SiteTag.parent'
+        db.add_column(u'seo_sitetag', 'parent',
+                      self.gf('django.db.models.fields.related.ForeignKey')(to=orm['seo.SeoSite'], null=True, blank=True),
+                      keep_default=False)
+
         # Adding field 'SiteTag.is_site_family'
         db.add_column(u'seo_sitetag', 'is_site_family',
                       self.gf('django.db.models.fields.BooleanField')(default=False),
@@ -369,7 +377,6 @@ class Migration(SchemaMigration):
         u'seo.sitetag': {
             'Meta': {'object_name': 'SiteTag'},
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
-            'parent': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['seo.SeoSite']", 'null': 'True', 'blank': 'True'}),
             'site_tag': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '100'}),
             'tag_navigation': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
         },

--- a/seo/models.py
+++ b/seo/models.py
@@ -673,12 +673,12 @@ class Company(models.Model):
         Counts how many users are mapped to this company. This is useful for
         determining which company to map companyusers to when two company
         instances have very similar names.
-        
+
         It is treated as a property of the model.
-        
+
         """
         return self.companyuser_set.count()
-        
+
     admins = models.ManyToManyField(User, through='CompanyUser')
     name = models.CharField('Name', max_length=200)
     company_slug = models.SlugField('Company Slug', max_length=200, null=True,
@@ -943,10 +943,6 @@ class SiteTag(models.Model):
                                          help_text='Tag can be used for '
                                                    'navigation by users. '
                                                    'Viewable by public.')
-    is_site_family = models.BooleanField('Tag represents site family',
-                                         default=False,
-                                         help_text='Site tag represents '
-                                                   'a family of sites.')
     parent = models.ForeignKey(SeoSite, blank=True, null=True,
                                help_text='The parent site if the tag is a '
                                          'for a site family.')

--- a/seo/models.py
+++ b/seo/models.py
@@ -943,9 +943,6 @@ class SiteTag(models.Model):
                                          help_text='Tag can be used for '
                                                    'navigation by users. '
                                                    'Viewable by public.')
-    parent = models.ForeignKey(SeoSite, blank=True, null=True,
-                               help_text='The parent site if the tag is a '
-                                         'for a site family.')
 
     def __unicode__(self):
         return "%s" % self.site_tag


### PR DESCRIPTION
removed is_site_family boolean from seo->models and admin. also generated migration for the change.

note: whitespace was apparently being removed by default of Atom. messed with the configs and these polluted commits shouldn't be happening any longer... fingers crossed.