### PR TITLE
[PD-1797] Remove qsreferer handling from cross site verify.

### DIFF
--- a/myjobs/cross_site_verify.py
+++ b/myjobs/cross_site_verify.py
@@ -31,25 +31,15 @@ def parse_request_meta(meta):
 
     xrw = meta.get('HTTP_X_REQUESTED_WITH')
 
-    qs = meta.get('QUERY_STRING', '')
-
-    qsreferer = parse_qs(qs).get('referer', [None])[0]
-
-    return (method, origin, referer, qsreferer, xrw)
+    return (method, origin, referer, xrw)
 
 
-def guess_child_domain(host, origin, referer, qsreferer):
+def guess_child_domain(host, origin, referer):
     if origin is not None:
         return origin
 
     if referer is not None:
         return referer
-
-    if qsreferer is not None:
-        if qsreferer == host:
-            return qsreferer
-        else:
-            raise DomainRelationshipException('qsreferer-not-host')
 
     raise DomainRelationshipException('no-child-info')
 
@@ -93,7 +83,7 @@ def get_site(domain):
 
 
 def verify_cross_site_request(site_loader, method, host_site, origin,
-                              referer, xrw, qsreferer):
+                              referer, xrw):
     if not is_permitted_method(method):
         raise DomainRelationshipException('method')
 
@@ -103,8 +93,7 @@ def verify_cross_site_request(site_loader, method, host_site, origin,
     if not is_parent(host_site):
         raise DomainRelationshipException('host-not-parent')
 
-    child = guess_child_domain(host_site.domain, origin, referer,
-                               qsreferer)
+    child = guess_child_domain(host_site.domain, origin, referer)
 
     child_site = site_loader(child)
     if not is_self_or_child(host_site, child_site):
@@ -118,19 +107,18 @@ def verify_cross_site_request(site_loader, method, host_site, origin,
 def cross_site_verify(fn):
     @wraps(fn)
     def verify(request):
-        method, origin, referer, qsreferer, xrw = (
+        method, origin, referer, xrw = (
             parse_request_meta(request.META))
 
         host_site = settings.SITE
 
         try:
             verify_cross_site_request(get_site, method, host_site, origin,
-                                      referer, xrw, qsreferer)
+                                      referer, xrw)
         except DomainRelationshipException as e:
             data = (("method: %r, host %r, origin %r, " +
-                     "referer %r, qsreferer %r, xrw %r") %
-                    (method, host_site.domain, origin, referer,
-                     qsreferer, xrw))
+                     "referer %r, xrw %r") %
+                    (method, host_site.domain, origin, referer, xrw))
             logger.warn(
                 "Rejected cross site request; reason : %s\n" +
                 "data: %s", e.message, data)

--- a/myjobs/cross_site_verify.py
+++ b/myjobs/cross_site_verify.py
@@ -4,7 +4,7 @@ from django.conf import settings
 
 from functools import wraps
 from seo.models import SeoSite
-from urlparse import urlparse, parse_qs
+from urlparse import urlparse
 
 
 XRW = 'XMLHttpRequest'

--- a/myjobs/tests/test_cross_site_verify.py
+++ b/myjobs/tests/test_cross_site_verify.py
@@ -24,53 +24,43 @@ class TestRequestParsing(unittest.TestCase):
             'HTTP_ORIGIN': 'http://bb.com',
             'HTTP_REFERER': 'http://cc.com/somewhere',
             'HTTP_X_REQUESTED_WITH': 'ddd',
-            'QUERY_STRING': 'a=b&referer=aa.com&c=d',
         })
-        expected = ('GET', 'bb.com', 'cc.com', 'aa.com', 'ddd')
+        expected = ('GET', 'bb.com', 'cc.com', 'ddd')
         self.assertEqual(expected, result)
 
     def test_none(self):
         result = parse_request_meta({})
-        self.assertEqual(('', None, None, None, None),
+        self.assertEqual(('', None, None, None),
                          result)
 
 
 class TestChildDomainGuessing(unittest.TestCase):
     def test_origin(self):
-        self.assert_domain('aa.com', None, 'aa.com', None, None)
+        self.assert_domain('aa.com', None, 'aa.com', None)
 
     def test_referer(self):
-        self.assert_domain('aa.com', None, None, 'aa.com', None)
-
-    def test_qsreferer(self):
-        self.assert_domain('aa.com', 'aa.com', None, None, 'aa.com')
-
-    def test_qsreferer_child(self):
-        self.assert_error('qsreferer-not-host', 'z', None, None, 'aa.com')
-
-    def test_qsreferer_host_none(self):
-        self.assert_error('qsreferer-not-host', None, None, None, 'aa.com')
+        self.assert_domain('aa.com', None, None, 'aa.com')
 
     def test_all_none(self):
-        self.assert_error('no-child-info', None, None, None, None)
+        self.assert_error('no-child-info', None, None, None)
 
-    def assert_domain(self, expected, host, origin, referer, qsreferer):
+    def assert_domain(self, expected, host, origin, referer):
         try:
             self.assertEqual(
                 expected,
-                guess_child_domain(host, origin, referer, qsreferer))
+                guess_child_domain(host, origin, referer))
         except DomainRelationshipException as e:
             message = ('Expected: %s, got error: %s for %r' % (
                        expected, e,
-                       [host, origin, referer, qsreferer]))
+                       [host, origin, referer]))
             self.fail(message)
 
-    def assert_error(self, expected, host, origin, referer, qsreferer):
+    def assert_error(self, expected, host, origin, referer):
         try:
