### PR TITLE
[PD-1815] Fixed the HTML view for Contact Record Reports

### DIFF
--- a/mypartners/models.py
+++ b/mypartners/models.py
@@ -546,7 +546,7 @@ class ContactRecordQuerySet(SearchParameterQuerySet):
         to the resulting objects.
         """
 
-        contacts = self.values(
+        all_contacts = self.values(
             'partner__name', 'partner', 'contact__name',
             'contact_email').distinct()
     
@@ -558,11 +558,11 @@ class ContactRecordQuerySet(SearchParameterQuerySet):
             'contact__name').annotate(
                 referrals=models.Count('contact__name')).distinct())
 
-        for contact in contacts:
+        for contact in all_contacts:
             contact['referrals'] = referrals.get(contact['contact__name'], 0)
             contact['records'] = records.get(contact['contact__name'], 0)
 
-        return sorted(contacts, key=lambda c: c['records'], reverse=True)
+        return sorted(all_contacts, key=lambda c: c['records'], reverse=True)
 
 
 class ContactRecordManager(SearchParameterManager):

--- a/mypartners/models.py
+++ b/mypartners/models.py
@@ -538,12 +538,21 @@ class ContactRecordQuerySet(SearchParameterQuerySet):
 
     @property
     def contacts(self):
-        contacts = self.exclude(
-            contact_type='job').values(
-                'partner__name', 'partner', 'contact__name',
-                'contact_email').annotate(
-                    records=models.Count('contact__name')).distinct().order_by(
-                        '-records')
+        """ 
+        Returns a queryset annotated by the number of referrals (contact_type =
+        'job') and number of records (contact_type != 'job'). Django doesn't
+        allow annotated values to be filtered without also filtering the base
+        result set, which is why we annotate separately then attach the values
+        to the resulting objects.
+        """
+
+        contacts = self.values(
+            'partner__name', 'partner', 'contact__name',
+            'contact_email').distinct()
+    
+        records = dict(self.exclude(contact_type='job').values_list(
+            'contact__name').annotate(
+                records=models.Count('contact__name')).distinct())
 
         referrals = dict(self.filter(contact_type='job').values_list(
             'contact__name').annotate(
@@ -551,8 +560,9 @@ class ContactRecordQuerySet(SearchParameterQuerySet):
 
         for contact in contacts:
             contact['referrals'] = referrals.get(contact['contact__name'], 0)
+            contact['records'] = records.get(contact['contact__name'], 0)
 
-        return contacts
+        return sorted(contacts, key=lambda c: c['records'], reverse=True)
 
 
 class ContactRecordManager(SearchParameterManager):

--- a/mypartners/tests/test_models.py
+++ b/mypartners/tests/test_models.py
@@ -258,5 +258,5 @@ class MyPartnerTests(MyJobsBase):
         self.assertEqual(records.interviews, 6)
         self.assertEqual(records.hires, 5)
         self.assertEqual(records.emails, 1)
-        self.assertEqual(records.cals, 1)
+        self.assertEqual(records.calls, 1)
 

--- a/myreports/tests/test_views.py
+++ b/myreports/tests/test_views.py
@@ -224,7 +224,7 @@ class TestReportView(MyReportsTestCase):
             self.assertEqual(data[key], 5)
 
         # check contact stats
-        self.assertEqual(data['contacts'][0]['records'], 1)
+        self.assertEqual(data['contacts'][0]['records'], 5)
         self.assertEqual(data['contacts'][0]['referrals'], 10)
 
 


### PR DESCRIPTION
Before:
![2015-10-01-140511_1052x1056_scrot](https://cloud.githubusercontent.com/assets/93686/10229314/9e8973ac-6845-11e5-8491-7f42cf13bfbc.png)

After:
![2015-10-01-140535_1052x1056_scrot](https://cloud.githubusercontent.com/assets/93686/10229324/a52ffcb2-6845-11e5-8f98-d3c18ad3748f.png)

Note that communication records always refers to records which aren't of type "job".