### PR TITLE
Rename function for retrieving company thumbnail

### DIFF
--- a/seo/helpers.py
+++ b/seo/helpers.py
@@ -1455,7 +1455,7 @@ def jobs_and_counts(request, filters, num_jobs, fl=search_fields):
     return default_jobs, featured_jobs, facet_counts
 
 
-def get_company_data(filters):
+def get_company_thumbnail(filters):
     """
         Return the thumbnail for a company if it exists. Returns None if company does
         not have a thumbnail.

--- a/seo/views/search_views.py
+++ b/seo/views/search_views.py
@@ -1786,7 +1786,7 @@ def search_by_results_and_slugs(request, *args, **kwargs):
     if not moc_term:
         moc_term = '\*'
 
-    company_data = helpers.get_company_data(filters)
+    company_data = helpers.get_company_thumbnail(filters)
     results_heading = helpers.build_results_heading(breadbox)
     breadbox.job_count = intcomma(total_default_jobs + total_featured_jobs)
     count_heading = helpers.build_results_heading(breadbox)


### PR DESCRIPTION
Simply rename get_company_data to get_company_thumbnail as the former name is misleading.