### PR TITLE
Fix solr test  [PD-1644]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ static/redirect.css
 content_226
 .coverage
 *.swp
+.ropeproject
 
 # Secret Stuff
 secrets*

--- a/default_settings.py
+++ b/default_settings.py
@@ -506,6 +506,20 @@ HAYSTACK_CONNECTIONS = {
     },
 }
 
+# Keep these here since a number of apps need them. (circular imports)
+TEST_HAYSTACK_CONNECTIONS = {
+    'default': {
+        'ENGINE': 'seo.tests.setup.TestDESolrEngine',
+        'URL': 'http://127.0.0.1:8983/solr/seo',
+        'INCLUDE_SPELLING': True,
+    },
+    'groups': {
+        'ENGINE': 'seo.tests.setup.TestSolrGrpEngine',
+        'URL': 'http://127.0.0.1:8983/solr/seo',
+        'INCLUDE_SPELLING': True,
+    },
+}
+
 # Password settings
 PASSWORD_MIN_LENGTH = 8
 PASSWORD_COMPLEXITY = {

--- a/functional_tests/test_mypartners.py
+++ b/functional_tests/test_mypartners.py
@@ -8,6 +8,7 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions
 from selenium.webdriver.support.wait import WebDriverWait
 from myjobs.tests.factories import UserFactory
+from seo.tests.factories import CompanyUserFactory, CompanyFactory
 from django.test import LiveServerTestCase
 from django.test.utils import override_settings
 from selenium import webdriver
@@ -53,7 +54,9 @@ class NewUserTests(SeleniumTestCase):
 
     def setUp(self):
         super(NewUserTests, self).setUp()
+        company = CompanyFactory()
         self.user = UserFactory(first_name="John", last_name="Doe")
+        company_user = CompanyUserFactory(company=company, user=self.user)
 
     def test_home_page_works(self):
         """

--- a/myjobs/__init__.py
+++ b/myjobs/__init__.py
@@ -2,6 +2,7 @@
 myjobs
 """
 
+import sys
 import solr.signals
 
 __version_info__ = {
@@ -25,3 +26,21 @@ def get_version():
     return ''.join(vers)
 
 __version__ = get_version()
+
+
+def hide_production_solr_from_tests():
+    """
+    This code here to protect production/staging systems from errant
+    unit tests. Including this code as a PROJECT_APP __init__.py
+    based on information found here:
+
+    http://stackoverflow.com/questions/6791911/execute-code-when-django-starts-once-only
+    """
+    import settings
+    import default_settings
+
+    settings.HAYSTACK_CONNECTIONS.clear()
+    settings.HAYSTACK_CONNECTIONS.update(default_settings.TEST_HAYSTACK_CONNECTIONS)
+
+if "test" in sys.argv or "jenkins" in sys.argv:
+    hide_production_solr_from_tests()

--- a/myjobs/__init__.py
+++ b/myjobs/__init__.py
@@ -42,5 +42,5 @@ def hide_production_solr_from_tests():
     settings.HAYSTACK_CONNECTIONS.clear()
     settings.HAYSTACK_CONNECTIONS.update(default_settings.TEST_HAYSTACK_CONNECTIONS)
 
-if "test" in sys.argv or "jenkins" in sys.argv:
+if "test" in ''.join(sys.argv) or "jenkins" in sys.argv:
     hide_production_solr_from_tests()

--- a/seo/tests/solr_settings.py
+++ b/seo/tests/solr_settings.py
@@ -3,14 +3,6 @@ import datetime
 
 from settings import *
 
-HAYSTACK_CONNECTIONS = {
-    'default': {
-        'ENGINE': 'seo.tests.setup.TestDESolrEngine',
-        'URL': 'http://127.0.0.1:8983/solr/seo',
-        'INCLUDE_SPELLING': True,
-    },
-}
-
 SOLR_FIXTURE = [
     {
         'buid': 0,

--- a/seo/tests/test_import_jobs.py
+++ b/seo/tests/test_import_jobs.py
@@ -3,7 +3,6 @@ import os
 
 from django.conf import settings
 
-from seo_pysolr import Solr
 from import_jobs import (DATA_DIR, add_company, remove_expired_jobs, update_solr, get_jobs_from_zipfile,
     filter_current_jobs, update_job_source)
 
@@ -21,14 +20,10 @@ class ImportJobsTestCase(DirectSEOBase):
         self.businessunit = BusinessUnitFactory(id=0)
         self.buid_id = self.businessunit.id        
         self.filepath = os.path.join(DATA_DIR, '0', 'dseo_feed_%s.xml' % self.buid_id)
-        self.solr_settings = {
-            'default': {'URL': 'http://127.0.0.1:8983/solr/seo'}
-        }
-        self.solr = Solr(settings.HAYSTACK_CONNECTIONS['default']['URL'])
 
     def tearDown(self):
         super(ImportJobsTestCase, self).tearDown()
-        self.solr.delete(q='*:*')
+        self.conn.delete(q='*:*')
 
     def test_solr_rm_feedfile(self):
         """
@@ -140,25 +135,20 @@ class ImportJobsTestCase(DirectSEOBase):
         active_jobs = [{'id': 'seo.%s' % i, 'buid': buid} for i in range(4)]
         old_jobs = [{'id': 'seo.%s' % i, 'buid': buid} for i in range(2, 10)]
 
-        with self.settings(HAYSTACK_CONNECTIONS=self.solr_settings):
-            self.solr.add(old_jobs)
-            self.solr.commit()
+        self.conn.add(old_jobs)
+        self.conn.commit()
 
-            removed = remove_expired_jobs(buid, [d['id'] for d in active_jobs])
-            self.assertEqual(len(removed), 6, "Removed jobs %s" % removed)
-            ids = [d['id'] for d in self.solr.search('*:*').docs]
-            self.assertTrue([5, 6, 7, 8, 9, 10] not in ids)
+        removed = remove_expired_jobs(buid, [d['id'] for d in active_jobs])
+        self.assertEqual(len(removed), 6, "Removed jobs %s" % removed)
+        ids = [d['id'] for d in self.conn.search('*:*').docs]
+        self.assertTrue([5, 6, 7, 8, 9, 10] not in ids)
 
 
 class LoadETLTestCase(DirectSEOBase):
     fixtures = ['countries.json']
     
     def setUp(self):
-        self.solr_settings = {
-            'default': {'URL': 'http://127.0.0.1:8983/solr/seo'}
-        }
-        self.solr = Solr(settings.HAYSTACK_CONNECTIONS['default']['URL'])
-        self.solr.delete(q="*:*")
+        super(LoadETLTestCase, self).setUp()
 
         self.zipfile = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                                     'data',
@@ -173,19 +163,20 @@ class LoadETLTestCase(DirectSEOBase):
         self.name = "Test"
     
     def tearDown(self):
-        pass
+        super(LoadETLTestCase, self).tearDown()
+
     
     @patch('import_jobs.get_jobsfs_zipfile')
     def test_update_job_source(self, mock_jobsfs):
         mock_jobsfs.return_value = open(self.zipfile, 'rb')
         
-        count = self.solr.search('*:*').hits
+        count = self.conn.search('*:*').hits
         self.assertEqual(count, 0, "Jobs for buid in solr before the test.  Cannot guarantee correct behavior.")
         self.assertEqual(self.businessunit.associated_jobs, 4, "Initial Job Count does not match the factory")
 
         update_job_source(self.guid, self.buid, self.name)
 
-        count = self.solr.search('buid:%s' % self.buid).hits
+        count = self.conn.search('buid:%s' % self.buid).hits
         # Note the job count being one low here is due to one job being filtered out due to include_in_index_bit
         self.assertEqual(count, 38, "38 Jobs not in solr after call to update job source. Found %s" % count)
         self.assertEqual(BusinessUnit.objects.get(id=self.buid).associated_jobs, 38, 

--- a/seo/tests/test_sitemap.py
+++ b/seo/tests/test_sitemap.py
@@ -12,8 +12,10 @@ from setup import DirectSEOBase
 class SitemapTestCase(DirectSEOBase):
     def setUp(self):
         super(SitemapTestCase, self).setUp()
-        self.conn = Solr('http://127.0.0.1:8983/solr/seo')
-        self.conn.add(SOLR_FIXTURE)
+
+    def tearDown(self):
+        super(SitemapTestCase, self).tearDown()
+        self.conn.delete("*:*")
 
     def test_index(self):
         resp = self.client.get("/sitemap.xml")
@@ -28,6 +30,8 @@ class SitemapTestCase(DirectSEOBase):
         site = SeoSite.objects.get(id=1)
         site.business_units = []
         site.save()
+        job = dict(SOLR_FIXTURE[0])
+        self.conn.add([job])
         today = datetime.datetime.today()
         dt = datetime.date(*today.timetuple()[0:3]).isoformat()
         resp = self.client.get("/sitemap-" + dt + ".xml")
@@ -70,7 +74,3 @@ class SitemapTestCase(DirectSEOBase):
         resp = self.client.get("/sitemap-" + dt + ".xml")
         self.assertEqual(resp.status_code, 200)
         self.assertTrue("<url>" in resp.content)
-        
-    def tearDown(self):
-        super(SitemapTestCase, self).tearDown()
-        self.conn.delete("*:*")

--- a/seo/tests/test_views.py
+++ b/seo/tests/test_views.py
@@ -66,6 +66,7 @@ class FallbackTestCase(DirectSEOTestCase):
 
     def tearDown(self):
         self.conn.delete(q='*:*')
+        super(FallbackTestCase, self).tearDown()
 
     def make_page(self, page_type):
         content = 'This is a content block'
@@ -2605,7 +2606,6 @@ class SeoViewsTestCase(DirectSEOTestCase):
         tag = SiteTag.objects.create(site_tag='network')
         for path in ['about', 'privacy', 'contact', 'contact_faq', 'terms']:
             response = self.client.get(reverse(path))
-            print path
             self.assertEqual(response.status_code, 404)
 
             site.site_tags.add(tag)

--- a/seo/tests/test_views.py
+++ b/seo/tests/test_views.py
@@ -35,8 +35,7 @@ from postajob.tests.factories import (JobFactory, JobLocationFactory,
                                       SitePackageFactory)
 from redirect.tests.factories import RedirectFactory
 from seo import helpers
-from seo.tests.setup import (connection, DirectSEOBase, DirectSEOTestCase,
-                             patch_settings)
+from seo.tests.setup import (DirectSEOBase, DirectSEOTestCase, patch_settings)
 from seo.models import (BusinessUnit, Company, Configuration, CustomPage,
                         SeoSite, SeoSiteFacet, SiteTag, User, SeoSiteRedirect)
 from seo.templatetags.seo_extras import url_for_sort_field
@@ -491,18 +490,17 @@ class SeoSiteTestCase(DirectSEOTestCase):
         site.business_units = [self.buid_id]
         site.save()
 
-        with connection(connections_info=solr_settings.HAYSTACK_CONNECTIONS):
-            resp = self.client.get('/jobs/?q=C#', follow=True)
-            self.assertEqual(resp.status_code, 200)
-            self.assertEqual(len(resp.context['default_jobs']), 1)
+        resp = self.client.get('/jobs/?q=C#', follow=True)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(len(resp.context['default_jobs']), 1)
 
-            resp = self.client.get('/jobs/?q=C$', follow=True)
-            self.assertEqual(resp.status_code, 200)
-            self.assertEqual(len(resp.context['default_jobs']), 1)
+        resp = self.client.get('/jobs/?q=C$', follow=True)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(len(resp.context['default_jobs']), 1)
 
-            resp = self.client.get('/jobs/?q=AT%5C%26T', follow=True)
-            self.assertEqual(resp.status_code, 200)
-            self.assertEqual(len(resp.context['default_jobs']), 1)
+        resp = self.client.get('/jobs/?q=AT%5C%26T', follow=True)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(len(resp.context['default_jobs']), 1)
 
     def test_postajob(self):
         company = factories.CompanyFactory()
@@ -1783,43 +1781,42 @@ class SeoViewsTestCase(DirectSEOTestCase):
         Test that the job listing header contains the correct job count.
 
         """
-        with connection(connections_info=solr_settings.HAYSTACK_CONNECTIONS):
-            job = solr_settings.SOLR_FIXTURE[0].copy()
-            job.update({
-                'city': 'Muncie',
-                'city_ac': 'Muncie',
-                'city_exact': 'Muncie',
-                'city_slab': 'muncie/indiana/usa/jobs::muncie, IN',
-                'city_slab_exact': 'muncie/indiana/usa/jobs::Muncie, IN',
-                'city_slug': 'muncie',
-                'full_loc': 'city::Indianapolis@@state::Indiana@@location::Indianapolis, IN@@country::United States',
-                'full_loc_exact': 'city::Muncie@@state::Indiana@@location::Muncie, IN@@country::United States',
-                'guid': '3'*32,
-                'id': 'seo.joblisting.3',
-                'location': 'Muncie, IN',
-                'location_exact': 'Muncie, IN',
-                'reqid': 'AAA000002',
-                'uid': "1002",
-                'link': 'http://my.jobs/' + '3'*32
-            })
-            self.conn.add([job])
-            site = factories.SeoSiteFactory.build()
-            site.save()
+        job = solr_settings.SOLR_FIXTURE[0].copy()
+        job.update({
+            'city': 'Muncie',
+            'city_ac': 'Muncie',
+            'city_exact': 'Muncie',
+            'city_slab': 'muncie/indiana/usa/jobs::muncie, IN',
+            'city_slab_exact': 'muncie/indiana/usa/jobs::Muncie, IN',
+            'city_slug': 'muncie',
+            'full_loc': 'city::Indianapolis@@state::Indiana@@location::Indianapolis, IN@@country::United States',
+            'full_loc_exact': 'city::Muncie@@state::Indiana@@location::Muncie, IN@@country::United States',
+            'guid': '3'*32,
+            'id': 'seo.joblisting.3',
+            'location': 'Muncie, IN',
+            'location_exact': 'Muncie, IN',
+            'reqid': 'AAA000002',
+            'uid': "1002",
+            'link': 'http://my.jobs/' + '3'*32
+        })
+        self.conn.add([job])
+        site = factories.SeoSiteFactory.build()
+        site.save()
 
-            for url, num_jobs in [('/indiana/usa/jobs/', 3),
-                                  ('/indianapolis/indiana/usa/jobs/', 2)]:
-                resp = self.client.get(url,
-                                       HTTP_HOST='buckconsultants.jobs',
-                                       follow=True)
-                self.assertEqual(len(resp.context['default_jobs']), num_jobs)
-                content = BeautifulSoup(resp.content)
-                count = content.find('h3',
-                                     **{'class': 'direct_highlightedText'})
+        for url, num_jobs in [('/indiana/usa/jobs/', 3),
+                                ('/indianapolis/indiana/usa/jobs/', 2)]:
+            resp = self.client.get(url,
+                                    HTTP_HOST='buckconsultants.jobs',
+                                    follow=True)
+            self.assertEqual(len(resp.context['default_jobs']), num_jobs)
+            content = BeautifulSoup(resp.content)
+            count = content.find('h3',
+                                    **{'class': 'direct_highlightedText'})
 
-                count_text = '%d Jobs in Indiana' % num_jobs
-                if 'indianapolis' in url:
-                    count_text += 'polis, IN'
-                self.assertEqual(count.text.strip(), count_text)
+            count_text = '%d Jobs in Indiana' % num_jobs
+            if 'indianapolis' in url:
+                count_text += 'polis, IN'
+            self.assertEqual(count.text.strip(), count_text)
 
     def test_url_for_sort_field(self):
         """
@@ -1844,15 +1841,14 @@ class SeoViewsTestCase(DirectSEOTestCase):
         all work.
         
         """
-        with connection(connections_info=solr_settings.HAYSTACK_CONNECTIONS):
-            site = factories.SeoSiteFactory.build()
-            site.save()
-            resp = self.client.get(
-                '/indianapolis/indiana/usa/jobs/',
-                HTTP_HOST='buckconsultants.jobs',
-                follow=True)
-            self.assertEqual(resp.status_code, 200)
-            self.assertEqual(len(resp.context['default_jobs']), 2)
+        site = factories.SeoSiteFactory.build()
+        site.save()
+        resp = self.client.get(
+            '/indianapolis/indiana/usa/jobs/',
+            HTTP_HOST='buckconsultants.jobs',
+            follow=True)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(len(resp.context['default_jobs']), 2)
 
     def test_customfacet_with_querystring(self):
         """
@@ -1917,18 +1913,17 @@ class SeoViewsTestCase(DirectSEOTestCase):
         site.business_units = [self.buid_id]
         site.save()
         
-        with connection(connections_info=solr_settings.HAYSTACK_CONNECTIONS):
-            next_link = '/feed/xml?num_items=1'
-            num_pages = 0
-            while next_link:
-                num_pages += 1
-                resp = self.client.get(next_link)
-                tree = etree.parse(StringIO(resp.content))
-                self.assertEqual(resp.status_code, 200)
-                next_link = tree.find("link[@rel='next']")
-                if next_link is not None:
-                    next_link = next_link.get('href')
-            self.assertEqual(num_pages, 2)
+        next_link = '/feed/xml?num_items=1'
+        num_pages = 0
+        while next_link:
+            num_pages += 1
+            resp = self.client.get(next_link)
+            tree = etree.parse(StringIO(resp.content))
+            self.assertEqual(resp.status_code, 200)
+            next_link = tree.find("link[@rel='next']")
+            if next_link is not None:
+                next_link = next_link.get('href')
+        self.assertEqual(num_pages, 2)
 
     def test_syndicate_feed_offset_larger_than_num_records(self):
         """Validate that when the offset is greater than the number of records,
@@ -1938,29 +1933,27 @@ class SeoViewsTestCase(DirectSEOTestCase):
         site.business_units = [self.buid_id]
         site.save()
         job = self.solr_docs[0]
-        with connection(connections_info=solr_settings.HAYSTACK_CONNECTIONS):
-            resp = self.client.get(
-                    '/feed/rss?q=uid:1000&offset=1'
-                )
-            tree = etree.parse(StringIO(resp.content))
-            self.assertEqual(resp.status_code, 200)
-            # Check that ther ren't any jobs.
-            self.assertNotIn('<guid>', resp.content)
+        resp = self.client.get(
+                '/feed/rss?q=uid:1000&offset=1'
+            )
+        tree = etree.parse(StringIO(resp.content))
+        self.assertEqual(resp.status_code, 200)
+        # Check that ther ren't any jobs.
+        self.assertNotIn('<guid>', resp.content)
 
     def test_syndicate_feed_query_results(self):
         site = SeoSite.objects.get(id=1)
         site.business_units = [self.buid_id]
         site.save()
         job = self.solr_docs[0]
-        with connection(connections_info=solr_settings.HAYSTACK_CONNECTIONS):
-            resp = self.client.get(
-                    '/feed/rss?q=uid:1000' 
-                )
-            tree = etree.parse(StringIO(resp.content))
-            self.assertEqual(resp.status_code, 200)
-            #Check that there's only one job
-            self.assertEqual(resp.content.find('<guid>'),
-                             resp.content.rfind('<guid>'))
+        resp = self.client.get(
+                '/feed/rss?q=uid:1000' 
+            )
+        tree = etree.parse(StringIO(resp.content))
+        self.assertEqual(resp.status_code, 200)
+        #Check that there's only one job
+        self.assertEqual(resp.content.find('<guid>'),
+                         resp.content.rfind('<guid>'))
 
     def test_syndicate_feed_query(self):
         # Since the BusinessUnit id for our test XML feed is set to 0 on the
@@ -1971,45 +1964,42 @@ class SeoViewsTestCase(DirectSEOTestCase):
         site.business_units = [self.buid_id]
         site.save()
         job = self.solr_docs[0]
-        with connection(connections_info=solr_settings.HAYSTACK_CONNECTIONS):
-            resp = self.client.get(
-                '/feed/xml?num_items=1&location=Indianapolis&q=Retail'
-                )
-            tree = etree.parse(StringIO(resp.content))
-            self.assertEqual(resp.status_code, 200)
-            self_link = tree.find("link[@rel='self']").get('href')
-            self.assertTrue('location=' in self_link and 'q=' in self_link)
-            next_link = tree.find("link[@rel='next']").get('href')
-            # Get the child tags of the first <job> tag from the XML output
-            self.assertTrue('location=' in next_link and 'q=' in next_link) 
+        resp = self.client.get(
+            '/feed/xml?num_items=1&location=Indianapolis&q=Retail'
+            )
+        tree = etree.parse(StringIO(resp.content))
+        self.assertEqual(resp.status_code, 200)
+        self_link = tree.find("link[@rel='self']").get('href')
+        self.assertTrue('location=' in self_link and 'q=' in self_link)
+        next_link = tree.find("link[@rel='next']").get('href')
+        # Get the child tags of the first <job> tag from the XML output
+        self.assertTrue('location=' in next_link and 'q=' in next_link) 
 
     def test_feed_title(self):
         site = SeoSite.objects.get(id=1)
         site.business_units = [self.buid_id]
         site.save()
         feed_types = ['rss', 'atom'] 
-        with connection(connections_info=solr_settings.HAYSTACK_CONNECTIONS):
-            for feed_type in feed_types:
-                resp = self.client.get('/jobs/feed/%s?q=Retail&location=Indianapolis' % 
-                                       feed_type, HTTP_HOST="buckconsultants.jobs")
-                self.assertEqual(resp.status_code, 200)
-                self.assertNotEqual(resp.content.find(
-                                    'Retail Jobs in Indianapolis'), -1)
+        for feed_type in feed_types:
+            resp = self.client.get('/jobs/feed/%s?q=Retail&location=Indianapolis' % 
+                                    feed_type, HTTP_HOST="buckconsultants.jobs")
+            self.assertEqual(resp.status_code, 200)
+            self.assertNotEqual(resp.content.find(
+                                'Retail Jobs in Indianapolis'), -1)
 
     def test_rss_link_title(self):
         site = SeoSite.objects.get(id=1)
         site.business_units = [self.buid_id]
         site.save()
-        with connection(connections_info=solr_settings.HAYSTACK_CONNECTIONS):
-            resp = self.client.get('/jobs/?q=Retail&location=Indianapolis',
-                                   HTTP_HOST="buckconsultants.jobs")
-            self.assertEqual(resp.status_code, 200)
+        resp = self.client.get('/jobs/?q=Retail&location=Indianapolis',
+                                HTTP_HOST="buckconsultants.jobs")
+        self.assertEqual(resp.status_code, 200)
 
-            rss_link = '<link rel="alternate" type="application/rss+xml" ' \
-                       'title="Test - Retail Jobs in Indianapolis" ' \
-                       'href="http://buckconsultants.jobs/jobs/feed/' \
-                       'rss?q=Retail&amp;amp;location=Indianapolis">'
-            self.assertIn(rss_link, resp.content)
+        rss_link = '<link rel="alternate" type="application/rss+xml" ' \
+                    'title="Test - Retail Jobs in Indianapolis" ' \
+                    'href="http://buckconsultants.jobs/jobs/feed/' \
+                    'rss?q=Retail&amp;amp;location=Indianapolis">'
+        self.assertIn(rss_link, resp.content)
 
     def test_feed_urls(self):
         
@@ -2040,23 +2030,22 @@ class SeoViewsTestCase(DirectSEOTestCase):
         job.site_packages.add(package)
         job.save()
 
-        with connection(connections_info=solr_settings.HAYSTACK_CONNECTIONS):
-            known_url = 'http://testserver/11111111111111111111111111111111'
-            postajob_url = 'http://testserver/%s/job/' % job_location.guid
-            for feed_type in feed_types:
-                resp = self.client.get('/feed/%s' % feed_type)
+        known_url = 'http://testserver/11111111111111111111111111111111'
+        postajob_url = 'http://testserver/%s/job/' % job_location.guid
+        for feed_type in feed_types:
+            resp = self.client.get('/feed/%s' % feed_type)
 
-                # Confirm that the url for a posted job is correct in the
-                # feed.
-                self.assertIn(postajob_url, resp.content)
-                # Confirm that the url for a normal job is correct
-                # in the feed.
-                self.assertIn(known_url, resp.content)
+            # Confirm that the url for a posted job is correct in the
+            # feed.
+            self.assertIn(postajob_url, resp.content)
+            # Confirm that the url for a normal job is correct
+            # in the feed.
+            self.assertIn(known_url, resp.content)
 
-                # Sanity check. Make sure the extra field we've added
-                # to help generate the urls isn't making it to the
-                # final feed.
-                self.assertNotIn('is_posted', resp.content)
+            # Sanity check. Make sure the extra field we've added
+            # to help generate the urls isn't making it to the
+            # final feed.
+            self.assertNotIn('is_posted', resp.content)
 
     def test_syndicate_feed(self):
 
@@ -2076,32 +2065,31 @@ class SeoViewsTestCase(DirectSEOTestCase):
         site.business_units = [self.buid_id]
         site.save()
 
-        with connection(connections_info=solr_settings.HAYSTACK_CONNECTIONS):
-            resp = self.client.get('/feed/xml')
-            tree = etree.parse(StringIO(resp.content))
-            walker = etree.iterwalk(tree, events=("start",), tag="job")
-            # Get the child tags of the first <job> tag from the XML output
-            children = walker.next()[1].iterchildren()
-            tags = [child.tag for child in children]
-            self.assertIn('reqid', tags)
-            site = factories.SeoSiteFactory.build()
-            site.save()
-            for feed_type, ctype in feed_types.items():
-                resp = self.client.get('/jobs/feed/%s' % feed_type,
-                                       HTTP_HOST="buckconsultants.jobs")
-                self.assertEqual(resp.status_code, 200)
+        resp = self.client.get('/feed/xml')
+        tree = etree.parse(StringIO(resp.content))
+        walker = etree.iterwalk(tree, events=("start",), tag="job")
+        # Get the child tags of the first <job> tag from the XML output
+        children = walker.next()[1].iterchildren()
+        tags = [child.tag for child in children]
+        self.assertIn('reqid', tags)
+        site = factories.SeoSiteFactory.build()
+        site.save()
+        for feed_type, ctype in feed_types.items():
+            resp = self.client.get('/jobs/feed/%s' % feed_type,
+                                    HTTP_HOST="buckconsultants.jobs")
+            self.assertEqual(resp.status_code, 200)
 
-                job = self.conn.search(q='uid:1000')
-                vs = feed_type
-                if vs == 'jsonp':
-                    vs = 'json'
-                test_str = "http://buckconsultants.jobs/%s%d" % \
-                           (job.docs[0]['guid'],
-                            settings.FEED_VIEW_SOURCES[vs])
-                self.assertNotEqual(resp.content.decode('utf-8').find(test_str),
-                                    -1)
+            job = self.conn.search(q='uid:1000')
+            vs = feed_type
+            if vs == 'jsonp':
+                vs = 'json'
+            test_str = "http://buckconsultants.jobs/%s%d" % \
+                        (job.docs[0]['guid'],
+                        settings.FEED_VIEW_SOURCES[vs])
+            self.assertNotEqual(resp.content.decode('utf-8').find(test_str),
+                                -1)
 
-                self.assertEqual(resp['Content-Type'], 'application/%s' % ctype)
+            self.assertEqual(resp['Content-Type'], 'application/%s' % ctype)
 
     def test_new_businessunit(self):
         """
@@ -2487,15 +2475,14 @@ class SeoViewsTestCase(DirectSEOTestCase):
         company.job_source_ids.add(alpha_buid.id)
         company.save()
         
-        with connection(connections_info=solr_settings.HAYSTACK_CONNECTIONS):   
-            #test for companies beginning with a number
-            resp = self.client.get("/all-companies/0-9/")
-            self.assertContains(resp,'<li class="company">',count=None, 
-                                status_code=200, msg_prefix='')
-            #test for companies beginning with a letter
-            resp = self.client.get("/all-companies/a/")
-            self.assertContains(resp,'<li class="company">',count=None, 
-                                status_code=200, msg_prefix='')
+        #test for companies beginning with a number
+        resp = self.client.get("/all-companies/0-9/")
+        self.assertContains(resp,'<li class="company">',count=None, 
+                            status_code=200, msg_prefix='')
+        #test for companies beginning with a letter
+        resp = self.client.get("/all-companies/a/")
+        self.assertContains(resp,'<li class="company">',count=None, 
+                            status_code=200, msg_prefix='')
             
     def test_empty_company_listing(self):
         company = Company.objects.none()
@@ -2573,33 +2560,31 @@ class SeoViewsTestCase(DirectSEOTestCase):
         
     def test_saved_search_render(self):
         """Test that network sites get the saved search form on job listings."""
-        with connection(connections_info=solr_settings.HAYSTACK_CONNECTIONS):
-            site = factories.SeoSiteFactory.build()
-            site.save()
-            site_tag = SiteTag(site_tag='network')
-            site_tag.save()
-            site.site_tags.add(site_tag)
-            resp = self.client.get(
-                    '/indianapolis/indiana/usa/jobs/',
-                    HTTP_HOST='buckconsultants.jobs',
-                    follow=True)
-            self.assertContains(resp,'<div id="de-myjobs-widget"',count=None, 
-                                    status_code=200, msg_prefix='')
+        site = factories.SeoSiteFactory.build()
+        site.save()
+        site_tag = SiteTag(site_tag='network')
+        site_tag.save()
+        site.site_tags.add(site_tag)
+        resp = self.client.get(
+                '/indianapolis/indiana/usa/jobs/',
+                HTTP_HOST='buckconsultants.jobs',
+                follow=True)
+        self.assertContains(resp,'<div id="de-myjobs-widget"',count=None, 
+                                status_code=200, msg_prefix='')
             
     def test_saved_search_non_render(self):
         """Test company sites don't have a saved search form on job listings."""
-        with connection(connections_info=solr_settings.HAYSTACK_CONNECTIONS):
-            site = factories.SeoSiteFactory.build()
-            site.save()
-            site_tag = SiteTag(site_tag='company')
-            site_tag.save()
-            site.site_tags.add(site_tag) 
-            resp = self.client.get(
-                    '/indianapolis/indiana/usa/jobs/',
-                    HTTP_HOST='buckconsultants.jobs',
-                    follow=True)
-            self.assertNotContains(resp,'<div id="direct_savedsearch"', 
-                                   status_code=200, msg_prefix='')
+        site = factories.SeoSiteFactory.build()
+        site.save()
+        site_tag = SiteTag(site_tag='company')
+        site_tag.save()
+        site.site_tags.add(site_tag) 
+        resp = self.client.get(
+                '/indianapolis/indiana/usa/jobs/',
+                HTTP_HOST='buckconsultants.jobs',
+                follow=True)
+        self.assertNotContains(resp,'<div id="direct_savedsearch"', 
+                                status_code=200, msg_prefix='')
 
     def test_secure_redirect(self):
         site = SeoSite.objects.get()


### PR DESCRIPTION
Some tests were attempting to override HAYSTACK_CONNECTIONS but haystack was still using django settings. In some cases the tests were still passing, leading to the ability to break staging.

HAYSTACK_CONNECTIONS is a dictionary and haystack takes a reference to the dictionary in django settings when it loads.

Test were replacing the dictionary in settings entirely. Haystack was referencing the old dictionary and therefore did not see the new dictionary.

**New:** I put code in `myjobs/__init__.py` to make sure that if we are testing, we permanently stomp the HAYSTACK_CONNECTIONS. We don't ever need a connection to a "real" solr instance in tests, anymore than we need a connection to a real database.

As an additional test I set my local dev_settings.py to point HAYSTACK to a completely bogus url. This url should have been ignored but it instead caused some tests to get 404 errors. I used these failures as an indication that some tests were referencing the HAYSTACK_CONNECTIONS setting. When all tests passed I knew that no more tests were using those settings.

All seo tests pass except two that I can't fix.