### PR TITLE
[PD-1780] Update company search filter logic

### DIFF
--- a/seo/helpers.py
+++ b/seo/helpers.py
@@ -1443,6 +1443,12 @@ def jobs_and_counts(request, filters, num_jobs, fl=search_fields):
 
 
 def get_company_data(filters):
+    '''
+    Return the thumbnail for a company if it exists. Returns None if company does
+    not have a thumbnail.
+    :param filters: dictionary of filters from search
+    :return: Company thumbnails, if exist, otherwise None
+    '''
     if filters['company_slug']:
         company_obj = Company.objects.filter(member=True)
         company_obj = company_obj.filter(company_slug=filters['company_slug'])

--- a/seo/helpers.py
+++ b/seo/helpers.py
@@ -1443,12 +1443,10 @@ def jobs_and_counts(request, filters, num_jobs, fl=search_fields):
 
 
 def get_company_data(filters):
-    '''
-    Return the thumbnail for a company if it exists. Returns None if company does
-    not have a thumbnail.
-    :param filters: dictionary of filters from search
-    :return: Company thumbnails, if exist, otherwise None
-    '''
+    """
+        Return the thumbnail for a company if it exists. Returns None if company does
+        not have a thumbnail.
+    """
     if filters['company_slug']:
         company_obj = Company.objects.filter(member=True)
         company_obj = company_obj.filter(company_slug=filters['company_slug'])

--- a/seo/tests/test_views.py
+++ b/seo/tests/test_views.py
@@ -2387,30 +2387,6 @@ class SeoViewsTestCase(DirectSEOTestCase):
         """
         resp = self.client.post("/ajax/data/sites?tag=Fake%20Tag")
         self.assertEqual(resp.status_code, 200)
-    
-    def test_valid_company_200(self):
-        """
-            Verify that a valid company search string returns a 200
-        """
-        new_company = factories.CompanyFactory()
-        resp = self.client.get("/%s/careers/" % new_company.company_slug)
-        self.assertEqual(resp.status_code, 200)
-        
-    def test_invalid_company_404(self):
-        """
-            Verify that invalid companies will return a 404 error
-        """
-        resp = self.client.get("/aslkdjas/careers/")
-        self.assertEqual(resp.status_code, 404)
-
-    def test_invalid_moc_404(self):
-        """
-            Verify that invalid moc url values will return a 404 error
-        """
-        resp = self.client.get("/a/fake/moc/vet-jobs/")
-        self.assertEqual(resp.status_code, 404)
-        resp = self.client.get("/fake/moc/vet-jobs/")
-        self.assertEqual(resp.status_code, 404)
 
     def test_moc_duplicate_search(self):
         """Search by non-unique moc should return all matching jobs."""
@@ -2787,6 +2763,69 @@ class StaticPageOverrideTests(DirectSEOBase):
         #self.assertEqual(response['Location'], redirect.new_path)
         pass
         # TODO: Reimplement test with qs redirects
+
+class FilterTestCase404(DirectSEOTestCase):
+    def setUp(self):
+        super(FilterTestCase404, self).setUp()
+        self.job = solr_settings.SOLR_FIXTURE[1]
+        self.conn.add([self.job])
+
+        self.site = SeoSite.objects.get()
+        self.buid = BusinessUnit.objects.get_or_create(pk=self.job['buid'])
+        self.site.business_units.add(self.job['buid'])
+        self.site.save()
+
+        self.config = Configuration.objects.get(status=2)
+        self.config.home_page_template = 'home_page/home_page_listing.html'
+        self.config.footer = ''
+        self.config.save()
+
+    def tearDown(self):
+        self.conn.delete(q='*:*')
+        super(FilterTestCase404, self).tearDown()
+
+    def test_valid_company_200(self):
+        """
+            Verify that a valid company search string returns a 200
+        """
+
+        new_company = factories.CompanyFactory()
+        resp = self.client.get("/%s/careers/" % new_company.company_slug,
+                               HTTP_HOST=self.site.domain)
+        self.assertEqual(resp.status_code, 200)
+
+    def test_invalid_company_behavior(self):
+        """
+            Verify that invalid companies will return a 404 error if they have no jobs,
+            200 if they have jobs
+        """
+        company_from_job = Company.objects.filter(name__iexact=self.job['company'])
+        if company_from_job:
+            slug_value = company_from_job[0].company_slug
+            company_from_job.delete() #make sure company doesn't exist in DB
+        else:
+            slug_value = self.job['company'].lower()
+
+        resp = self.client.get("/%s/careers/" % slug_value,
+                               HTTP_HOST=self.site.domain)
+        self.assertEqual(resp.status_code, 200) #make sure 200 returned if jobs exist
+
+        self.conn.delete(q='*:*') #delete job that was created
+
+        resp = self.client.get("/%s/careers/" % slug_value,
+                               HTTP_HOST=self.site.domain)
+        self.assertEqual(resp.status_code, 404) #make sure 404 returned if jobs don't exist
+
+    def test_invalid_moc_404(self):
+        """
+            Verify that invalid moc url values will return a 404 error
+        """
+        resp = self.client.get("/a/fake/moc/vet-jobs/",
+                               HTTP_HOST=self.site.domain)
+        self.assertEqual(resp.status_code, 404)
+        resp = self.client.get("/fake/moc/vet-jobs/",
+                               HTTP_HOST=self.site.domain)
+        self.assertEqual(resp.status_code, 404)
 
 
 class DubaiTests(DirectSEOTestCase):

--- a/seo/tests/test_views.py
+++ b/seo/tests/test_views.py
@@ -2765,6 +2765,9 @@ class StaticPageOverrideTests(DirectSEOBase):
         # TODO: Reimplement test with qs redirects
 
 class FilterTestCase404(DirectSEOTestCase):
+    """
+        Test cases involved in the search filter slugs. Ensure 404 returned under proper conditions.
+    """
     def setUp(self):
         super(FilterTestCase404, self).setUp()
         self.job = solr_settings.SOLR_FIXTURE[1]

--- a/seo/views/search_views.py
+++ b/seo/views/search_views.py
@@ -1713,15 +1713,15 @@ def search_by_results_and_slugs(request, *args, **kwargs):
     sitecommit_str = helpers.make_specialcommit_string(settings.COMMITMENTS.all())
     site_config = get_site_config(request)
     num_jobs = int(site_config.num_job_items_to_show) * 2
-    
-    custom_facet_counts = []
-    facet_slugs = []
-    active_facets = []
 
     if filters['moc_slug']:
         moc = helpers.pull_moc_object_via_slug(filters['moc_slug'])
         if not moc:
             raise Http404("No MOC object found for url input %s" % filters['moc_slug'])
+
+    custom_facet_counts = []
+    facet_slugs = []
+    active_facets = []
 
     if site_config.browse_facet_show:
         cf_count_tup = get_custom_facets(request, filters=filters,


### PR DESCRIPTION
### Issues Fixed:
* Company filtering used incorrect method for determining if company exists
   * Company filtering now checks the model itself for existence and not a separate function
* Company filtering was returning 404 for companies that had jobs (but did not exist in DB)
   * Company filtering now only returns a 404 if company does not exist in DB and has no jobs
* Function call had ambiguous name
   * Added comment to function call to prevent future misunderstandings

_Tests updated to verify new logic._