### PR TITLE
Made sure myreports tests run properly even if local config misconfigured.

### DIFF
--- a/myreports/tests/test_views.py
+++ b/myreports/tests/test_views.py
@@ -4,6 +4,7 @@ import json
 import os
 
 from django.test import TestCase
+from django.test.utils import override_settings
 from django.core.urlresolvers import reverse
 
 from myjobs.tests.test_views import TestClient
@@ -16,6 +17,7 @@ from myreports.models import Report
 from seo.tests.factories import CompanyFactory, CompanyUserFactory
 
 
+@override_settings(PROJECT="myjobs", ROOT_URLCONF="myjobs_urls")
 class MyReportsTestCase(TestCase):
     """
     Base class for all MyReports Tests. Identical to `django.test.TestCase`


### PR DESCRIPTION
Basically, if you set PROJECT to "dseo" and then try to run tests, myreports (at the very least) fails. This at least fixes that for myreports.