### PR TITLE
Child site checking  [PD-1610]

### DIFF
--- a/myjobs/child_dashboard.py
+++ b/myjobs/child_dashboard.py
@@ -1,8 +1,10 @@
 from django.http import HttpResponse
 
 from myjobs.autoserialize import autoserialize
+from myjobs.cross_site_verify import cross_site_verify
 
 
+@cross_site_verify
 @autoserialize
 def child_dashboard(request):
     return {'start_here': 'fill in return data'}

--- a/myjobs/cross_site_verify.py
+++ b/myjobs/cross_site_verify.py
@@ -1,0 +1,151 @@
+import re
+import logging
+from django.http import HttpResponse
+
+from functools import wraps
+from universal.helpers import get_domain
+from seo.models import SeoSite
+from urlparse import urlparse, parse_qs
+
+
+XRW = 'XMLHttpRequest'
+logger = logging.getLogger(__name__)
+
+
+class DomainRelationshipException(Exception):
+    pass
+
+
+def extract_hostname(url):
+    if url is None:
+        return None
+    else:
+        return urlparse(url).hostname
+
+
+def extract_hostname_from_header(header):
+    if header is None:
+        return header
+    match = re.match(r'(.*):[0-9]+$', header)
+    if match:
+        return match.group(1)
+    else:
+        return header
+
+
+def parse_request_meta(meta):
+    method = meta.get('REQUEST_METHOD', '')
+
+    host = extract_hostname_from_header(meta.get('HTTP_HOST'))
+
+    origin = extract_hostname(meta.get('HTTP_ORIGIN'))
+
+    referer = extract_hostname(meta.get('HTTP_REFERER'))
+
+    xrw = meta.get('HTTP_X_REQUESTED_WITH')
+
+    qs = meta.get('QUERY_STRING', '')
+
+    qsreferer = parse_qs(qs).get('referer', [None])[0]
+
+    return (method, host, origin, referer, qsreferer, xrw)
+
+
+def guess_child_domain(host, origin, referer, qsreferer):
+    if origin is not None:
+        return origin
+
+    if referer is not None:
+        return referer
+
+    if qsreferer is not None:
+        if qsreferer == host:
+            return qsreferer
+        else:
+            raise DomainRelationshipException('qsreferer-not-host')
+
+    raise DomainRelationshipException('no-child-info')
+
+
+def fail():
+    return HttpResponse(status=404, content="not found")
+
+
+def is_permitted_method(method):
+    return method in ('GET', 'POST', 'OPTIONS')
+
+
+def is_parent(site):
+    return site.parent_site is None
+
+
+def is_parent_self_call(host_site, origin_site):
+    return origin_site.id == host_site.id
+
+
+def is_child_of_parent(host_site, origin_site):
+    if origin_site.parent_site is None:
+        return False
+    return origin_site.parent_site.id == host_site.id
+
+
+def is_self_or_child(host_site, origin_site):
+    return (is_parent_self_call(host_site, origin_site) or
+            is_child_of_parent(host_site, origin_site))
+
+
+def xrw_ok(xrw):
+    return xrw == XRW
+
+
+def get_site(domain):
+    sites = SeoSite.objects.filter(domain=domain)
+    if len(sites) != 1:
+        return None
+    return sites[0]
+
+
+def verify_cross_site_request(site_loader, method, host, origin,
+                              referer, xrw, qsreferer):
+    if not is_permitted_method(method):
+        raise DomainRelationshipException('method')
+
+    host_site = site_loader(host)
+
+    if host_site is None:
+        raise DomainRelationshipException('host-unknown')
+
+    if not is_parent(host_site):
+        raise DomainRelationshipException('host-not-parent')
+
+    child = guess_child_domain(host, origin, referer, qsreferer)
+
+    child_site = site_loader(child)
+    if not is_self_or_child(host_site, child_site):
+        raise DomainRelationshipException('not-child-of-parent')
+
+    if method in ('POST', 'OPTIONS'):
+        if not xrw_ok(xrw):
+            raise DomainRelationshipException('bad-xrw')
+
+
+def cross_site_verify(fn):
+    @wraps(fn)
+    def verify(request):
+        method, host, origin, referer, qsreferer, xrw = (
+            parse_request_meta(request.META))
+
+        try:
+            verify_cross_site_request(get_site, method, host, origin,
+                                      referer, xrw, qsreferer)
+        except DomainRelationshipException as e:
+            data = (("method: %r, host %r, origin %r, " +
+                     "referer %r, qsreferer %r, xrw %r") %
+                    (method, host, origin, referer, qsreferer, xrw))
+            logger.warn(
+                "Rejected cross site request; reason : %s\n" +
+                "data: %s", e.message, data)
+            return fail()
+        return fn(request)
+
+    return verify

