### PR TITLE
[PD-1808][PD-1812] Added posting_access to admin and updated how we redirect to login

### DIFF
--- a/dseo_urls.py
+++ b/dseo_urls.py
@@ -121,4 +121,3 @@ urlpatterns += patterns(
     '',
     url(r'^message/', include('mymessages.urls'))
 )
-

--- a/myblocks/tests/factories.py
+++ b/myblocks/tests/factories.py
@@ -105,6 +105,16 @@ class RowFactory(django.DjangoModelFactory):
         model = 'myblocks.Row'
 
 
+class RowOrderFactory(django.DjangoModelFactory):
+    class Meta:
+        model = 'myblocks.RowOrder'
+
+
+class BlockOrderFactory(django.DjangoModelFactory):
+    class Meta:
+        model = 'myblocks.BlockOrder'
+
+
 class PageFactory(django.DjangoModelFactory):
     class Meta:
         model = 'myblocks.Page'

--- a/myjobs/urls.py
+++ b/myjobs/urls.py
@@ -17,7 +17,12 @@ urlpatterns = patterns(
 
     url(r'^$', 'home', name='home'),
     url(r'^login$',
-        RedirectView.as_view(url='/'), name='login'),
+        RedirectView.as_view(url='/')),
+    # Url is duplicated so that we can also easily refer to it as the
+    # login url. This might mess with things if you try to resolve a url
+    # and use url_name, since it could be either home or login.
+    url(r'^$', 'home', name='login'),
+
     url(r'^about/$', About.as_view(), name='about'),
     url(r'^privacy/$', Privacy.as_view(), name='privacy'),
     url(r'^terms/$', Terms.as_view(), name='terms'),

--- a/myjobs/urls.py
+++ b/myjobs/urls.py
@@ -17,12 +17,7 @@ urlpatterns = patterns(
 
     url(r'^$', 'home', name='home'),
     url(r'^login$',
-        RedirectView.as_view(url='/')),
-    # Url is duplicated so that we can also easily refer to it as the
-    # login url. This might mess with things if you try to resolve a url
-    # and use url_name, since it could be either home or login.
-    url(r'^$', 'home', name='login'),
-
+        RedirectView.as_view(url='/'), name='login'),
     url(r'^about/$', About.as_view(), name='about'),
     url(r'^privacy/$', Privacy.as_view(), name='privacy'),
     url(r'^terms/$', Terms.as_view(), name='terms'),

