### PR TITLE
Call child dashboard from microsites [PD-1625]

### DIFF
--- a/dseo_urls.py
+++ b/dseo_urls.py
@@ -122,3 +122,7 @@ urlpatterns += patterns(
     url(r'^message/', include('mymessages.urls'))
 )
 
+urlpatterns += patterns(
+    'myjobs.child_dashboard',
+    url(r'^child-dashboard/$', 'child_dashboard', name='child_dashboard'),
+)

--- a/myjobs/child_dashboard.py
+++ b/myjobs/child_dashboard.py
@@ -1,9 +1,12 @@
-from django.http import HttpResponse
+from django.views.decorators.csrf import (
+    csrf_exempt as django_csrf_exempt)
 
 from myjobs.autoserialize import autoserialize
 from myjobs.cross_site_verify import cross_site_verify
 
 
+# The django csrf exemption should stay first in this list.
+@django_csrf_exempt
 @cross_site_verify
 @autoserialize
 def child_dashboard(request):

--- a/seo/cache.py
+++ b/seo/cache.py
@@ -139,13 +139,14 @@ def get_site_config(request):
                 site_config = Configuration.objects.get(id=2)
         cache.set(config_cache_key, site_config, timeout)
     return site_config
-    
-def get_domain_parent(request):
+
+
+def get_secure_blocks_site(request):
     """"
-        Returns the parent site for the currently selected domain (if exists)
-        
+        Returns the secure blocks site for the current site
+
         Returns:
-        - SeoSite object or None
+        - SeoSite object or None if we can't figure out the current site.
     """
     if request.user.is_staff and 'domain' in request.REQUEST:
         # filter() + first() will return None rather than raising an exception
@@ -155,9 +156,11 @@ def get_domain_parent(request):
         # SITE might not be set on the settings object
         site = getattr(settings, 'SITE', None)
 
+    # We can't figure out the current site. Give up.
     if site is None:
         return None
 
+    # Return parent if there is one. This site, otherwise.
     parent_site = getattr(site, 'parent_site', None)
     if parent_site is None:
         return site

--- a/seo/cache.py
+++ b/seo/cache.py
@@ -160,6 +160,6 @@ def get_domain_parent(request):
 
     parent_site = getattr(site, 'parent_site', None)
     if parent_site is None:
-        return site.domain
+        return site
     else:
         return parent_site

--- a/seo/cache.py
+++ b/seo/cache.py
@@ -155,4 +155,11 @@ def get_domain_parent(request):
         # SITE might not be set on the settings object
         site = getattr(settings, 'SITE', None)
 
-    return getattr(site, 'parent_site', None)
+    if site is None:
+        return None
+
+    parent_site = getattr(site, 'parent_site', None)
+    if parent_site is None:
+        return site.domain
+    else:
+        return parent_site

--- a/seo/context_processors.py
+++ b/seo/context_processors.py
@@ -1,6 +1,6 @@
-from seo.cache import get_site_config, get_domain_parent
+from seo.cache import get_site_config, get_secure_blocks_site
 
 
 def site_config_context(request):
     return {'site_config': get_site_config(request),
-            'domain_parent': get_domain_parent(request)}
+            'secure_blocks_domain': get_secure_blocks_site(request)}

--- a/seo/tests/test_context_processor.py
+++ b/seo/tests/test_context_processor.py
@@ -73,6 +73,15 @@ class SiteTestCase(DirectSEOBase):
         resp = self.client.get("/")
         self.assertEqual(resp.context['domain_parent'],parent_site) 
 
+    def test_parent_domain_context_variable_visit_parent_site(self):
+        child_site = factories.SeoSiteFactory()
+        child_site.domain = "zz." + child_site.domain
+        child_site.parent_site = self.site
+        self.site.save()
+        resp = self.client.get("/")
+        self.assertEqual(resp.context['domain_parent'],
+                         self.site.domain)
+
     def test_parent_domain_context_variable_with_domain_switching(self):
         self.setup_superuser()
         parent_site = factories.SeoSiteFactory()

