### PR TITLE
[PD-1782] Fix None Returns for Company Titles

### DIFF
--- a/seo/breadbox.py
+++ b/seo/breadbox.py
@@ -155,7 +155,8 @@ class Breadbox(object):
 
     def build_company_breadcrumbs_from_slugs(self):
         company_slug_value = self.filters.get('company_slug')
-        display_title = helpers.bread_box_company_heading(company_slug_value)
+        display_title = helpers.bread_box_company_heading(company_slug_value,
+                                                          self.jobs)
         breadcrumb = self.build_breadcrumb_for_slug_type('company_slug',
                                                          display_title)
         if breadcrumb:

--- a/seo/helpers.py
+++ b/seo/helpers.py
@@ -388,13 +388,10 @@ def bread_box_company_heading(company_slug_value, jobs=None):
     if not company_slug_value:
         return None
     kwargs = {'title_slug': company_slug_value}
-    business_unit = BusinessUnit.objects.filter(**kwargs)
+    business_unit = BusinessUnit.objects.filter(**kwargs).first()
 
-    try:
-        return business_unit[0].title
-    except (IndexError, TypeError):
-        # No business unit found
-        pass
+    if business_unit:
+        return business_unit.title
 
     try:
         return jobs[0].company
@@ -404,7 +401,7 @@ def bread_box_company_heading(company_slug_value, jobs=None):
 
     # this is unlikely to happen as companies that do not exist in DB
     # and do not have associated jobs are often 404'd.
-    return company_slug_value
+    return company_slug_value.replace('-', ' ').title()
 
 
 def location_from_job(job, num_locations):

--- a/seo/helpers.py
+++ b/seo/helpers.py
@@ -541,7 +541,7 @@ def get_bread_box_headings(filters=None, jobs=None):
             bread_box_headings['moc_slug'] = moc
 
         company_slug_value = filters.get("company_slug")
-        company = bread_box_company_heading(company_slug_value)
+        company = bread_box_company_heading(company_slug_value, jobs)
         if company:
             bread_box_headings['company_slug'] = company
 

--- a/seo/helpers.py
+++ b/seo/helpers.py
@@ -383,7 +383,7 @@ def bread_box_company_heading(company_slug_value, jobs=None):
     otherwise, return company string from job or company slug itself
     :param company_slug_value: company filter provided
     :param jobs: jobs matching the provided company
-    :return:
+    :return: business unit title or company slug value parameter
     """
     if not company_slug_value:
         return None

--- a/seo/helpers.py
+++ b/seo/helpers.py
@@ -377,18 +377,34 @@ def _page_title(crumbs):
     return " in ".join([info_part, loc_part])
 
 
-def bread_box_company_heading(company_slug_value):
-    # TODO write test to hit this logic
+def bread_box_company_heading(company_slug_value, jobs=None):
+    """
+    Return the company header we have in the DB (if possible),
+    otherwise, return company string from job or company slug itself
+    :param company_slug_value: company filter provided
+    :param jobs: jobs matching the provided company
+    :return:
+    """
     if not company_slug_value:
         return None
-
     kwargs = {'title_slug': company_slug_value}
     business_unit = BusinessUnit.objects.filter(**kwargs)
 
     try:
         return business_unit[0].title
-    except Exception:
-        return None
+    except (IndexError, TypeError):
+        # No business unit found
+        pass
+
+    try:
+        return jobs[0].company
+    except (IndexError, TypeError):
+        # No job provided
+        pass
+
+    # this is unlikely to happen as companies that do not exist in DB
+    # and do not have associated jobs are often 404'd.
+    return company_slug_value
 
 
 def location_from_job(job, num_locations):
@@ -401,6 +417,7 @@ def location_from_job(job, num_locations):
             return job.country
     except IndexError:
         return None
+
 
 def bread_box_location_heading(location_slug_value, jobs=None):
     if not location_slug_value:

--- a/seo/tests/setup.py
+++ b/seo/tests/setup.py
@@ -9,6 +9,7 @@ from django.core.cache import cache
 from django.core.urlresolvers import clear_url_caches
 from django.db import connections
 from django.test import TestCase
+from django.test.client import Client
 from django.template import context
 
 from seo_pysolr import Solr
@@ -130,43 +131,22 @@ class DirectSeoTCWithJobAndSite(DirectSEOTestCase):
     """
         Test case with a job added and site configured
         Attributes:
-            job - job from solr_settings.SOLR_FIXTURE
-            buid -  business unit id from provided job
-            site - site attached to business unit id from job
-            config - configuration of selected site
+            site - test seosite instance
+            config - config for test seosite
+            client - same as default client, but uses test seosite's domain as HTTP_HOST
     """
     def setUp(self):
         super(DirectSeoTCWithJobAndSite, self).setUp()
-        # import ipdb; ipdb.set_trace()
-        # self.site = SeoSite.objects.get(pk=settings.SITE_ID)
         self.site = SeoSiteFactory()
-        self.site.business_units.add(self.buid_id)
+        self.site.business_units.add(self.businessunit)
 
-        self.config = ConfigurationFactory.build()
-        self.config.status = 2
-        self.config.home_page_template = 'home_page/home_page_listing.html'
-        self.config.footer = ''
+        self.config = ConfigurationFactory.build(status=2)
         self.config.save()
 
         self.site.configurations.add(self.config)
 
-        self.client.HTTP_HOST = self.site.domain
-        # super(DirectSeoTCWithJobAndSite, self).setUp()
-        #
-        # self.job = self.solr_docs[1]
-        # self.conn.add([self.job])
-        #
-        # self.site = SeoSite.objects.get()
-        # self.business_unit = BusinessUnit.objects.get_or_create(pk=self.job['buid'])
-        # self.site.business_units.add(self.job['buid'])
-        # self.site.save()
-        #
-        # self.content = 'This is a content block'
-        #
-        # self.config = Configuration.objects.get(status=2)
-        # self.config.home_page_template = 'home_page/home_page_listing.html'
-        # self.config.footer = ''
-        # self.config.save()
+        # ensure tests in this class use the correct domain
+        self.client = Client(HTTP_HOST=self.site.domain)
 
     def tearDown(self):
         self.conn.delete(q='*:*')

--- a/seo/tests/setup.py
+++ b/seo/tests/setup.py
@@ -140,7 +140,7 @@ class DirectSeoTCWithJobAndSite(DirectSEOTestCase):
         self.conn.add([self.job])
 
         self.site = SeoSite.objects.get()
-        self.buid = BusinessUnit.objects.get_or_create(pk=self.job['buid'])[0]
+        self.business_unit = BusinessUnit.objects.get_or_create(pk=self.job['buid'])[0]
         self.site.business_units.add(self.job['buid'])
         self.site.save()
 

--- a/seo/tests/setup.py
+++ b/seo/tests/setup.py
@@ -1,6 +1,5 @@
 import os.path
 from contextlib import contextmanager
-from haystack import connections as haystack_connections
 
 from django.conf import settings
 from seo.search_backend import DESolrSearchBackend, DESolrEngine
@@ -16,7 +15,6 @@ from seo_pysolr import Solr
 from import_jobs import DATA_DIR
 from seo.tests.factories import BusinessUnitFactory
 from seo.tests.factories import SeoSiteFactory, ConfigurationFactory
-from seo.models import SeoSite, Configuration, BusinessUnit
 import solr_settings
 
 

--- a/seo/tests/setup.py
+++ b/seo/tests/setup.py
@@ -125,7 +125,7 @@ class DirectSEOTestCase(DirectSEOBase):
         self.assertEqual(self.conn.search(q='*:*').hits, 0)
 
 
-class DirectSeoTCWithJobAndSite(DirectSEOTestCase):
+class DirectSeoTCWithSiteAndConfig(DirectSEOTestCase):
     """
         Test case with a job added and site configured
         Attributes:
@@ -134,7 +134,7 @@ class DirectSeoTCWithJobAndSite(DirectSEOTestCase):
             client - same as default client, but uses test seosite's domain as HTTP_HOST
     """
     def setUp(self):
-        super(DirectSeoTCWithJobAndSite, self).setUp()
+        super(DirectSeoTCWithSiteAndConfig, self).setUp()
         self.site = SeoSiteFactory()
         self.site.business_units.add(self.businessunit)
 
@@ -145,10 +145,6 @@ class DirectSeoTCWithJobAndSite(DirectSEOTestCase):
 
         # ensure tests in this class use the correct domain
         self.client = Client(HTTP_HOST=self.site.domain)
-
-    def tearDown(self):
-        self.conn.delete(q='*:*')
-        super(DirectSeoTCWithJobAndSite, self).tearDown()
 
 
 class SettingDoesNotExist:

--- a/seo/tests/test_helpers.py
+++ b/seo/tests/test_helpers.py
@@ -8,7 +8,7 @@ from django.conf import settings
 from seo import helpers
 from seo.models import CustomFacet
 from seo.tests import factories
-from setup import DirectSEOBase, DirectSeoTCWithJobAndSite
+from setup import DirectSEOBase, DirectSeoTCWithSiteAndConfig
 
 
 class SeoHelpersTestCase(DirectSEOBase):
@@ -186,7 +186,7 @@ class SeoHelpersDjangoTestCase(DirectSEOBase):
                     self.assertEqual(query.find(term), -1)
 
 
-class HelpersTestsWithJobAndSite(DirectSeoTCWithJobAndSite):
+class HelpersTestsWithJobAndSite(DirectSeoTCWithSiteAndConfig):
     """
         Tests for helpers functions that require a job and/or a site to be configured
         in order to operate.

--- a/seo/tests/test_helpers.py
+++ b/seo/tests/test_helpers.py
@@ -199,8 +199,9 @@ class HelpersTestsWithJobAndSite(DirectSeoTCWithSiteAndConfig):
         company.company_slug = self.businessunit.title_slug
         self.assertEqual(helpers.bread_box_company_heading(company.company_slug), self.businessunit.title)
 
-        # test company slug that does not match a business unit returns the company slug back
+        # test company slug that does not match a business unit returns the company slug back, but "deslugified"
         company.company_slug = 'thisslugisntvalid'
-        self.assertEqual(helpers.bread_box_company_heading(company.company_slug), company.company_slug)
+        self.assertEqual(helpers.bread_box_company_heading(company.company_slug),
+                         company.company_slug.replace('-', ' ').title())
         # extra test to ensure businessunit.title != company_slug
         self.assertNotEqual(helpers.bread_box_company_heading(company.company_slug), self.businessunit.title)

--- a/seo/tests/test_helpers.py
+++ b/seo/tests/test_helpers.py
@@ -8,7 +8,7 @@ from django.conf import settings
 from seo import helpers
 from seo.models import CustomFacet
 from seo.tests import factories
-from setup import DirectSEOBase
+from setup import DirectSEOBase, DirectSeoTCWithJobAndSite
 
 
 class SeoHelpersTestCase(DirectSEOBase):
@@ -184,3 +184,23 @@ class SeoHelpersDjangoTestCase(DirectSEOBase):
                     self.assertNotEqual(query.find(term), -1)
                 for term in missing_terms:
                     self.assertEqual(query.find(term), -1)
+
+
+class HelpersTestsWithJobAndSite(DirectSeoTCWithJobAndSite):
+    """
+        Tests for helpers functions that require a job and/or a site to be configured
+        in order to operate.
+    """
+    def test_company_heading(self):
+        # test company_slug = None returns None
+        self.assertIsNone(helpers.bread_box_company_heading(None))
+        # test company slug w/ valid business unit returns business unit's title
+        company = factories.CompanyFactory()
+        company.company_slug = self.business_unit.title_slug
+        self.assertEqual(helpers.bread_box_company_heading(company.company_slug), self.business_unit.title)
+
+        # test company slug that does not match a business unit returns the company slug back
+        company.company_slug = 'thisslugisntvalid'
+        self.assertEqual(helpers.bread_box_company_heading(company.company_slug), company.company_slug)
+        # extra test to ensure business_unit.title != company_slug
+        self.assertNotEqual(helpers.bread_box_company_heading(company.company_slug), self.business_unit.title)