-            result = guess_child_domain(host, origin, referer, qsreferer)
+            result = guess_child_domain(host, origin, referer)
             message = ('Expected error: %s, got: %s for %r' % (
                        expected, result,
-                       [host, origin, referer, qsreferer]))
+                       [host, origin, referer]))
             self.fail(message)
         except DomainRelationshipException as e:
             assert(expected, e.message)
@@ -104,7 +94,6 @@ class TestVerifyCrossSite(unittest.TestCase):
             None,
             None,
             None,
-            None,
             None)
 
     def test_bad_xrw(self):
@@ -114,27 +103,7 @@ class TestVerifyCrossSite(unittest.TestCase):
             AA,
             AA.domain,
             None,
-            "z" + XRW,
-            None)
-
-    def test_no_origin_is_parent(self):
-        self.assert_success(
-            'POST',
-            AA,
-            None,
-            None,
-            XRW,
-            AA.domain)
-
-    def test_no_origin_is_parent_qsreferer_mismatch(self):
-        self.assert_failure(
-            'qsreferer-not-host',
-            'POST',
-            AA,
-            None,
-            None,
-            XRW,
-            BB.domain)
+            "z" + XRW)
 
     def test_get_origin_is_parent(self):
         self.assert_success(
@@ -142,15 +111,13 @@ class TestVerifyCrossSite(unittest.TestCase):
             AA,
             AA.domain,
             None,
-            XRW,
-            None)
+            XRW)
 
     def test_get_host_is_child(self):
         self.assert_failure(
             'host-not-parent',
             'POST',
             AA2,
-            None,
             None,
             None,
             None)
@@ -162,8 +129,7 @@ class TestVerifyCrossSite(unittest.TestCase):
             BB,
             AA2.domain,
             None,
-            XRW,
-            None)
+            XRW)
 
     def test_origin_is_child_of_parent_no_xrw(self):
         self.assert_failure(
@@ -171,7 +137,6 @@ class TestVerifyCrossSite(unittest.TestCase):
             'POST',
             AA,
             AA2.domain,
-            None,
             None,
             None)
 
@@ -181,8 +146,7 @@ class TestVerifyCrossSite(unittest.TestCase):
             AA,
             AA2.domain,
             None,
-            XRW,
-            None)
+            XRW)
 
     def test_get_referer_is_missing(self):
         self.assert_failure(
@@ -191,30 +155,9 @@ class TestVerifyCrossSite(unittest.TestCase):
             AA,
             None,
             None,
-            None,
             None)
 
-    def test_get_referer_is_missing_qsreferer_is_parent(self):
-        self.assert_success(
-            'GET',
-            AA,
-            None,
-            None,
-            None,
-            AA.domain)
-
-    def test_get_referer_is_missing_qsreferer_is_child(self):
-        self.assert_failure(
-            'qsreferer-not-host',
-            'GET',
-            AA,
-            None,
-            None,
-            None,
-            AA2.domain)
-
-    def assert_success(self, method, host, origin, referer, xrw,
-                       qsreferer):
+    def assert_success(self, method, host, origin, referer, xrw):
         try:
             verify_cross_site_request(
                 mock_site_loader,
@@ -222,17 +165,15 @@ class TestVerifyCrossSite(unittest.TestCase):
                 host,
                 origin,
                 referer,
-                xrw,
-                qsreferer)
+                xrw)
         except DomainRelationshipException as e:
             message = ('Expected: ok, got error: %s for %r' % (
                        e,
-                       [method, host, origin, referer,
-                        xrw, qsreferer]))
+                       [method, host, origin, referer, xrw]))
             self.fail(message)
 
     def assert_failure(self, expected_fail, method, host,
-                       origin, referer, xrw, qsreferer):
+                       origin, referer, xrw):
         try:
             verify_cross_site_request(
                 mock_site_loader,
@@ -240,12 +181,10 @@ class TestVerifyCrossSite(unittest.TestCase):
                 host,
                 origin,
                 referer,
-                xrw,
-                qsreferer)
+                xrw)
             message = ('Expected error: %s, got success for %r' % (
                        expected_fail,
-                       [method, host, origin, referer,
-                        xrw, qsreferer]))
+                       [method, host, origin, referer, xrw]))
             self.fail(message)
         except DomainRelationshipException as e:
             self.assertEqual(expected_fail, e.message)
@@ -282,12 +221,6 @@ class TestVerifyCrossSiteIntegration(django.test.TestCase):
             HTTP_HOST="aa.com",
             HTTP_ORIGIN="http://aa.com",
             HTTP_X_REQUESTED_WITH="XMLHttpRequest")
-        self.assertEqual(200, resp.status_code)
-
-    def test_get_qsreferer(self):
-        resp = self.client.get(
-            "/ping/?referer=aa.com",
-            HTTP_HOST="aa.com")
         self.assertEqual(200, resp.status_code)
 
     def test_post_mismatched_child(self):

--- a/myjobs/tests/test_cross_site_verify.py
+++ b/myjobs/tests/test_cross_site_verify.py
@@ -1,6 +1,3 @@
-import re
-import json
-
 from django.http import HttpResponse
 from django.conf.urls import url
 import django.test
@@ -10,7 +7,6 @@ from seo.tests.factories import SeoSiteFactory
 
 import unittest
 
-from seo.models import SeoSite
 from myjobs.cross_site_verify import cross_site_verify, \
     verify_cross_site_request, DomainRelationshipException, \
     guess_child_domain, parse_request_meta, XRW


### PR DESCRIPTION
Once we started testing IE8 we discovered that there was no need for trusting a referer in a query string as originally expected in PD-1610.

This should result in a more secure CSRF mechanism since we don't deliberately leave a foothold for foreign JavaScript to manipulate our mechanism.
