### PR TITLE
Add docs and improvements to how things are archived [PD-1793]

### DIFF
--- a/mypartners/models.py
+++ b/mypartners/models.py
@@ -11,7 +11,7 @@ from django.core.files.storage import default_storage
 from django.core.urlresolvers import reverse
 from django.core.exceptions import ValidationError
 from django.db import models
-from django.db.models.signals import pre_delete, pre_save, post_save
+from django.db.models.signals import pre_delete, pre_save
 from django.dispatch import receiver
 
 from postajob.location_data import states
@@ -124,7 +124,10 @@ class SearchParameterManager(models.Manager):
     def __init__(self, archived=False):
         """
         Adds a new argument to the manager constructor to allow us to specify
-        if a given query should include archived models
+        if a given query should include archived models.
+
+        If this isn't doing what you want, examine the model using it and pay
+        special attention to what value of "archived" is being passed in.
 
         Inputs:
         :archived: True: query archived only, False: exclude
@@ -156,13 +159,21 @@ class SearchParameterManager(models.Manager):
 class ArchivedModel(models.Model):
     archived_on = models.DateTimeField(null=True)
 
+    # These two managers do different things and may not exactly do what you
+    # want unless you're paying attention. The first (objects) retrieves only
+    # objects where archived_on is None. The second (all_objects) retrieves all
+    # objects regardless of the state of archived_on. Managers used by related
+    # objects exhibit some weirdness as shown below.
+    #
+    # A demo is available as test_archived_manager_weirdness in
+    # mypartners/tests/test_models
     objects = SearchParameterManager()
     all_objects = SearchParameterManager(archived=None)
 
     class Meta:
         abstract = True
 
-    def delete(self, *args, **kwargs):
+    def archive(self, *args, **kwargs):
         self.archived_on = datetime.now()
         self.save()
 
@@ -242,7 +253,10 @@ class Contact(ArchivedModel):
     def delete(self, *args, **kwargs):
         pre_delete.send(sender=Contact, instance=self, using='default')
         super(Contact, self).delete(*args, **kwargs)
-        self.primary_contact.clear()
+
+    def archive(self, *args, **kwargs):
+        pre_delete.send(sender=Contact, instance=self, using='default')
+        super(Contact, self).archive(*args, **kwargs)
 
     def get_contact_url(self):
         base_urls = {
@@ -278,19 +292,6 @@ def delete_contact(sender, instance, using, **kwargs):
                     'has been disabled.').format(name=instance.name)
             pss.notes += note
             pss.save()
-
-
-@receiver(pre_delete, sender=Contact,
-          dispatch_uid='post_delete_contact_signal')
-def delete_contact_locations(sender, instance, **kwargs):
-    """
-    Since locations will more than likely be specific to a contact, we should
-    be able to delete all of a contact's locations when that contact is
-    deleted.
-    """
-    for location in instance.locations.all():
-        if not location.contacts.all():
-            location.delete()
 
 
 @receiver(pre_save, sender=Contact, dispatch_uid='pre_save_contact_signal')

--- a/mypartners/models.py
+++ b/mypartners/models.py
@@ -146,6 +146,10 @@ class SearchParameterManager(models.Manager):
         if ('archived_on' in self.model._meta.get_all_field_names()
                 and self._archived is not None):
             qs = qs.exclude(archived_on__isnull=self._archived)
+            if self.model in [ContactRecord, Contact]:
+                qs = qs.exclude(partner__archived_on__isnull=self._archived)
+                if self.model == ContactRecord:
+                    qs = qs.exclude(contact__archived_on__isnull=self._archived)
         return qs
 
     def from_search(self, company=None, filters=None):

--- a/mypartners/tests/test_models.py
+++ b/mypartners/tests/test_models.py
@@ -175,12 +175,20 @@ class MyPartnerTests(MyJobsBase):
         ArchivedModel.objects.
         """
         self.partner.archive()
-        # Try retrieving the archived partner using both managers
+        # Try retrieving the archived partner using both managers. The "objects"
+        # manager excludes archived instances so an exception is raised.
         self.assertRaises(Partner.DoesNotExist,
                           lambda: Partner.objects.get(pk=self.partner.pk))
         Partner.all_objects.get(pk=self.partner.pk)
 
-        self.contact = Contact.objects.get(pk=self.contact.pk)
+        # This contact has not been archived (as we demonstrate in a few lines)
+        # but is excluded by the "objects" manager as its partner has been
+        # archived.
+        self.assertRaises(Contact.DoesNotExist,
+                          lambda: Contact.objects.get(pk=self.contact.pk))
+        self.contact = Contact.all_objects.get(pk=self.contact.pk)
+        self.assertFalse(self.contact.archived_on)
+
         # The manager used by related objects in this instance excludes
         # archived partners. As it's basically a Partner.objects.get(id=...),
         # this fails.

--- a/mypartners/views.py
+++ b/mypartners/views.py
@@ -307,10 +307,9 @@ def delete_prm_item(request):
 
     if content_id == ContentType.objects.get_for_model(Partner).id:
         partner = get_object_or_404(Partner, id=partner_id, owner=company)
-        Contact.objects.filter(partner=partner).delete()
         log_change(partner, None, request.user, partner, partner.name,
                    action_type=DELETION)
-        partner.delete()
+        partner.archive()
         return HttpResponseRedirect(reverse('prm') + '?company=' +
                                     str(company.id))
     elif content_id == ContentType.objects.get_for_model(ContactRecord).id:
@@ -319,7 +318,7 @@ def delete_prm_item(request):
         partner = get_object_or_404(Partner, id=partner_id, owner=company)
         log_change(contact_record, None, request.user, partner,
                    contact_record.contact.name, action_type=DELETION)
-        contact_record.delete()
+        contact_record.archive()
         return HttpResponseRedirect(reverse('partner_records')+'?company=' +
                                     str(company.id)+'&partner=' +
                                     str(partner_id))
@@ -337,7 +336,7 @@ def delete_prm_item(request):
         contact = get_object_or_404(Contact, id=contact_id)
         log_change(contact, None, request.user, partner, contact.name,
                    action_type=DELETION)
-        contact.delete()
+        contact.archive()
         return HttpResponseRedirect(reverse('partner_details')+'?company=' +
                                     str(company.id)+'&partner=' +
                                     str(partner_id))


### PR DESCRIPTION
This moves the logic in the previously overridden delete methods to a new archive method and modifies the delete view to instead call this new method.

We now filter out contacts/communication records as appropriate when any parent/grandparent contacts/partners have been archived.

All tests pass.