### PR TITLE
Opt in to content negotiation with a decorator. [PD-1621]

### DIFF
--- a/myjobs/autoserialize.py
+++ b/myjobs/autoserialize.py
@@ -3,7 +3,7 @@ import json
 from functools import wraps
 
 
-def autoserialize_view_decorator(fn):
+def autoserialize(fn):
     @wraps(fn)
     def handle_autoserialize(request):
         response = fn(request)

--- a/myjobs/autoserialize.py
+++ b/myjobs/autoserialize.py
@@ -6,19 +6,15 @@ from functools import wraps
 def autoserialize_view_decorator(fn):
     @wraps(fn)
     def handle_autoserialize(request):
-        if "callback" in request.GET:
-            callback = request.GET['callback']
-            content_type = "text/javascript"
-        else:
-            callback = None
-            content_type = "application/json"
-
         response = fn(request)
 
         payload = json.dumps(response)
-        if callback is not None:
+        if "callback" in request.GET:
+            callback = request.GET['callback']
             content = "%s(%s)" % (callback, payload)
+            content_type = "text/javascript"
         else:
             content = payload
+            content_type = "application/json"
         return HttpResponse(content=content, content_type=content_type)
     return handle_autoserialize

--- a/myjobs/autoserialize.py
+++ b/myjobs/autoserialize.py
@@ -1,0 +1,24 @@
+from django.http import HttpResponse
+import json
+from functools import wraps
+
+
+def autoserialize_view_decorator(fn):
+    @wraps(fn)
+    def handle_autoserialize(request):
+        if "callback" in request.GET:
+            callback = request.GET['callback']
+            content_type = "text/javascript"
+        else:
+            callback = None
+            content_type = "application/json"
+
+        response = fn(request)
+
+        payload = json.dumps(response)
+        if callback is not None:
+            content = "%s(%s)" % (callback, payload)
+        else:
+            content = payload
+        return HttpResponse(content=content, content_type=content_type)
+    return handle_autoserialize

--- a/myjobs/child_dashboard.py
+++ b/myjobs/child_dashboard.py
@@ -1,0 +1,8 @@
+from django.http import HttpResponse
+
+from myjobs.autoserialize import autoserialize_view_decorator
+
+
+@autoserialize_view_decorator
+def child_dashboard(request):
+    return {'start_here': 'fill in return data'}

--- a/myjobs/child_dashboard.py
+++ b/myjobs/child_dashboard.py
@@ -1,8 +1,8 @@
 from django.http import HttpResponse
 
-from myjobs.autoserialize import autoserialize_view_decorator
+from myjobs.autoserialize import autoserialize
 
 
-@autoserialize_view_decorator
+@autoserialize
 def child_dashboard(request):
     return {'start_here': 'fill in return data'}

--- a/myjobs/tests/test_autoserialize.py
+++ b/myjobs/tests/test_autoserialize.py
@@ -6,10 +6,10 @@ from django.test import TestCase
 from django.test.utils import override_settings
 
 from myjobs.tests.setup import MyJobsBase
-from myjobs.autoserialize import autoserialize_view_decorator
+from myjobs.autoserialize import autoserialize
 
 
-@autoserialize_view_decorator
+@autoserialize
 def ping(request):
     return {"pong": request.GET.get("param", "")}
 

--- a/myjobs/tests/test_autoserialize.py
+++ b/myjobs/tests/test_autoserialize.py
@@ -1,0 +1,45 @@
+import re
+import json
+
+from django.conf.urls import url
+from django.test import TestCase
+from django.test.utils import override_settings
+
+from myjobs.tests.setup import MyJobsBase
+from myjobs.autoserialize import autoserialize_view_decorator
+
+
+@autoserialize_view_decorator
+def ping(request):
+    return {"pong": request.GET.get("param", "")}
+
+
+urlpatterns = [
+    url(r'^ping/$', ping, name='ping'),
+]
+
+
+@override_settings(ROOT_URLCONF=__name__)
+class TestAutoserialize(TestCase):
+    def test_json(self):
+        resp = self.client.get("/ping/?param=hello")
+        result = json.loads(resp.content)
+        self.assertEqual({'pong': 'hello'}, result)
+        self.assertEqual("application/json", resp['Content-Type'])
+
+    def test_jsonp(self):
+        resp = self.client.get("/ping/?"
+                               "callback=zzz&param=hello")
+        payload = self.assertCallbackMatch("zzz", resp.content)
+        result = json.loads(payload)
+        self.assertEqual({'pong': 'hello'}, result)
+        self.assertEqual("text/javascript", resp['Content-Type'])
+
+    def assertCallbackMatch(self, expected_callback, actual):
+        pattern = r'^%s\((.*)\)$' % (re.escape(expected_callback))
+        message = "expected '%s' to match '%s'" % (actual, pattern)
+
+        match = re.match(pattern, actual)
+        self.assertIsNotNone(match, message)
+
+        return match.group(1)

--- a/myjobs/tests/test_child_dashboard.py
+++ b/myjobs/tests/test_child_dashboard.py
@@ -1,0 +1,12 @@
+import json
+
+from django.core.urlresolvers import reverse
+
+from myjobs.tests.setup import MyJobsBase
+
+
+class TestChildDashboard(MyJobsBase):
+    def test_child_dastboard(self):
+        resp = self.client.get(reverse('child_dashboard'))
+        result = json.loads(resp.content)
+        self.assertIn("start_here", result)

--- a/myjobs/urls.py
+++ b/myjobs/urls.py
@@ -2,6 +2,7 @@ from django.conf.urls import patterns, url, include
 from django.views.generic import RedirectView
 
 from myjobs.views import About, Privacy, Terms
+from myjobs.child_dashboard import child_dashboard
 
 accountpatterns = patterns('myjobs.views',
     url(r'^edit/$', 'edit_account', name='edit_account'),
@@ -32,4 +33,5 @@ urlpatterns = patterns(
     url(r'^toolbar/$', 'toolbar', name='toolbar'),
     url(r'^cas/$', 'cas', name='cas'),
     url(r'^topbar/$', 'topbar', name='topbar'),
+    url(r'^child-dashboard/$', child_dashboard, name='child_dashboard'),
 )


### PR DESCRIPTION
Set up for allowing browsers to use either JSON XHR or JSONP. This is a generic mechanism allowing our views to focus on providing data.

Stub in a method which will, in the future, do provide secure information for child sites. The hope is that this new method will replace most of the existing jsonp endpoints.

This is an opt in decorator so existing code should not be affected.

