### PR TITLE
Add help text and reorder form fields for address forms. PD-1488

### DIFF
--- a/mypartners/forms.py
+++ b/mypartners/forms.py
@@ -24,6 +24,7 @@ def init_tags(self):
         self.initial['tags'] = tag_names
     self.fields['tags'] = forms.CharField(
         label='Tags', max_length=255, required=False,
+        help_text='ie \'Disability\', \'veteran-outreach\', etc. Spaces are not allowed.',
         widget=forms.TextInput(attrs={'id': 'p-tags', 'placeholder': 'Tags'})
     )
 
@@ -157,20 +158,24 @@ class NewPartnerForm(NormalizedModelForm):
         new_fields = {
             'partnername': forms.CharField(
                 label="Partner Organization", max_length=255, required=True,
+                help_text="Name of the Organization",
                 widget=forms.TextInput(
                     attrs={'placeholder': 'Partner Organization',
                            'id': 'id_partner-partnername'})),
             'partnersource': forms.CharField(
                 label="Source", max_length=255, required=False,
+                help_text="Website, event, or other source where you found the partner",
                 widget=forms.TextInput(
                     attrs={'placeholder': 'Source',
                            'id': 'id_partner-partnersource'})),
             'partnerurl': forms.URLField(
                 label="URL", max_length=255, required=False,
+                help_text="Full url. ie http://partnerorganization.org",
                 widget=forms.TextInput(attrs={'placeholder': 'URL',
                                               'id': 'id_partner-partnerurl'})),
             'partner-tags': forms.CharField(
                 label='Tags', max_length=255, required=False,
+                help_text="ie 'Disability', 'veteran-outreach', etc. Spaces are not allowed.",
                 widget=forms.TextInput(attrs={'id': 'p-tags',
                                               'placeholder': 'Tags'}))
         }
@@ -290,6 +295,7 @@ class PartnerForm(NormalizedModelForm):
 
         self.fields['primary_contact'] = forms.ChoiceField(
             label="Primary Contact", required=False,
+            help_text='Denotes who the primary contact is for this organization.',
             initial=unicode(choices[0][0]),
             choices=choices)
 

--- a/mypartners/forms.py
+++ b/mypartners/forms.py
@@ -24,7 +24,7 @@ def init_tags(self):
         self.initial['tags'] = tag_names
     self.fields['tags'] = forms.CharField(
         label='Tags', max_length=255, required=False,
-        help_text='ie \'Disability\', \'veteran-outreach\', etc. Spaces are not allowed.',
+        help_text='ie \'Disability\', \'veteran-outreach\', etc. Separate tags with a comma.',
         widget=forms.TextInput(attrs={'id': 'p-tags', 'placeholder': 'Tags'})
     )
 
@@ -175,7 +175,7 @@ class NewPartnerForm(NormalizedModelForm):
                                               'id': 'id_partner-partnerurl'})),
             'partner-tags': forms.CharField(
                 label='Tags', max_length=255, required=False,
-                help_text="ie 'Disability', 'veteran-outreach', etc. Spaces are not allowed.",
+                help_text="ie 'Disability', 'veteran-outreach', etc. Separate tags with a comma.",
                 widget=forms.TextInput(attrs={'id': 'p-tags',
                                               'placeholder': 'Tags'}))
         }

--- a/mypartners/models.py
+++ b/mypartners/models.py
@@ -177,14 +177,17 @@ class Contact(models.Model):
     # used if this partner was created by using the partner library
     library = models.ForeignKey('PartnerLibrary', null=True,
                                 on_delete=models.SET_NULL)
-    name = models.CharField(max_length=255, verbose_name='Full Name')
-    email = models.EmailField(max_length=255, verbose_name='Email', blank=True)
+    name = models.CharField(max_length=255, verbose_name='Full Name',
+                             help_text='Contact\'s full name')
+    email = models.EmailField(max_length=255, verbose_name='Email', blank=True,
+                             help_text='Contact\'s email address')
     phone = models.CharField(max_length=30, verbose_name='Phone', blank=True,
-            default='')
+            default='', help_text='ie 123-456-7890, (123)456-7890')
     locations = models.ManyToManyField('Location', related_name='contacts')
     tags = models.ManyToManyField('Tag', null=True)
     notes = models.TextField(max_length=1000, verbose_name='Notes',
-                             blank=True, default="")
+                             blank=True, default="", 
+                             help_text='Any additional information you want to record')
     archived_on = models.DateTimeField(null=True)
     approval_status = models.OneToOneField(
         'mypartners.Status', null=True, verbose_name="Approval Status")
