### PR TITLE
[PD-1791] Resolve some circular imports

### DIFF
--- a/mypartners/forms.py
+++ b/mypartners/forms.py
@@ -331,19 +331,6 @@ class PartnerForm(NormalizedModelForm):
         return instance
 
 
-def PartnerEmailChoices(partner):
-    choices = [(None, '----------')]
-    contacts = Contact.objects.filter(
-        partner=partner, archived_on__isnull=True)
-    for contact in contacts:
-        if contact.user:
-            choices.append((contact.user.email, contact))
-        else:
-            if contact.email:
-                choices.append((contact.email, contact))
-    return choices
-
-
 class ContactRecordForm(NormalizedModelForm):
     date_time = SplitDateTimeDropDownField(label='Date & Time')
     length = TimeDropDownField()

--- a/mypartners/models.py
+++ b/mypartners/models.py
@@ -14,7 +14,6 @@ from django.db import models
 from django.db.models.signals import pre_delete, pre_save, post_save
 from django.dispatch import receiver
 
-from myjobs.models import User
 from postajob.location_data import states
 from universal.helpers import json_to_query
 
@@ -171,7 +170,7 @@ class Contact(models.Model):
     object there is Contact.partner_set and .partners_set
 
     """
-    user = models.ForeignKey(User, blank=True, null=True,
+    user = models.ForeignKey('myjobs.User', blank=True, null=True,
                              on_delete=models.SET_NULL)
     partner = models.ForeignKey('Partner', 
                                 null=True, on_delete=models.SET_NULL)
@@ -207,23 +206,6 @@ class Contact(models.Model):
         return 'Contact object'
 
     natural_key = __unicode__
-
-    def save(self, *args, **kwargs):
-        """
-        Checks to see if there is a User that is using self.email add said User
-        to self.user
-
-        """
-        if not self.user:
-            if self.email:
-                try:
-                    user = User.objects.get(email=self.email)
-                except User.DoesNotExist:
-                    pass
-                else:
-                    self.user = user
-
-        return super(Contact, self).save(*args, **kwargs)
 
     def delete(self, *args, **kwargs):
         pre_delete.send(sender=Contact, instance=self, using='default')
@@ -563,7 +545,7 @@ class ContactRecord(models.Model):
     objects = ContactRecordManager()
 
     created_on = models.DateTimeField(auto_now_add=True)
-    created_by = models.ForeignKey(User, null=True, on_delete=models.SET_NULL)
+    created_by = models.ForeignKey('myjobs.User', null=True, on_delete=models.SET_NULL)
     partner = models.ForeignKey(Partner, null=True, on_delete=models.SET_NULL)
     contact = models.ForeignKey(Contact, null=True, on_delete=models.SET_NULL)
     contact_type = models.CharField(choices=CONTACT_TYPE_CHOICES,
@@ -757,7 +739,7 @@ class ContactLogEntry(models.Model):
     object_id = models.TextField('object id', blank=True, null=True)
     object_repr = models.CharField('object repr', max_length=200)
     partner = models.ForeignKey(Partner, null=True, on_delete=models.SET_NULL)
-    user = models.ForeignKey(User, null=True, on_delete=models.SET_NULL)
+    user = models.ForeignKey('myjobs.User', null=True, on_delete=models.SET_NULL)
     successful = models.NullBooleanField(default=None)
 
     def get_edited_object(self):
@@ -799,7 +781,7 @@ class Tag(models.Model):
     company = models.ForeignKey('seo.Company')
 
     created_on = models.DateTimeField(auto_now_add=True)
-    created_by = models.ForeignKey(User, null=True, on_delete=models.SET_NULL)
+    created_by = models.ForeignKey('myjobs.User', null=True, on_delete=models.SET_NULL)
 
     objects = SearchParameterManager()
 

--- a/mysearches/tests/test_forms.py
+++ b/mysearches/tests/test_forms.py
@@ -137,6 +137,37 @@ class PartnerSavedSearchFormTests(MyJobsBase):
         contact = Contact.objects.get(pk=self.contact.pk)
         self.assertEqual(invitation.invitee, contact.user)
 
+    def test_user_only_linked_to_contact_after_pss_created(self):
+        """
+        A contact who's email so happens to coincide with an existing user's
+        should not be attached to that user until after a partner saved search
+        is created for it.
+        """
+
+        # we don't have a saved search, so the contact shouldn't be associated
+        # with a user
+        contact = ContactFactory(user=None,
+                                 email="some_random_contact@gmail.com",
+                                 partner=self.partner)
+        user = UserFactory(email=contact.email)
+        self.assertFalse(contact.user)
+        self.partner_search_data['email'] = contact.email
+        form = PartnerSavedSearchForm(partner=self.partner,
+                                      data=self.partner_search_data,
+                                      request=self.request)
+
+        instance = form.instance
+        instance.provider = self.company
+        instance.partner = self.partner
+        instance.created_by = self.user
+        instance.custom_message = instance.partner_message
+        self.assertTrue(form.is_valid())
+        form.save()
+        # after the saved search was created, the user should have been
+        # associated automatically
+        contact = Contact.objects.get(id=contact.id)
+        self.assertTrue(contact.user)
+
     def test_initial_email_has_unsubscription_options(self):
         """
         The initial email received for a partner saved search should have an


