### PR TITLE
Fixed circular imports in order to make generating documenatation a p…

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -19,9 +19,8 @@ import os
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.abspath('../..'))
-os.environ['DJANGO_SETTINGS_MODULE'] = 'myjobs.settings'
-from django.conf import settings
-settings.configure()
+os.environ['DJANGO_SETTINGS_MODULE'] = 'settings'
+import settings
 
 # -- General configuration ------------------------------------------------
 

--- a/doc/source/my_partners.rst
+++ b/doc/source/my_partners.rst
@@ -7,5 +7,6 @@ Overview
 My Partners is a module designed to track recruitment efforts by Partners (client-company employees) toward
 Contacts (prospective employees).
 
-.. automodule:: myjobs.mypartners.models
+.. automodule:: mypartners.models
+    :members:
 

--- a/mysearches/models.py
+++ b/mysearches/models.py
@@ -10,7 +10,6 @@ from django.utils.translation import ugettext_lazy as _
 from django.template.loader import render_to_string
 import uuid
 
-from myjobs.models import User
 from mypartners.models import Contact, ContactRecord, Partner, EMAIL
 from mysearches.helpers import (parse_feed, update_url_if_protected,
                                 url_sort_options, validate_dotjobs_url)
@@ -546,7 +545,7 @@ class PartnerSavedSearch(SavedSearch):
                               "of this saved search.")
     unsubscribed = models.BooleanField(default=False)
     tags = models.ManyToManyField('mypartners.Tag', null=True)
-    created_by = models.ForeignKey(User, editable=False,
+    created_by = models.ForeignKey("myjobs.User", editable=False,
                                    related_name='created_by',
                                    on_delete=models.SET_NULL,
                                    null=True)
@@ -628,7 +627,7 @@ class SavedSearchLog(models.Model):
                                        "SendGrid may not have responded yet - "
                                        "give it a few minutes."))
     reason = models.TextField()
-    recipient = models.ForeignKey(User, on_delete=models.SET_NULL, null=True)
+    recipient = models.ForeignKey("myjobs.User", on_delete=models.SET_NULL, null=True)
     recipient_email = models.EmailField(max_length=255, blank=False)
     new_jobs = models.IntegerField()
     backfill_jobs = models.IntegerField()

--- a/solr/signals.py
+++ b/solr/signals.py
@@ -1,15 +1,17 @@
 import logging
 
 from django.contrib.contenttypes.models import ContentType
+from django.db.models.loading import get_model
 from django.db.models.signals import post_save, post_delete, pre_save
 
-from myjobs.models import User
 from myprofile.models import ProfileUnits
-from mysearches.models import SavedSearch
 from solr.models import Update
 
 logging.basicConfig()
 logger = logging.getLogger(__name__)
+
+User = get_model("myjobs", "User")
+SavedSearch = get_model("mysearches", "SavedSearch")
 
 
 def presave_solr(sender, instance, *args, **kwargs):


### PR DESCRIPTION
- The django settings machinery wasn't working properly in this environment, so I hacked the existing hack and just import our settings directly
- myjobs (the directory) is not a package, so I removed it from the import statement
- added `:members:` just so you can see stuff being automatically generated
- replaced explicit module usage with strings where possible, and get_model otherwise