@@ -290,18 +293,23 @@ class Partner(models.Model):
 
     """
     name = models.CharField(max_length=255,
-                            verbose_name='Partner Organization')
+                            verbose_name='Partner Organization',
+                            help_text='Name of the Organization')
     data_source = models.CharField(max_length=255,
                                    verbose_name='Source',
-                                   blank=True)
-    uri = models.URLField(verbose_name='URL', blank=True)
+                                   blank=True, 
+                                   help_text='Website, event, or other source where you found the partner')
+    uri = models.URLField(verbose_name='URL', blank=True, 
+                        help_text='Full url. ie http://partnerorganization.org')
     primary_contact = models.ForeignKey('Contact', null=True,
                                         related_name='primary_contact',
-                                        on_delete=models.SET_NULL)
+                                        on_delete=models.SET_NULL,
+                                        help_text='Denotes who the primary contact is for this organization.')
     # used if this partner was created by using the partner library
     library = models.ForeignKey('PartnerLibrary', null=True,
                                 on_delete=models.SET_NULL)
-    tags = models.ManyToManyField('Tag', null=True)
+    tags = models.ManyToManyField('Tag', null=True, 
+        help_text='ie \'Disability\', \'veteran-outreach\', etc. Spaces are not allowed.')
     # owner is the Company that owns this partner.
     owner = models.ForeignKey('seo.Company', null=True,
                               on_delete=models.SET_NULL)

--- a/mypartners/models.py
+++ b/mypartners/models.py
@@ -182,7 +182,7 @@ class Contact(models.Model):
     email = models.EmailField(max_length=255, verbose_name='Email', blank=True,
                              help_text='Contact\'s email address')
     phone = models.CharField(max_length=30, verbose_name='Phone', blank=True,
-            default='', help_text='ie 123-456-7890, (123)456-7890')
+            default='', help_text='ie (123) 456-7890')
     locations = models.ManyToManyField('Location', related_name='contacts')
     tags = models.ManyToManyField('Tag', null=True)
     notes = models.TextField(max_length=1000, verbose_name='Notes',
@@ -309,7 +309,7 @@ class Partner(models.Model):
     library = models.ForeignKey('PartnerLibrary', null=True,
                                 on_delete=models.SET_NULL)
     tags = models.ManyToManyField('Tag', null=True, 
-        help_text='ie \'Disability\', \'veteran-outreach\', etc. Spaces are not allowed.')
+        help_text='ie \'Disability\', \'veteran-outreach\', etc. Separate tags with a comma.')
     # owner is the Company that owns this partner.
     owner = models.ForeignKey('seo.Company', null=True,
                               on_delete=models.SET_NULL)

--- a/mypartners/models.py
+++ b/mypartners/models.py
@@ -134,20 +134,26 @@ class SearchParameterManager(models.Manager):
 
 
 class Location(models.Model):
-    label = models.CharField(max_length=60, verbose_name='Address Label',
-                             blank=True)
     address_line_one = models.CharField(max_length=255,
                                         verbose_name='Address Line One',
-                                        blank=True)
+                                        blank=True,
+                                        help_text='ie 123 Main St')
     address_line_two = models.CharField(max_length=255,
                                         verbose_name='Address Line Two',
-                                        blank=True)
-    city = models.CharField(max_length=255, verbose_name='City')
-    state = models.CharField(max_length=200, verbose_name='State/Region')
+                                        blank=True,
+                                        help_text='ie Suite 100')
+    city = models.CharField(max_length=255, verbose_name='City',
+                                           help_text='ie Chicago, Washington, Dayton')
+    state = models.CharField(max_length=200, verbose_name='State/Region',
+                                             help_text='ie NY, WA, DC')
     country_code = models.CharField(max_length=3, verbose_name='Country',
                                     default='USA')
     postal_code = models.CharField(max_length=12, verbose_name='Postal Code',
-                                   blank=True)
+                                   blank=True,
+                                   help_text='ie 90210, 12345-7890')
+    label = models.CharField(max_length=60, verbose_name='Address Name',
+                             blank=True,
+                             help_text='ie Main Office, Corporate, Regional')
 
     def __unicode__(self):
         return ", ".join(filter(bool, [self.city, self.state]))

--- a/myprofile/models.py
+++ b/myprofile/models.py
@@ -39,7 +39,6 @@ class ProfileUnits(models.Model):
 
     def get_fields(self):
         """