### PR DESCRIPTION
# Rationale
Attempting to use any third-party tools (sphinx, pytest, or even [this code snippet](https://gist.github.com/aspidites/c9ee5e4e4c0ad5dacaa8) results in a circular import error. This PR attempts to do the minimum amount of work possible to resolve the circular import without disrupting the rest of the ecosystem or resorting to hacks.

# Changes
- I moved `PartnerEmailChoices` from `mypartners.forms` to `mysearches.forms` as `partner_email_choices`
-- it is only used in mysearches.forms
-- I needed to use the User model, which is already imported in `mysearches.forms`, but not `mypartners.forms`
- I moved the logic in `mypartners.models` which attaches a user to a contact on save
-- Unless I misunderstand why we were doing so, we only care if a user with an email exists when modifying contact, as the email becomes read only in that case. Further, we only automatically create users when partner saved searches are created
-- As the code was only executed on save, a user created after a contact would not show a read-only email address, as the user didn't exist on time of save of that contact; subsequent saves of that contact, however, would then mark the email as read-only since the user would exist and thus be created on that subsequent save
- All references to `User` in `mypartners.model` were replaced with `"myjobs.User"` and the import of `User` was removed.

I'm relying on jenkins to run tests, as I'm not currently able to run the entire suite. 

~~# Feedback~~
~~I'm especially curious as to if my assumptions about the `Contact.save` functionality are misguided, as that single assumption is what makes this PR possible.~~

Spoke with Jason S. The only time a user should be attached to a contact is if a partner saved search is created. Originally, when a partner saved search is created a new account is created as well. The intended behavior here is that if a user already exists, that one should be associated with the contact. On the other hand, if a contact is created using an email that happens to belong to a user, that user should NOT be associated with the contact UNLESS a partner saved search is created for that contact.

# Updated Changes
- ~~I rationalized (please correct me if I'm wrong) that if a contact was attached to a user, that user's email would be the same as the contact's email, so there was no need to iterate and attach the user's email instead of the contact's email as they wouldn't differ. Once a user is associated with a contact, that contact can't change their email anyway~~
- ~~I attached the user to the contact only when the form is saved to avoid the case where a user is attached to a contact merely because a partner starts creating a saved search for that contact. I suspect that if the saved search isn't created, the association shouldn't happen.~~
- ~~PartnerEmailChoices has been reduced to a comprehension that has been inlined.~~

Apparently some other voodoo happens with how we make the contact choices and such, because when I made the changes above, tests about the initial email started failing. Rather than waste time investigating that, I decided to compromise with at least knowing that the user isn't associated with the contact in all cases.