--- a/myjobs/urls.py
+++ b/myjobs/urls.py
@@ -16,6 +16,8 @@ urlpatterns = patterns(
     'myjobs.views',
 
     url(r'^$', 'home', name='home'),
+    url(r'^login$',
+        RedirectView.as_view(url='/')),
     # Url is duplicated so that we can also easily refer to it as the
     # login url. This might mess with things if you try to resolve a url
     # and use url_name, since it could be either home or login.

--- a/postajob/tests/test_views.py
+++ b/postajob/tests/test_views.py
@@ -63,7 +63,7 @@ class PostajobTestBase(DirectSEOBase):
 
     def login_user(self, user=None, password=None):
         user = user or self.user
-        password = password = '5UuYquA@'
+        password = password or '5UuYquA@'
 
         return self.client.login(username=user.email, password=password)
 

--- a/postajob/tests/test_views.py
+++ b/postajob/tests/test_views.py
@@ -8,7 +8,6 @@ from django.core import mail
 from django.core.urlresolvers import reverse
 
 from seo.tests.setup import DirectSEOBase
-from seo.tests.factories import ConfigurationFactory
 from mydashboard.tests.factories import (BusinessUnitFactory, CompanyFactory,
                                          CompanyUserFactory, SeoSiteFactory)
 from myjobs.tests.factories import UserFactory
@@ -37,8 +36,6 @@ class PostajobTestBase(DirectSEOBase):
         self.user = UserFactory(password='5UuYquA@')
         self.company = CompanyFactory(product_access=True, posting_access=True)
 
-        #configuration = ConfigurationFactory(
-        #    home_page_template='home_page/home_page_listing.html')
         self.site = SeoSiteFactory(canonical_company=self.company)
         self.bu = BusinessUnitFactory()
         self.site.business_units.add(self.bu)

--- a/postajob/tests/test_views.py
+++ b/postajob/tests/test_views.py
@@ -8,6 +8,7 @@ from django.core import mail
 from django.core.urlresolvers import reverse
 
 from seo.tests.setup import DirectSEOBase
+from seo.tests.factories import ConfigurationFactory
 from mydashboard.tests.factories import (BusinessUnitFactory, CompanyFactory,
                                          CompanyUserFactory, SeoSiteFactory)
 from myjobs.tests.factories import UserFactory
@@ -36,6 +37,8 @@ class PostajobTestBase(DirectSEOBase):
         self.user = UserFactory(password='5UuYquA@')
         self.company = CompanyFactory(product_access=True, posting_access=True)
 
+        #configuration = ConfigurationFactory(
+        #    home_page_template='home_page/home_page_listing.html')
         self.site = SeoSiteFactory(canonical_company=self.company)
         self.bu = BusinessUnitFactory()
         self.site.business_units.add(self.bu)
@@ -875,7 +878,8 @@ class ViewTests(PostajobTestBase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(OfflinePurchase.objects.all().count(), 1)
         offline_purchase = OfflinePurchase.objects.get()
-        self.assertIn(offline_purchase.redemption_uid, response.content)
+        self.assertIn(offline_purchase.redemption_uid,
+                      response.content.decode('utf-8'))
 
     @skip('Feature disabled for now.')
     def test_offlinepurchase_add_with_company(self):
@@ -959,12 +963,13 @@ class ViewTests(PostajobTestBase):
 
         response = self.client.get(reverse('product_listing'),
                                    HTTP_HOST='test.jobs')
+
         for text in [productgrouping.display_title, productgrouping.explanation,
                      unicode(self.product)]:
             # When the entire chain of objects exists, the return HTML should
             # include elements from the relevant ProductGrouping and Product
             # instances
-            self.assertTrue(text in response.content)
+            self.assertTrue(text in response.content.decode('utf-8'))
     
     def test_job_add_and_remove_locations(self):
         location = {

--- a/seo/admin.py
+++ b/seo/admin.py
@@ -1168,7 +1168,8 @@ class CompanyAdmin(admin.ModelAdmin):
     search_fields = ['name', 'seosite__name', 'seosite__domain']
     fieldsets = [
         ('Basics', {'fields': [('name'), ('company_slug'), ('member'),
-                               ('enhanced'), ('digital_strategies_customer')]}),
+                               ('posting_access'), ('enhanced'),
+                               ('digital_strategies_customer')]}),
         ('Company Info',{'fields':[('logo_url'),('linkedin_id'),
                                    ('canonical_microsite'),
                                    ('og_img')]}),

--- a/universal/decorators.py
+++ b/universal/decorators.py
@@ -105,7 +105,7 @@ def warn_when(condition, feature, message, link=None, link_text=None,
         def wrap(request, *args, **kwargs):
             if request.user.is_anonymous() and redirect:
                 params = {'next': request.get_full_path()}
-                next_url = build_url(reverse('home'), params)
+                next_url = build_url(reverse('login'), params)
                 return HttpResponseRedirect(next_url)
 
             ctx = {'feature': feature,

--- a/universal/decorators.py
+++ b/universal/decorators.py
@@ -26,7 +26,7 @@ def company_has_access(perm_field):
             # with this url as the next url.
             if request.user.is_anonymous():
                 params = {'next': request.get_full_path()}
-                next_url = build_url(reverse('home'), params)
+                next_url = build_url(reverse('login'), params)
                 return HttpResponseRedirect(next_url)
 
             # If the user is logged in, but they aren't a CompanyUser or they

--- a/universal/helpers.py
+++ b/universal/helpers.py
@@ -7,6 +7,7 @@ from urlparse import urlparse, urlunparse
 
 from django.db.models.loading import get_model
 from django.conf import settings
+from django.core.exceptions import ObjectDoesNotExist
 from django.shortcuts import get_object_or_404, Http404
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 from django.core.mail import EmailMessage
@@ -190,8 +191,11 @@ def send_email(email_body, email_type=settings.GENERIC,
 
     if site:
         domain = site.email_domain
-        if site.canonical_company:
+        try:
             company_name = site.canonical_company.name
+        # using object instead of Company to avoid circular imports
+        except (ObjectDoesNotExist, AttributeError):
+            pass
 
     kwargs['company_name'] = company_name
     kwargs['domain'] = domain.lower()


### PR DESCRIPTION
In order to set posting_access on a company without first needing to get write access to the database, I need to enable it in admin. This will also prevent member services from needing developer intervention in order to set up postajob access in the future. 

Update; Added a regression test for login redirects and made all postajob tests use seo settings.