--- a/seo/tests/test_helpers.py
+++ b/seo/tests/test_helpers.py
@@ -196,11 +196,11 @@ class HelpersTestsWithJobAndSite(DirectSeoTCWithJobAndSite):
         self.assertIsNone(helpers.bread_box_company_heading(None))
         # test company slug w/ valid business unit returns business unit's title
         company = factories.CompanyFactory()
-        company.company_slug = self.business_unit.title_slug
-        self.assertEqual(helpers.bread_box_company_heading(company.company_slug), self.business_unit.title)
+        company.company_slug = self.businessunit.title_slug
+        self.assertEqual(helpers.bread_box_company_heading(company.company_slug), self.businessunit.title)
 
         # test company slug that does not match a business unit returns the company slug back
         company.company_slug = 'thisslugisntvalid'
         self.assertEqual(helpers.bread_box_company_heading(company.company_slug), company.company_slug)
-        # extra test to ensure business_unit.title != company_slug
-        self.assertNotEqual(helpers.bread_box_company_heading(company.company_slug), self.business_unit.title)
+        # extra test to ensure businessunit.title != company_slug
+        self.assertNotEqual(helpers.bread_box_company_heading(company.company_slug), self.businessunit.title)

--- a/seo/tests/test_views.py
+++ b/seo/tests/test_views.py
@@ -114,7 +114,7 @@ class FallbackTestCase(DirectSeoTCWithJobAndSite):
 
         self.make_page(Page.ERROR_404)
 
-        response = self.client.get('/asldfjsadflasjfsdlafj/', follow=True)
+        response = self.client.get('/asldfjsadflasjfsdlafj/', follow=True, HTTP_HOST=self.site.domain)
         # The content block should be present, since there's
         # a Page.
         self.assertIn(self.content, response.content)

--- a/seo/tests/test_views.py
+++ b/seo/tests/test_views.py
@@ -2788,23 +2788,6 @@ class FilterTestCase404(DirectSeoTCWithJobAndSite):
         self.assertEqual(resp.status_code, 404)
         resp = self.client.get("/fake/moc/vet-jobs/",
                                HTTP_HOST=self.site.domain)
-        self.assertEqual(resp.status_code, 404)
-
-
-class DisplayFunctionTests(DirectSeoTCWithJobAndSite):
-    def test_company_heading(self):
-        # test company_slug = None returns None
-        self.assertIsNone(helpers.bread_box_company_heading(None))
-        # test company slug w/ valid BUID returns business unit's title
-        company = factories.CompanyFactory()
-        company.company_slug = self.buid.title_slug
-        self.assertEqual(helpers.bread_box_company_heading(company.company_slug), self.buid.title)
-
-        # test company slug that does not match a BUID returns the company slug back
-        company.company_slug = 'thisslugisntvalid'
-        self.assertEqual(helpers.bread_box_company_heading(company.company_slug), company.company_slug)
-        # extra test to ensure buid.title != company_slug
-        self.assertNotEqual(helpers.bread_box_company_heading(company.company_slug), self.buid.title)
 
 
 class DubaiTests(DirectSEOTestCase):

--- a/seo/tests/test_views.py
+++ b/seo/tests/test_views.py
@@ -36,7 +36,7 @@ from postajob.tests.factories import (JobFactory, JobLocationFactory,
                                       SitePackageFactory)
 from redirect.tests.factories import RedirectFactory
 from seo import helpers
-from seo.tests.setup import (DirectSEOBase, DirectSEOTestCase, patch_settings, DirectSeoTCWithJobAndSite)
+from seo.tests.setup import (DirectSEOBase, DirectSEOTestCase, patch_settings, DirectSeoTCWithSiteAndConfig)
 from seo.models import (BusinessUnit, Company, Configuration, CustomPage,
                         SeoSite, SeoSiteFacet, SiteTag, User, SeoSiteRedirect)
 from seo.templatetags.seo_extras import url_for_sort_field
