### PR TITLE
[PD-1701] Removing attachments no longer causes validation errors.

### DIFF
--- a/mypartners/helpers.py
+++ b/mypartners/helpers.py
@@ -156,7 +156,7 @@ def get_form_delta(form):
                 new_val = form.data.get(field, '')
                 new_val = form.fields[field].to_python(new_val)
             except ValidationError:
-                # MultipleFileFields break hear because the two place initial
+                # MultipleFileFields break here because the two places initial
                 # data can come from are formatted differently: one is a list,
                 # and the other is a string. We don't simply move this into an
                 # else block because choice fields rely on this initialization

--- a/mypartners/helpers.py
+++ b/mypartners/helpers.py
@@ -6,6 +6,7 @@ from urlparse import urlparse, parse_qsl, urlunparse
 from urllib import urlencode
 
 from django.db.models import Min, Max, Q
+from django.core.exceptions import ValidationError
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.http import Http404
@@ -145,15 +146,23 @@ def get_form_delta(form):
     if form.changed_data:
 
         for field in form.changed_data:
-            # There are two places that initial data can come from:
-            # form.initial or form.fields[field].initial. Django
-            # favors form.initial in their code, so this code prefers
-            # form.initial first as well.
-            initial_val = form.initial.get(field, form.fields[field].initial)
-            initial_val = form.fields[field].to_python(initial_val)
-
-            new_val = form.data.get(field, '')
-            new_val = form.fields[field].to_python(new_val)
+            try:
+                # There are two places that initial data can come from:
+                # form.initial or form.fields[field].initial. Django
+                # favors form.initial in their code, so this code prefers
+                # form.initial first as well.
+                initial_val = form.initial.get(field, form.fields[field].initial)
+                initial_val = form.fields[field].to_python(initial_val)
+                new_val = form.data.get(field, '')
+                new_val = form.fields[field].to_python(new_val)
+            except ValidationError:
+                # MultipleFileFields break hear because the two place initial
+                # data can come from are formatted differently: one is a list,
+                # and the other is a string. We don't simply move this into an
+                # else block because choice fields rely on this initialization
+                # of initial_val and new_val.
+                initial_val = None
+                new_val = None
 
             if isinstance(form.fields[field], MultipleFileField):
                 # Multiple file added results in a MultiValueDict.


### PR DESCRIPTION
Not a fan, but it was the fastest way to fix this that worked. Will re-evaluate this functionality and improve tests in PD-1704.