--- a/seo/tests/test_context_processor.py
+++ b/seo/tests/test_context_processor.py
@@ -80,7 +80,7 @@ class SiteTestCase(DirectSEOBase):
         self.site.save()
         resp = self.client.get("/")
         self.assertEqual(resp.context['domain_parent'],
-                         self.site.domain)
+                         self.site)
 
     def test_parent_domain_context_variable_with_domain_switching(self):
         self.setup_superuser()

--- a/seo/tests/test_context_processor.py
+++ b/seo/tests/test_context_processor.py
@@ -71,7 +71,7 @@ class SiteTestCase(DirectSEOBase):
         self.site.parent_site = parent_site
         self.site.save()
         resp = self.client.get("/")
-        self.assertEqual(resp.context['domain_parent'],parent_site) 
+        self.assertEqual(resp.context['secure_blocks_domain'], parent_site)
 
     def test_parent_domain_context_variable_visit_parent_site(self):
         child_site = factories.SeoSiteFactory()
@@ -79,7 +79,7 @@ class SiteTestCase(DirectSEOBase):
         child_site.parent_site = self.site
         self.site.save()
         resp = self.client.get("/")
-        self.assertEqual(resp.context['domain_parent'],
+        self.assertEqual(resp.context['secure_blocks_domain'],
                          self.site)
 
     def test_parent_domain_context_variable_with_domain_switching(self):
@@ -90,4 +90,4 @@ class SiteTestCase(DirectSEOBase):
         child_site.domain="parentchildtest"
         child_site.save()
         resp = self.client.get("/?domain=parentchildtest")
-        self.assertEqual(resp.context['domain_parent'],parent_site)
+        self.assertEqual(resp.context['secure_blocks_domain'], parent_site)

--- a/static/dashboard.100-10.js
+++ b/static/dashboard.100-10.js
@@ -1,0 +1,50 @@
+
+function read_cookie(cookie) {
+    var nameEQ = cookie + "=",
+        ca = document.cookie.split(';');
+    for (var i=0; i< ca.length; i++) {
+        var c = ca[i];
+        while (c.charAt(0) === ' ')
+            c = c.substring(1, c.length);
+        if (c.indexOf(nameEQ) === 0)
+            return c.substring(nameEQ.length, c.length);
+    }
+    return null;
+}
+
+function dashboard(dashboard_url) {
+  // need to explicitly marshal the result data into this deferred
+  // because we are on old jQuery.
+  var result = $.Deferred();
+  $.ajax({
+    type: "OPTIONS",
+    crossDomain: true,
+  }).then(function(data, textStatus, xhr) {
+    xhr_dashboard(dashboard_url).then(result.resolve, result.reject);
+  }, function(xhr, textStatus, error) {
+    jsonp_dashboard(dashboard_url).then(result.resolve, result.reject);
+  });
+  return result.promise();
+}
+
+function xhr_dashboard(dashboard_url) {
+  var csrftoken = read_cookie("csrftoken");
+  return $.ajax({
+    url: dashboard_url,
+    type: "POST",
+    headers: {'X-Requested-With': 'XMLHttpRequest'},
+    data: {csrfmiddlewaretoken: csrftoken},
+    xhrFields: {
+      withCredentials: true
+    },
+  });
+}
+
+function jsonp_dashboard(dashboard_url) {
+  return $.ajax({
+    url: dashboard_url,
+    type: "GET",
+    dataType: "jsonp",
+  });
+}
+

--- a/static/dashboard.100-10.js
+++ b/static/dashboard.100-10.js
@@ -19,10 +19,14 @@ function dashboard(dashboard_url) {
   $.ajax({
     type: "OPTIONS",
     crossDomain: true,
-  }).then(function(data, textStatus, xhr) {
-    xhr_dashboard(dashboard_url).then(result.resolve, result.reject);
-  }, function(xhr, textStatus, error) {
-    jsonp_dashboard(dashboard_url).then(result.resolve, result.reject);
+  }).done(function(data, textStatus, xhr) {
+    xhr_dashboard(dashboard_url).
+        done(result.resolve).
+        fail(result.reject);
+  }).fail(function(xhr, textStatus, error) {
+    jsonp_dashboard(dashboard_url).
+        done(result.resolve).
+        fail(result.reject);
   });
   return result.promise();
 }

--- a/static/secure-block.168-30.js
+++ b/static/secure-block.168-30.js
@@ -12,7 +12,7 @@ function read_cookie(cookie) {
     return null;
 }
 
-function dashboard(dashboard_url) {
+function secure_block(secure_block_url) {
   // need to explicitly marshal the result data into this deferred
   // because we are on old jQuery.
   var result = $.Deferred();
@@ -20,21 +20,21 @@ function dashboard(dashboard_url) {
     type: "OPTIONS",
     crossDomain: true,
   }).done(function(data, textStatus, xhr) {
-    xhr_dashboard(dashboard_url).
+    xhr_secure_block(secure_block_url).
         done(result.resolve).
         fail(result.reject);
   }).fail(function(xhr, textStatus, error) {
-    jsonp_dashboard(dashboard_url).
+    jsonp_secure_block(secure_block_url).
         done(result.resolve).
         fail(result.reject);
   });
   return result.promise();
 }
 
-function xhr_dashboard(dashboard_url) {
+function xhr_secure_block(secure_block_url) {
   var csrftoken = read_cookie("csrftoken");
   return $.ajax({
-    url: dashboard_url,
+    url: secure_block_url,
     type: "POST",
     headers: {'X-Requested-With': 'XMLHttpRequest'},
     data: {csrfmiddlewaretoken: csrftoken},
@@ -44,9 +44,9 @@ function xhr_dashboard(dashboard_url) {
   });
 }
 
-function jsonp_dashboard(dashboard_url) {
+function jsonp_secure_block(secure_block_url) {
   return $.ajax({
-    url: dashboard_url,
+    url: secure_block_url,
     type: "GET",
     dataType: "jsonp",
   });

--- a/static/secure-block.168-30.js
+++ b/static/secure-block.168-30.js
@@ -32,12 +32,11 @@ function secure_block(secure_block_url) {
 }
 
 function xhr_secure_block(secure_block_url) {
-  var csrftoken = read_cookie("csrftoken");
   return $.ajax({
     url: secure_block_url,
     type: "POST",
     headers: {'X-Requested-With': 'XMLHttpRequest'},
-    data: {csrfmiddlewaretoken: csrftoken},
+    data: {},
     xhrFields: {
       withCredentials: true
     },

--- a/templates/seo_base.html
+++ b/templates/seo_base.html
@@ -37,7 +37,7 @@
     <script type="text/javascript">
       var pager_num_items = {{ site_config.num_subnav_items_to_show }};
       $(document).on("ready", function() {
-        var secuire_block_url = "https://{{ domain_parent }}/child-dashboard/";
+        var secuire_block_url = "https://{{ secure_blocks_domain }}/child-dashboard/";
 
         secure_block(secuire_block_url).fail(function(xhr, text, error) {
           console.error("secure block fail: ", xhr, text, error);

--- a/templates/seo_base.html
+++ b/templates/seo_base.html
@@ -33,23 +33,18 @@
     </style>
 
     <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
+    <script src="{{ STATIC_URL }}dashboard.100-10.js" type="text/javascript"></script>
     <script type="text/javascript">
       var pager_num_items = {{ site_config.num_subnav_items_to_show }};
-      {% if domain_parent %}
       $(document).on("ready", function() {
-        // determine whether or not we should use CORS or JSONP
-        $.ajax({
-          type: "OPTIONS",
-          crossDomain: true
-        }).fail(function(xhr, textStatus, error) {
-          // Do JSONP
-          console.log("jsonp");
-        }).done(function() {
-          // Do CORS-enabled AJAX
-          console.log("cors");
+        var dashboard_url = ABSOLUTE_URL + "child-dashboard/";
+
+        dashboard(dashboard_url).fail(function(xhr, text, error) {
+          console.error("dashboard fail: ", xhr, text, error);
+        }).done(function(data, text, xhr) {
+          console.log("dashboard success: ", data, text, xhr);
         });
       });
-      {% endif %}
     </script>
 
     <script type="text/javascript" src="{{ STATIC_URL }}pager.164-21.js"></script>

--- a/templates/seo_base.html
+++ b/templates/seo_base.html
@@ -37,9 +37,9 @@
     <script type="text/javascript">
       var pager_num_items = {{ site_config.num_subnav_items_to_show }};
       $(document).on("ready", function() {
-        var secuire_block_url = "https://{{ secure_blocks_domain }}/child-dashboard/";
+        var secure_block_url = "https://{{ secure_blocks_domain }}/child-dashboard/";
 
-        secure_block(secuire_block_url).fail(function(xhr, text, error) {
+        secure_block(secure_block_url).fail(function(xhr, text, error) {
           console.error("secure block fail: ", xhr, text, error);
         }).done(function(data, text, xhr) {
           console.log("secure block success: ", data, text, xhr);

--- a/templates/seo_base.html
+++ b/templates/seo_base.html
@@ -37,7 +37,7 @@
     <script type="text/javascript">
       var pager_num_items = {{ site_config.num_subnav_items_to_show }};
       $(document).on("ready", function() {
-        var dashboard_url = "http://{{ domain_parent }}/child-dashboard/";
+        var dashboard_url = "https://{{ domain_parent }}/child-dashboard/";
 
         dashboard(dashboard_url).fail(function(xhr, text, error) {
           console.error("dashboard fail: ", xhr, text, error);

--- a/templates/seo_base.html
+++ b/templates/seo_base.html
@@ -33,16 +33,16 @@
     </style>
 
     <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
-    <script src="{{ STATIC_URL }}dashboard.100-10.js" type="text/javascript"></script>
+    <script src="{{ STATIC_URL }}secure-block.168-30.js" type="text/javascript"></script>
     <script type="text/javascript">
       var pager_num_items = {{ site_config.num_subnav_items_to_show }};
       $(document).on("ready", function() {
-        var dashboard_url = "https://{{ domain_parent }}/child-dashboard/";
+        var secuire_block_url = "https://{{ domain_parent }}/child-dashboard/";
 
-        dashboard(dashboard_url).fail(function(xhr, text, error) {
-          console.error("dashboard fail: ", xhr, text, error);
+        secure_block(secuire_block_url).fail(function(xhr, text, error) {
+          console.error("secure block fail: ", xhr, text, error);
         }).done(function(data, text, xhr) {
-          console.log("dashboard success: ", data, text, xhr);
+          console.log("secure block success: ", data, text, xhr);
         });
       });
     </script>

--- a/templates/seo_base.html
+++ b/templates/seo_base.html
@@ -37,7 +37,7 @@
     <script type="text/javascript">
       var pager_num_items = {{ site_config.num_subnav_items_to_show }};
       $(document).on("ready", function() {
-        var dashboard_url = ABSOLUTE_URL + "child-dashboard/";
+        var dashboard_url = "http://{{ domain_parent }}/child-dashboard/";
 
         dashboard(dashboard_url).fail(function(xhr, text, error) {
           console.error("dashboard fail: ", xhr, text, error);


### PR DESCRIPTION
* Put child dashboard endpoint on microsites in addition to secure.
* Plumb in the rest of the client code for calling the correct microsite.
* Lots of hand testing in a browser to make sure `@cross_site_verify` is doing the right thing in context.

This appears to correctly accept/reject all the situations I can throw at it. I don't have access to ie8 for testing and I haven't covered adding a referer querystring for ie8.

__Note:__ If we haven't discussed it enough, Django's CSRF middleware is incompatible with what we are doing here. Our `@cross_site_verify`, assuming we have correctly implemented it, is sufficient to protect against CSRF according to the OWASP cheat sheet.