-        Returns the module type, value, and field type for all
         fields on a specific model
         """
         field_list = []
@@ -293,22 +292,30 @@ class Education(ProfileUnits):
         else:
             return []
 
-
 class Address(ProfileUnits):
-    label = models.CharField(max_length=60, blank=True,
-                             verbose_name=_('Address Label'))
     address_line_one = models.CharField(max_length=255, blank=True,
-                                        verbose_name=_('Address Line One'))
+                                        verbose_name=_('Address Line One'),
+                                        help_text='ie 123 Main St')
     address_line_two = models.CharField(max_length=255, blank=True,
-                                        verbose_name=_('Address Line Two'))
+                                        verbose_name=_('Address Line Two'),
+                                        help_text='ie apartment 1')
     city_name = models.CharField(max_length=255, blank=True,
-                                 verbose_name=_("City"))
+                                 verbose_name=_("City"),
+                                 help_text='ie Chicago, Washington, Dayton')
     country_sub_division_code = models.CharField(max_length=5, blank=True,
-                                                 verbose_name=_("State/Region"))
+                                                 verbose_name=_("State/Region"),
+                                                 help_text='ie NY, WA, DC')
     country_code = models.CharField(max_length=3, blank=True,
-                                    verbose_name=_("Country"))
+                                    verbose_name=_("Country"),
+                                    default='USA')
     postal_code = models.CharField(max_length=12, blank=True,
-                                   verbose_name=_("Postal Code"))
+                                   verbose_name=_("Postal Code"),
+                                   help_text='ie 90210, 12345-7890')
+    label = models.CharField(max_length=60, blank=True,
+                             verbose_name=_('Address Name'),
+                             help_text='ie Home, Work, etc')
+    
+
 
     @classmethod
     def get_suggestion(cls, user):

--- a/myprofile/models.py
+++ b/myprofile/models.py
@@ -39,6 +39,7 @@ class ProfileUnits(models.Model):
 
     def get_fields(self):
         """
+        Returns the module type, value, and field type for all        
         fields on a specific model
         """
         field_list = []

--- a/postajob/models.py
+++ b/postajob/models.py
@@ -788,7 +788,7 @@ class CompanyProfile(models.Model):
     zipcode = models.CharField(max_length=255, blank=True,
                                    help_text='ie 90210, 12345-7890')
     phone = models.CharField(max_length=255, blank=True,
-                                   help_text='ie 123-456-7890, (123)456-7890')
+                                   help_text='ie (123) 456-7890')
 
     # Only used for Partner Microsites.
     authorize_net_login = models.CharField(

--- a/postajob/models.py
+++ b/postajob/models.py
@@ -772,17 +772,23 @@ class CompanyProfile(models.Model):
 
     company = models.OneToOneField('seo.Company')
     description = models.TextField(max_length=255, blank=True,
-                                   verbose_name='Company Description')
+                                   verbose_name='Company Description',
+                                        help_text='Acme Corporation')
     address_line_one = models.CharField(max_length=255, blank=True,
-                                        verbose_name='Address Line One')
+                                        verbose_name='Address Line One',
+                                        help_text='ie 123 Main St')
     address_line_two = models.CharField(max_length=255, blank=True,
-                                        verbose_name='Address Line Two')
-    city = models.CharField(max_length=255, blank=True)
+                                        verbose_name='Address Line Two',
+                                        help_text='ie suite 100')
+    city = models.CharField(max_length=255, blank=True,
+                                       help_text='ie Chicago, Washington, Dayton')
     state = models.CharField(max_length=255, blank=True)
     country = models.CharField(max_length=255, choices=country_choices,
                                default='United States')
-    zipcode = models.CharField(max_length=255, blank=True)
-    phone = models.CharField(max_length=255, blank=True)
+    zipcode = models.CharField(max_length=255, blank=True,
+                                   help_text='ie 90210, 12345-7890')
+    phone = models.CharField(max_length=255, blank=True,
+                                   help_text='ie 123-456-7890, (123)456-7890')
 
     # Only used for Partner Microsites.
     authorize_net_login = models.CharField(


### PR DESCRIPTION
Adds help text to the address forms in profile, post a job, and PRM contacts. Also relabels "Address Label" as "Address Name" and moves it to the bottom of the form to avoid confusion that is occuring with users putting address line 1 in the address label field.