### PR TITLE
[PD-1706] Create PRMAttachmentFactory

### DIFF
--- a/mypartners/models.py
+++ b/mypartners/models.py
@@ -720,6 +720,12 @@ class PRMAttachment(models.Model):
     def partner(self):
         return getattr(self.contact_record, 'partner', None)
 
+    @partner.setter
+    def partner(self, partner):
+        # TODO: find all parts in code which attempt to set the partner
+        # attribute and remove them
+        pass
+
     def save(self, *args, **kwargs):
         instance = super(PRMAttachment, self).save(*args, **kwargs)
 

--- a/mypartners/models.py
+++ b/mypartners/models.py
@@ -716,6 +716,10 @@ class PRMAttachment(models.Model):
     contact_record = models.ForeignKey(ContactRecord, null=True,
                                        on_delete=models.SET_NULL)
 
+    @property
+    def partner(self):
+        return getattr(self.contact_record, 'partner', None)
+
     def save(self, *args, **kwargs):
         instance = super(PRMAttachment, self).save(*args, **kwargs)
 

--- a/mypartners/tests/factories.py
+++ b/mypartners/tests/factories.py
@@ -99,3 +99,12 @@ class LocationFactory(factory.django.DjangoModelFactory):
     city = fuzzy.FuzzyText()
     state = fuzzy.FuzzyText(length=2, chars=string.ascii_uppercase)
     postal_code = fuzzy.FuzzyInteger(10000, 99999)
+
+
+class PRMAttachmentFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = "mypartners.PRMAttachment"
+
+    attachment = factory.django.FileField(
+        filename='attachment.txt', data=b'This is an attachment.')
+    contact_record = factory.SubFactory(ContactRecordFactory)

--- a/mypartners/tests/test_helpers.py
+++ b/mypartners/tests/test_helpers.py
@@ -61,6 +61,20 @@ class HelpersTests(MyPartnersTestCase):
             else:
                 self.assertEqual("View All", date_str)
 
+    def test_get_form_delta(self):
+        from mypartners.tests.factories import *
+        from mypartners.forms import ContactRecordForm
+
+        attachment = PRMAttachmentFactory()
+        contact_record = attachment.contact_record
+        form = ContactRecordForm(instance=contact_record, 
+                                 partner=attachment.partner)
+
+        # figure out the syntax for form save with deleted attachment
+        # assert no errors
+        # check the delta
+
+
     def test_start_date_before_end_date(self):
         request = self.request_factory.get(
             'prm/view/reports/details/records/', dict(

--- a/mypartners/tests/test_helpers.py
+++ b/mypartners/tests/test_helpers.py
@@ -3,9 +3,11 @@ from datetime import datetime, timedelta
 import random
 
 from mypartners import helpers
+from mypartners.forms import ContactRecordForm
 from mypartners.tests.test_views import (MyPartnersTestCase,
                                          PartnerLibraryTestCase)
-from mypartners.tests.factories import ContactRecordFactory, PartnerFactory
+from mypartners.tests.factories import (ContactRecordFactory, PartnerFactory,
+                                        PRMAttachmentFactory)
 
 
 
@@ -62,17 +64,16 @@ class HelpersTests(MyPartnersTestCase):
                 self.assertEqual("View All", date_str)
 
     def test_get_form_delta(self):
-        from mypartners.tests.factories import *
-        from mypartners.forms import ContactRecordForm
-
+        """Test that all form changes are properly logged as a delta."""
         attachment = PRMAttachmentFactory()
         contact_record = attachment.contact_record
         form = ContactRecordForm(instance=contact_record, 
                                  partner=attachment.partner)
 
-        # figure out the syntax for form save with deleted attachment
-        # assert no errors
-        # check the delta
+        # TODO:
+        # - figure out the syntax for form save with deleted attachment
+        # - assert no errors
+        # - check the delta
 
 
     def test_start_date_before_end_date(self):


### PR DESCRIPTION
# Problem
- No factory exists for the `mypartners.PRMAttachment` model. 
- This model references a `partner` attribute, despite never declaring it
- The above two points mean that when we want an attachment during testing, we have to reference a file on disk and have to make sure to mutate the attachment object before associating it with a file. 

# Solution
- I've created a factory which uses a byte string as the attached file, which should eliminate unnecessary IO during unit tests
- I've made `partner` a property which then retrieves the attachment's contact record's partner
- No more mutation that you have to remember to do else risk exceptions.

# Caveats
- While there is technically a new unit test, it's more of a stub to ensure that I was able to instantiate the PRMAttachmentFactory. This test will be implemented in a separate PR
- Note that I'm merging this into a feature branch. The idea is that all subtasks get merged there, then I'll create a PR for the parent ticket (tagging subtasks along the way). I'm trying this out as a way to organize my work. We'll see how it goes.