@@ -45,7 +45,7 @@ import solr_settings
 from universal.helpers import build_url
 
 
-class FallbackTestCase(DirectSeoTCWithJobAndSite):
+class FallbackTestCase(DirectSeoTCWithSiteAndConfig):
     def setUp(self):
         super(FallbackTestCase, self).setUp()
         self.job = self.solr_docs[1]
@@ -2751,7 +2751,7 @@ class StaticPageOverrideTests(DirectSEOBase):
         # TODO: Reimplement test with qs redirects
 
 
-class FilterTestCase404(DirectSeoTCWithJobAndSite):
+class FilterTestCase404(DirectSeoTCWithSiteAndConfig):
     """
         Test cases involved in the search filter slugs. Ensure 404 returned under proper conditions.
     """

--- a/seo/tests/test_views.py
+++ b/seo/tests/test_views.py
@@ -24,6 +24,7 @@ from BeautifulSoup import BeautifulSoup
 from lxml import etree
 
 from import_jobs import clear_solr, download_feed_file, update_solr
+from slugify import slugify
 from xmlparse import DEv2JobFeed
 from moc_coding import models as moc_models
 from moc_coding.tests import factories as moc_factories
@@ -2776,7 +2777,7 @@ class FilterTestCase404(DirectSeoTCWithSiteAndConfig):
             slug_value = company_from_job[0].company_slug
             company_from_job.delete()  # make sure company doesn't exist in DB
         else:
-            slug_value = job['company'].lower()
+            slug_value = slugify(job['company'])
 
         resp = self.client.get("/%s/careers/" % slug_value,
                                HTTP_HOST=self.site.domain)

--- a/seo/tests/test_views.py
+++ b/seo/tests/test_views.py
@@ -114,7 +114,7 @@ class FallbackTestCase(DirectSeoTCWithJobAndSite):
 
         self.make_page(Page.ERROR_404)
 
-        response = self.client.get('/asldfjsadflasjfsdlafj/', follow=True, HTTP_HOST=self.site.domain)
+        response = self.client.get('/asldfjsadflasjfsdlafj/', follow=True)
         # The content block should be present, since there's
         # a Page.
         self.assertIn(self.content, response.content)

--- a/seo/tests/test_views.py
+++ b/seo/tests/test_views.py
@@ -46,6 +46,14 @@ from universal.helpers import build_url
 
 
 class FallbackTestCase(DirectSeoTCWithJobAndSite):
+    def setUp(self):
+        super(FallbackTestCase, self).setUp()
+        self.job = self.solr_docs[1]
+        self.content = 'This is a content block'
+        self.config.home_page_template = 'home_page/home_page_listing.html'
+        self.config.footer = ''
+        self.config.save()
+
     def make_page(self, page_type):
         content = 'This is a content block'
         content_block = ContentBlockFactory(template=content)
@@ -2762,12 +2770,13 @@ class FilterTestCase404(DirectSeoTCWithJobAndSite):
             Verify that invalid companies will return a 404 error if they have no jobs,
             200 if they have jobs
         """
-        company_from_job = Company.objects.filter(name__iexact=self.job['company'])
+        job = self.solr_docs[1]
+        company_from_job = Company.objects.filter(name__iexact=job['company'])
         if company_from_job:
             slug_value = company_from_job[0].company_slug
             company_from_job.delete()  # make sure company doesn't exist in DB
         else:
-            slug_value = self.job['company'].lower()
+            slug_value = job['company'].lower()
 
         resp = self.client.get("/%s/careers/" % slug_value,
                                HTTP_HOST=self.site.domain)


### PR DESCRIPTION
## The Issue
Companies listed in jobs may or may not exist in our database. When the company header function is called with a company slug that does not exist in our DB, try to pull the title from the job. If that fails, return the company slug as a last resort

### Updates
1. Added handling to attempt to match company slug to a given job and to default to provided company slug if job is unavailable.
2. Created new tests for function to retrieve company title
3. Created new test base class (pulled from test_views.FallbackTestCase) that contains a configured site and a job.