--- a/myjobs/cross_site_verify.py
+++ b/myjobs/cross_site_verify.py
@@ -3,7 +3,6 @@ import logging
 from django.http import HttpResponse
 
 from functools import wraps
-from universal.helpers import get_domain
 from seo.models import SeoSite
 from urlparse import urlparse, parse_qs
 

--- a/myjobs/tests/test_child_dashboard.py
+++ b/myjobs/tests/test_child_dashboard.py
@@ -6,7 +6,7 @@ from myjobs.tests.setup import MyJobsBase
 
 
 class TestChildDashboard(MyJobsBase):
-    def test_child_dastboard(self):
+    def test_child_dashboard(self):
         url = reverse('child_dashboard')
         url += "?referer=jobs.directemployers.org"
         resp = self.client.post(

--- a/myjobs/tests/test_child_dashboard.py
+++ b/myjobs/tests/test_child_dashboard.py
@@ -7,6 +7,14 @@ from myjobs.tests.setup import MyJobsBase
 
 class TestChildDashboard(MyJobsBase):
     def test_child_dastboard(self):
-        resp = self.client.get(reverse('child_dashboard'))
+        url = reverse('child_dashboard')
+        url += "?referer=jobs.directemployers.org"
+        resp = self.client.post(
+            url, {},
+            HTTP_HOST='jobs.directemployers.org',
+            HTTP_ORIGIN='http://jobs.directemployers.org',
+            HTTP_X_REQUESTED_WITH='XMLHttpRequest',
+        )
+        self.assertEqual(200, resp.status_code)
         result = json.loads(resp.content)
         self.assertIn("start_here", result)

--- a/myjobs/tests/test_cross_site_verify.py
+++ b/myjobs/tests/test_cross_site_verify.py
@@ -1,0 +1,322 @@
+import re
+import json
+
+from django.http import HttpResponse
+from django.conf.urls import url
+import django.test
+from django.test.utils import override_settings
+
+import unittest
+
+from seo.models import SeoSite
+from myjobs.cross_site_verify import cross_site_verify, \
+    verify_cross_site_request, DomainRelationshipException, \
+    guess_child_domain, parse_request_meta, XRW, \
+    extract_hostname_from_header
+
+
+class TestRequestParsing(unittest.TestCase):
+    def test_data(self):
+        result = parse_request_meta({
+            'REQUEST_METHOD': 'GET',
+            'HTTP_HOST': 'aa.com',
+            'HTTP_ORIGIN': 'http://bb.com',
+            'HTTP_REFERER': 'http://cc.com/somewhere',
+            'HTTP_X_REQUESTED_WITH': 'ddd',
+            'QUERY_STRING': 'a=b&referer=aa.com&c=d',
+        })
+        expected = ('GET', 'aa.com', 'bb.com', 'cc.com', 'aa.com', 'ddd')
+        self.assertEqual(expected, result)
+
+    def test_none(self):
+        result = parse_request_meta({})
+        self.assertEqual(('', None, None, None, None, None),
+                         result)
+
+    def test_hostname_typical(self):
+        self.assert_hostname_header('aa.com', 'aa.com')
+
+    def test_hostname_no_dot(self):
+        self.assert_hostname_header('aa', 'aa')
+
+    def test_hostname_with_port(self):
+        self.assert_hostname_header('aa.com', 'aa.com:8000')
+
+    def test_hostname_none(self):
+        self.assert_hostname_header(None, None)
+
+    def assert_hostname_header(self, expected, header):
+        self.assertEqual(expected,
+                         extract_hostname_from_header(header))
+
+
+class TestChildDomainGuessing(unittest.TestCase):
+    def test_origin(self):
+        self.assert_domain('aa.com', None, 'aa.com', None, None)
+
+    def test_referer(self):
+        self.assert_domain('aa.com', None, None, 'aa.com', None)
+
+    def test_qsreferer(self):
+        self.assert_domain('aa.com', 'aa.com', None, None, 'aa.com')
+
+    def test_qsreferer_child(self):
+        self.assert_error('qsreferer-not-host', 'z', None, None, 'aa.com')
+
+    def test_qsreferer_host_none(self):
+        self.assert_error('qsreferer-not-host', None, None, None, 'aa.com')
+
+    def test_all_none(self):
+        self.assert_error('no-child-info', None, None, None, None)
+
+    def assert_domain(self, expected, host, origin, referer, qsreferer):
+        try:
+            self.assertEqual(
+                expected,
+                guess_child_domain(host, origin, referer, qsreferer))
+        except DomainRelationshipException as e:
+            message = ('Expected: %s, got error: %s for %r' % (
+                       expected, e,
+                       [host, origin, referer, qsreferer]))
+            self.fail(message)
+
+    def assert_error(self, expected, host, origin, referer, qsreferer):
+        try:
+            result = guess_child_domain(host, origin, referer, qsreferer)
+            message = ('Expected error: %s, got: %s for %r' % (
+                       expected, result,
+                       [host, origin, referer, qsreferer]))
+            self.fail(message)
+        except DomainRelationshipException as e:
+            assert(expected, e.message)
+
+
+class MockSite(object):
+    def __init__(self, id, parent_site=None):
+        self.id = id
+        self.parent_site = parent_site
+
+
+def mock_site_loader(site):
+    aa = MockSite('aa')
+    return {
+        'aa.com': aa,
+        'teach.aa.com': MockSite('aa2', aa),
+        'bb.com': MockSite('bb'),
+    }.get(site)
+
+
+class TestVerifyCrossSite(unittest.TestCase):
+    def test_put(self):
+        self.assert_failure(
+            'method',
+            'PUT',
+            None,
+            None,
+            None,
+            None,
+            None)
+
+    def test_bad_xrw(self):
+        self.assert_failure(
+            'bad-xrw',
+            'POST',
+            'aa.com',
+            'aa.com',
+            None,
+            "z" + XRW,
+            None)
+
+    def test_no_origin_is_parent(self):
+        self.assert_success(
+            'POST',
+            'aa.com',
+            None,
+            None,
+            XRW,
+            'aa.com')
+
+    def test_no_origin_is_parent_qsreferer_mismatch(self):
+        self.assert_failure(
+            'qsreferer-not-host',
+            'POST',
+            'aa.com',
+            None,
+            None,
+            XRW,
+            'bb.com')
+
+    def test_get_origin_is_parent(self):
+        self.assert_success(
+            'POST',
+            'aa.com',
+            'aa.com',
+            None,
+            XRW,
+            None)
+
+    def test_get_host_is_child(self):
+        self.assert_failure(
+            'host-not-parent',
+            'POST',
+            'teach.aa.com',
+            None,
+            None,
+            None,
+            None)
+
+    def test_origin_not_child_of_parent(self):
+        self.assert_failure(
+            'not-child-of-parent',
+            'POST',
+            'bb.com',
+            'teach.aa.com',
+            None,
+            XRW,
+            None)
+
+    def test_origin_is_child_of_parent_no_xrw(self):
+        self.assert_failure(
+            'bad-xrw',
+            'POST',
+            'aa.com',
+            'teach.aa.com',
+            None,
+            None,
+            None)
+
+    def test_origin_is_child_of_parent(self):
+        self.assert_success(
+            'POST',
+            'aa.com',
+            'teach.aa.com',
+            None,
+            XRW,
+            None)
+
+    def test_get_referer_is_missing(self):
+        self.assert_failure(
+            'no-child-info',
+            'GET',
+            'aa.com',
+            None,
+            None,
+            None,
+            None)
+
+    def test_get_referer_is_missing_qsreferer_is_parent(self):
+        self.assert_success(
+            'GET',
+            'aa.com',
+            None,
+            None,
+            None,
+            'aa.com')
+
+    def test_get_referer_is_missing_qsreferer_is_child(self):
+        self.assert_failure(
+            'qsreferer-not-host',
+            'GET',
+            'aa.com',
+            None,
+            None,
+            None,
+            'teach.aa.com')
+
+    def assert_success(self, method, host, origin, referer, xrw,
+                       qsreferer):
+        try:
+            verify_cross_site_request(
+                mock_site_loader,
+                method,
+                host,
+                origin,
+                referer,
+                xrw,
+                qsreferer)
+        except DomainRelationshipException as e:
+            message = ('Expected: ok, got error: %s for %r' % (
+                       e,
+                       [method, host, origin, referer,
+                        xrw, qsreferer]))
+            self.fail(message)
+
+    def assert_failure(self, expected_fail, method, host,
+                       origin, referer, xrw, qsreferer):
+        try:
+            verify_cross_site_request(
+                mock_site_loader,
+                method,
+                host,
+                origin,
+                referer,
+                xrw,
+                qsreferer)
+            message = ('Expected error: %s, got success for %r' % (
+                       expected_fail,
+                       [method, host, origin, referer,
+                        xrw, qsreferer]))
+            self.fail(message)
+        except DomainRelationshipException as e:
+            self.assertEqual(expected_fail, e.message)
+
+
+@cross_site_verify
+def ping(request):
+    return HttpResponse("hello")
+
+
+urlpatterns = [
+    url(r'^ping/$', ping, name='ping'),
+]
+
+
+@override_settings(ROOT_URLCONF=__name__)
+class TestVerifyCrossSiteIntegration(django.test.TestCase):
+    def setUp(self):
+        self.client.cookies['lastmicrosite'] = ''
+        domain = 'jobs.directemployers.org'
+        self.de_site = SeoSite.objects.filter(domain=domain)[0]
+
+        self.aa = self.build_site('AA', 'aa.com', None)
+        self.aa2 = self.build_site('AA', 'teach.aa.com', self.aa)
+        self.bb = self.build_site('BB', 'bb.com', None)
+
+    def build_site(self, name, domain, parent):
+        create = SeoSite.objects.create
+        company = create(name=name, domain=domain,
+                         group=self.de_site.group)
+        if parent is not None:
+            company.parent_site = parent
+        company.save()
+        return company
+
+    def test_get_from_parent(self):
+        resp = self.client.get(
+            "/ping/",
+            HTTP_HOST="aa.com",
+            HTTP_REFERER="http://aa.com",
+            HTTP_X_REQUESTED_WITH="XMLHttpRequest")
+        self.assertEqual(200, resp.status_code)
+
+    def test_post_xhr_from_parent(self):
+        resp = self.client.post(
+            "/ping/", {},
+            HTTP_HOST="aa.com",
+            HTTP_ORIGIN="http://aa.com",
+            HTTP_X_REQUESTED_WITH="XMLHttpRequest")
+        self.assertEqual(200, resp.status_code)
+
+    def test_get_qsreferer(self):
+        resp = self.client.get(
+            "/ping/?referer=aa.com",
+            HTTP_HOST="aa.com")
+        self.assertEqual(200, resp.status_code)
+
+    def test_post_mismatched_child(self):
+        resp = self.client.post(
+            "/ping/", {},
+            HTTP_HOST="aa.com",
+            HTTP_ORIGIN="http://bb.com",
+            HTTP_X_REQUESTED_WITH="XMLHttpRequest")
+        self.assertEqual(404, resp.status_code)


### PR DESCRIPTION
Add a decorator that will allow child sites to call secure parent sites to show blocks that should be secure.

Integrate with stubbed child dashboard call.
