### PR TITLE
[PD-1667] blocks admin - overview/dashboard page

### DIFF
--- a/seo/urls/search_urls.py
+++ b/seo/urls/search_urls.py
@@ -130,6 +130,8 @@ urlpatterns += patterns('seo.views.search_views',
         name='manage_header_footer'),
     url(r'^dashboard/events/manage-templates/$', 'manage_templates',
         name='manage_templates'),
+    # Dashboard - Blocks Manager/Admin
+    url(r'dashboard/blocks/$', 'blocks_overview', name='blocks_overview'),
 
     # SEO Pages
     url(r'^network/states/$', 'seo_states'),

--- a/seo/views/search_views.py
+++ b/seo/views/search_views.py
@@ -2080,6 +2080,17 @@ def manage_templates(request):
                               context_instance=RequestContext(request))
 
 
+@user_is_allowed()
+def blocks_overview(request):
+    company = get_company_or_404(request)
+
+    data_dict = {}
+
+    return render_to_response('seo/dashboard/blocks/blocks_overview.html',
+                              data_dict,
+                              context_instance=RequestContext(request))
+
+
 def seo_states(request):
     # Pull jobs from solr, only in the US and group by states.
     search = DESearchQuerySet().narrow('country:United States').facet('state')

--- a/seo/views/search_views.py
+++ b/seo/views/search_views.py
@@ -64,6 +64,7 @@ from universal.states import states_with_sites
 from universal.helpers import get_company_or_404
 from myjobs.decorators import user_is_allowed
 from myemails.models import EmailTemplate, EmailSection
+from myblocks.models import Page
 
 """
 The 'filters' dictionary seen in some of these methods
@@ -2084,7 +2085,13 @@ def manage_templates(request):
 def blocks_overview(request):
     company = get_company_or_404(request)
 
-    data_dict = {}
+    # grab SeoSites associated to company
+    sites = company.get_seo_sites()
+
+    # retrieve pages for any site in sites list
+    pages = Page.objects.filter(sites__in=sites)
+
+    data_dict = {'pages': pages}
 
     return render_to_response('seo/dashboard/blocks/blocks_overview.html',
                               data_dict,

--- a/templates/seo/dashboard/blocks/blocks_base.html
+++ b/templates/seo/dashboard/blocks/blocks_base.html
@@ -1,0 +1,6 @@
+{% extends "seo/dashboard/dashboard_base.html" %}
+
+{% block css %}
+    {{ block.super }}
+    <link href="{{ STATIC_URL }}seo/dashboard/event-emails.168-09.css" rel="stylesheet">
+{% endblock css %}

--- a/templates/seo/dashboard/blocks/blocks_overview.html
+++ b/templates/seo/dashboard/blocks/blocks_overview.html
@@ -4,7 +4,37 @@
 {% include "seo/dashboard/blocks/includes/header.html" %}
 <div class="row">
     <div class="col-md-12">
-        <a class="btn btn-default" href="#">Edit Blocks</a>
+        <h3>Pages</h3>
+        <a class="awrap" href="#">
+            <div class="add-row">
+                <i class="fa fa-plus-circle green"></i><span class="cta">Create a page</span>
+            </div>
+        </a>
+        <table class="table table-striped">
+            {% for page in pages %}
+            <tr>
+                <td>
+                    {{ page }}
+                </td>
+                <td>
+                    <a class="btn btn-default" href="">
+                        <i class="fa fa-eye"></i>
+                        Preview
+                    </a>
+                    <a class="btn btn-default" href="">
+                        <i class="fa fa-pencil"></i>
+                        Edit
+                    </a>
+                </td>
+            </tr>
+            {% empty %}
+            <tr>
+                <td>
+                    Currently there are no pages created for this company.
+                </td>
+            </tr>
+            {% endfor %}
+        </table>
     </div>
 </div>
 {% endblock content %}

--- a/templates/seo/dashboard/blocks/blocks_overview.html
+++ b/templates/seo/dashboard/blocks/blocks_overview.html
@@ -1,0 +1,10 @@
+{% extends "seo/dashboard/blocks/blocks_base.html" %}
+
+{% block content %}
+{% include "seo/dashboard/blocks/includes/header.html" %}
+<div class="row">
+    <div class="col-md-12">
+        <a class="btn btn-default" href="#">Edit Blocks</a>
+    </div>
+</div>
+{% endblock content %}

--- a/templates/seo/dashboard/blocks/blocks_overview.html
+++ b/templates/seo/dashboard/blocks/blocks_overview.html
@@ -17,11 +17,11 @@
                     {{ page }}
                 </td>
                 <td>
-                    <a class="btn btn-default" href="">
+                    <a class="btn btn-default" href="#">
                         <i class="fa fa-eye"></i>
                         Preview
                     </a>
-                    <a class="btn btn-default" href="">
+                    <a class="btn btn-default" href="#">
                         <i class="fa fa-pencil"></i>
                         Edit
                     </a>

--- a/templates/seo/dashboard/blocks/includes/header.html
+++ b/templates/seo/dashboard/blocks/includes/header.html
@@ -1,0 +1,3 @@
+<h1>
+    Blocks Admin
+</h1>

--- a/templates/seo/dashboard/dashboard_base.html
+++ b/templates/seo/dashboard/dashboard_base.html
@@ -34,7 +34,7 @@
                         <a href="{% url 'event_overview' %}">Event Manager</a>
                     </li>
                     <li>
-                        <a href="">Blocks Admin</a>
+                        <a href="{% url 'blocks_overview' %}">Blocks Admin</a>
                     </li>
                 </ul>
             </div>


### PR DESCRIPTION
Dashboard overview page that features the Page object.

Displays any Page objects associated by company's SeoSites. 
Ex: phillip66.jobs -> phillip66 (company) -> all phillip66.jobs sites (not just canonical site) Pages

For each page there is a preview button and edit button. If there are no pages a message is displayed accordingly.

No real functionality, no buttons or links go anywhere.