### PR TITLE
[PD-1514] Fixed javascript for field parsing in reports.

### DIFF
--- a/myreports/views.py
+++ b/myreports/views.py
@@ -267,11 +267,11 @@ def downloads(request):
             'contact': common_blacklist + ['archived_on', 'library', 'user'],
             'partner': common_blacklist + ['library', 'owner']}
 
-        if not report.results:
-            report.regenerate()
-
-        fields = sorted([field for field in report.python[0].keys()
-                         if field not in blacklist[report.model]])
+        if report.python:
+            fields = sorted([field for field in report.python[0].keys()
+                             if field not in blacklist[report.model]])
+        else:
+            fields = []
 
         values = json.loads(report.values) or fields
         for field_list in [values, fields]:

--- a/static/reporting.167-20.js
+++ b/static/reporting.167-20.js
@@ -319,8 +319,12 @@ Field.prototype = {
     return $("#" + this.id);
   },
   onSave: function(key) {
-    var data = {};
-    steelToe(data).set(key || this.key, this.currentVal());
+    var data = {},
+        value = this.currentVal();
+
+    if(value) {
+      steelToe(data).set(key || this.key, value);
+    }
 
     return data;
   },
@@ -776,6 +780,7 @@ TagField.prototype = $.extend(Object.create(TextField.prototype), {
   },
   onSave: function(key) {
     var data = {};
+
     if (this.value.length) {
       steelToe(data).set(key || this.key, this.currentVal());
     }
@@ -1020,14 +1025,6 @@ FilteredList.prototype = $.extend(Object.create(Field.prototype), {
     }
 
     return this;
-  },
-  onSave: function(key) {
-    var data = {},
-        value = this.currentVal();
-
-    steelToe(data).set(key || this.key, value);
-
-    return data;
   }
 });
 
@@ -1317,7 +1314,7 @@ function createReport(type) {
                                         },
                                         state: 'contact.locations.state.icontains',
                                         city: 'contact.locations.city.icontains',
-                                        tags: 'contactrecord.tags.name.in',
+                                        tags: 'contact.tags.name.in',
                                       },
                                       values: ["pk", "name"],
                                       order_by: "name"

--- a/templates/myreports/reports.html
+++ b/templates/myreports/reports.html
@@ -26,7 +26,7 @@
 <![endif]-->
 <script src="{{ STATIC_URL }}bootstrap/bootstrap-modalmanager.js"></script>
 <script src="{{ STATIC_URL }}bootstrap/bootstrap-modal.js"></script>
-<script src="{{ STATIC_URL }}reporting.167-6.js"></script>
+<script src="{{ STATIC_URL }}reporting.167-20.js"></script>
 <script src="{{ STATIC_URL }}pickadate/picker.js"></script>
 <script src="{{ STATIC_URL }}pickadate/picker.date.js"></script>
 <script src="{{ STATIC_URL }}pickadate/legacy.js"></script>


### PR DESCRIPTION
-  the changes to reports/views.py prevent index errors when a report has 0 results
- the changes to static/reporting.js prevent adding of empty values to filter parameters and fix the key used for tags in contact reports
- the template file was just updated to reflect the new filename for reporting.js.