### PR TITLE
[PD-1383]  dynamic reporting interface

### DIFF
--- a/myreports/fixtures/class_and_pres.json
+++ b/myreports/fixtures/class_and_pres.json
@@ -163,8 +163,189 @@
     {
         "model": "myreports.ReportingTypeReportTypes",
         "fields": {"report_type": 6, "reporting_type": 2, "is_active": false}
-    }
+    },
 
+    {
+        "model": "myreports.Configuration",
+        "pk": 1,
+        "fields": {"name": "Inactive",
+                   "is_active": false}
+    },
+
+    {
+        "model": "myreports.Configuration",
+        "pk": 2,
+        "fields": {"name": "Maybe Inactive",
+                   "is_active": true}
+    },
+
+    {
+        "model": "myreports.Configuration",
+        "pk": 3,
+        "fields": {"name": "Basic Report",
+                   "is_active": true}
+    },
+
+    {
+        "model": "myreports.Column",
+        "pk": 1,
+        "fields": {"app_name": "zzz",
+                   "model_name": "Inactive",
+                   "column_name": "zzz",
+                   "is_active": false}
+    },
+
+    {
+        "model": "myreports.Column",
+        "pk": 2,
+        "fields": {"app_name": "zzz",
+                   "model_name": "MaybeActive",
+                   "column_name": "zzz",
+                   "is_active": true}
+    },
+
+    {
+        "model": "myreports.Column",
+        "pk": 3,
+        "fields": {"app_name": "mypartners",
+                   "model_name": "Contact",
+                   "column_name": "date_time",
+                   "is_active": true}
+    },
+
+    {
+        "model": "myreports.Column",
+        "pk": 4,
+        "fields": {"app_name": "mypartners",
+                   "model_name": "Contact",
+                   "column_name": "locations.state",
+                   "is_active": true}
+    },
+
+    {
+        "model": "myreports.Column",
+        "pk": 5,
+        "fields": {"app_name": "mypartners",
+                   "model_name": "Contact",
+                   "column_name": "locations.city",
+                   "is_active": true}
+    },
+
+    {
+        "model": "myreports.Column",
+        "pk": 6,
+        "fields": {"app_name": "mypartners",
+                   "model_name": "Contact",
+                   "column_name": "locations.city",
+                   "is_active": true}
+    },
+
+    {
+        "model": "myreports.Column",
+        "pk": 7,
+        "fields": {"app_name": "mypartners",
+                   "model_name": "Contact",
+                   "column_name": "tags",
+                   "is_active": true}
+    },
+
+    {
+        "model": "myreports.Column",
+        "pk": 8,
+        "fields": {"app_name": "mypartners",
+                   "model_name": "Contact",
+                   "column_name": "partner",
+                   "is_active": true}
+    },
+
+    {
+        "model": "myreports.InterfaceElementType",
+        "pk": 1,
+        "fields": {"interface_element_type": "inactive",
+                   "description": "Inactive Element Type",
+                   "element_code": "div",
+                   "is_active": false}
+    },
+
+    {
+        "model": "myreports.ConfigurationColumn",
+        "pk": 1,
+        "fields": {"configuration": 3,
+                   "interface_element_type": 1,
+                   "column": 1,
+                   "multi_value_expansion": false,
+                   "is_active": true}
+    },
+
+    {
+        "model": "myreports.ConfigurationColumn",
+        "pk": 2,
+        "fields": {"configuration": 3,
+                   "interface_element_type": 1,
+                   "column": 2,
+                   "multi_value_expansion": false,
+                   "is_active": false}
+    },
+
+    {
+        "model": "myreports.ConfigurationColumn",
+        "pk": 3,
+        "fields": {"configuration": 3,
+                   "interface_element_type": 1,
+                   "column": 3,
+                   "multi_value_expansion": false,
+                   "is_active": true}
+    },
+
+    {
+        "model": "myreports.ConfigurationColumn",
+        "pk": 4,
+        "fields": {"configuration": 3,
+                   "interface_element_type": 1,
+                   "column": 4,
+                   "multi_value_expansion": false,
+                   "is_active": true}
+    },
+
+    {
+        "model": "myreports.ConfigurationColumn",
+        "pk": 5,
+        "fields": {"configuration": 3,
+                   "interface_element_type": 1,
+                   "column": 5,
+                   "multi_value_expansion": false,
+                   "is_active": true}
+    },
+
+    {
+        "model": "myreports.ConfigurationColumn",
+        "pk": 6,
+        "fields": {"configuration": 3,
+                   "interface_element_type": 1,
+                   "column": 6,
+                   "multi_value_expansion": false,
+                   "is_active": true}
+    },
+
+    {
+        "model": "myreports.ConfigurationColumn",
+        "pk": 7,
+        "fields": {"configuration": 3,
+                   "interface_element_type": 1,
+                   "column": 7,
+                   "multi_value_expansion": false,
+                   "is_active": true}
+    },
+
+    {
+        "model": "myreports.ConfigurationColumn",
+        "pk": 8,
+        "fields": {"configuration": 3,
+                   "interface_element_type": 1,
+                   "column": 8,
+                   "multi_value_expansion": false,
+                   "is_active": true}
+    }
 ]
 
 

--- a/myreports/migrations/0009_auto__add_dynamicreport__del_field_column_table_name__add_field_column.py
+++ b/myreports/migrations/0009_auto__add_dynamicreport__del_field_column_table_name__add_field_column.py
@@ -1,0 +1,503 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding model 'DynamicReport'
+        db.create_table(u'myreports_dynamicreport', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('created_by', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['myjobs.User'], null=True, on_delete=models.SET_NULL)),
+            ('created_on', self.gf('django.db.models.fields.DateTimeField')(auto_now_add=True, blank=True)),
+            ('owner', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['seo.Company'])),
+            ('configuration', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['myreports.Configuration'])),
+            ('results', self.gf('django.db.models.fields.files.FileField')(max_length=100)),
+        ))
+        db.send_create_signal(u'myreports', ['DynamicReport'])
+
+        # Deleting field 'Column.table_name'
+        db.delete_column(u'myreports_column', 'table_name')
+
+        # Adding field 'Column.app_name'
+        db.add_column(u'myreports_column', 'app_name',
+                      self.gf('django.db.models.fields.CharField')(max_length=50, null=True),
+                      keep_default=False)
+
+        # Adding field 'Column.model_name'
+        db.add_column(u'myreports_column', 'model_name',
+                      self.gf('django.db.models.fields.CharField')(max_length=50, null=True),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting model 'DynamicReport'
+        db.delete_table(u'myreports_dynamicreport')
+
+
+        # User chose to not deal with backwards NULL issues for 'Column.table_name'
+        raise RuntimeError("Cannot reverse this migration. 'Column.table_name' and its values cannot be restored.")
+        
+        # The following code is provided here to aid in writing a correct migration        # Adding field 'Column.table_name'
+        db.add_column(u'myreports_column', 'table_name',
+                      self.gf('django.db.models.fields.CharField')(max_length=50),
+                      keep_default=False)
+
+        # Deleting field 'Column.app_name'
+        db.delete_column(u'myreports_column', 'app_name')
+
+        # Deleting field 'Column.model_name'
+        db.delete_column(u'myreports_column', 'model_name')
+
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'myjobs.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'deactivate_type': ('django.db.models.fields.CharField', [], {'default': "'none'", 'max_length': '11'}),
+            'email': ('django.db.models.fields.EmailField', [], {'unique': 'True', 'max_length': '255', 'db_index': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'gravatar': ('django.db.models.fields.EmailField', [], {'db_index': 'True', 'max_length': '255', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'in_reserve': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_disabled': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_verified': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'last_response': ('django.db.models.fields.DateField', [], {'default': 'datetime.datetime.now', 'blank': 'True'}),
+            'opt_in_employers': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'opt_in_myjobs': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'password_change': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'profile_completion': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'source': ('django.db.models.fields.CharField', [], {'default': "'https://secure.my.jobs'", 'max_length': '255'}),
+            'timezone': ('django.db.models.fields.CharField', [], {'default': "'America/New_York'", 'max_length': '255'}),
+            'user_guid': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '100', 'db_index': 'True'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"})
+        },
+        u'myreports.column': {
+            'Meta': {'object_name': 'Column'},
+            'app_name': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True'}),
+            'column_name': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'model_name': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True'})
+        },
+        u'myreports.columnformat': {
+            'Meta': {'object_name': 'ColumnFormat'},
+            'format_code': ('django.db.models.fields.CharField', [], {'max_length': '2000'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'myreports.configuration': {
+            'Meta': {'object_name': 'Configuration'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'myreports.configurationcolumn': {
+            'Meta': {'object_name': 'ConfigurationColumn'},
+            'alias': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'column': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['myreports.Column']", 'null': 'True'}),
+            'column_formats': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['myreports.ColumnFormat']", 'through': u"orm['myreports.ConfigurationColumnFormats']", 'symmetrical': 'False'}),
+            'configuration': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['myreports.Configuration']"}),
+            'default_value': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '500', 'blank': 'True'}),
+            'filter_only': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'interface_element_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['myreports.InterfaceElementType']"}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'multi_value_expansion': ('django.db.models.fields.PositiveSmallIntegerField', [], {})
+        },
+        u'myreports.configurationcolumnformats': {
+            'Meta': {'object_name': 'ConfigurationColumnFormats'},
+            'column_format': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['myreports.ColumnFormat']"}),
+            'configuration_column': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['myreports.ConfigurationColumn']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        u'myreports.datatype': {
+            'Meta': {'object_name': 'DataType'},
+            'data_type': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '500'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        u'myreports.dynamicreport': {
+            'Meta': {'object_name': 'DynamicReport'},
+            'configuration': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['myreports.Configuration']"}),
+            'created_by': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['myjobs.User']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
+            'created_on': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['seo.Company']"}),
+            'results': ('django.db.models.fields.files.FileField', [], {'max_length': '100'})
+        },
+        u'myreports.interfaceelementtype': {
+            'Meta': {'object_name': 'InterfaceElementType'},
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '500'}),
+            'element_code': ('django.db.models.fields.CharField', [], {'max_length': '2000'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'interface_element_type': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        u'myreports.presentationtype': {
+            'Meta': {'object_name': 'PresentationType'},
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '500'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'presentation_type': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'myreports.report': {
+            'Meta': {'object_name': 'Report'},
+            'app': ('django.db.models.fields.CharField', [], {'default': "'mypartners'", 'max_length': '50'}),
+            'created_by': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['myjobs.User']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
+            'created_on': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'filters': ('django.db.models.fields.TextField', [], {'default': "'{}'"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'default': "'contactrecord'", 'max_length': '50'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'order_by': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '50', 'blank': 'True'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['seo.Company']"}),
+            'results': ('django.db.models.fields.files.FileField', [], {'max_length': '100'}),
+            'values': ('django.db.models.fields.CharField', [], {'default': "'[]'", 'max_length': '500'})
+        },
+        u'myreports.reportingtype': {
+            'Meta': {'object_name': 'ReportingType'},
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '500'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'report_types': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['myreports.ReportType']", 'through': u"orm['myreports.ReportingTypeReportTypes']", 'symmetrical': 'False'}),
+            'reporting_type': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'myreports.reportingtypereporttypes': {
+            'Meta': {'object_name': 'ReportingTypeReportTypes'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'report_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['myreports.ReportType']"}),
+            'reporting_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['myreports.ReportingType']"})
+        },
+        u'myreports.reportpresentation': {
+            'Meta': {'object_name': 'ReportPresentation'},
+            'configuration': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['myreports.Configuration']"}),
+            'display_name': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'presentation_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['myreports.PresentationType']"}),
+            'report_data': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['myreports.ReportTypeDataTypes']"})
+        },
+        u'myreports.reporttype': {
+            'Meta': {'object_name': 'ReportType'},
+            'data_types': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['myreports.DataType']", 'through': u"orm['myreports.ReportTypeDataTypes']", 'symmetrical': 'False'}),
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '500'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'report_type': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'myreports.reporttypedatatypes': {
+            'Meta': {'object_name': 'ReportTypeDataTypes'},
+            'data_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['myreports.DataType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'report_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['myreports.ReportType']"})
+        },
+        u'myreports.userreportingtypes': {
+            'Meta': {'object_name': 'UserReportingTypes'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'reporting_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['myreports.ReportingType']"}),
+            'user_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['myreports.UserType']"})
+        },
+        u'myreports.usertype': {
+            'Meta': {'object_name': 'UserType'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'reporting_types': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['myreports.ReportingType']", 'through': u"orm['myreports.UserReportingTypes']", 'symmetrical': 'False'}),
+            'user_type': ('django.db.models.fields.CharField', [], {'max_length': '10'})
+        },
+        u'postajob.package': {
+            'Meta': {'object_name': 'Package'},
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        },
+        u'postajob.sitepackage': {
+            'Meta': {'object_name': 'SitePackage', '_ormbases': [u'postajob.Package']},
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['seo.Company']", 'null': 'True', 'blank': 'True'}),
+            u'package_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['postajob.Package']", 'unique': 'True', 'primary_key': 'True'}),
+            'sites': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['seo.SeoSite']", 'null': 'True', 'symmetrical': 'False'})
+        },
+        u'seo.atssourcecode': {
+            'Meta': {'object_name': 'ATSSourceCode'},
+            'ats_name': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '200'}),
+            'group': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.Group']", 'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '200'}),
+            'value': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '200'})
+        },
+        u'seo.billboardimage': {
+            'Meta': {'object_name': 'BillboardImage'},
+            'copyright_info': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'group': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.Group']", 'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'image_url': ('django.db.models.fields.URLField', [], {'max_length': '200'}),
+            'logo_url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'source_url': ('django.db.models.fields.URLField', [], {'max_length': '200'}),
+            'sponsor_url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '200'})
+        },
+        u'seo.businessunit': {
+            'Meta': {'object_name': 'BusinessUnit'},
+            'associated_jobs': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'date_crawled': ('django.db.models.fields.DateTimeField', [], {}),
+            'date_updated': ('django.db.models.fields.DateTimeField', [], {}),
+            'enable_markdown': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'federal_contractor': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'id': ('django.db.models.fields.IntegerField', [], {'max_length': '10', 'primary_key': 'True'}),
+            'ignore_includeinindex': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'site_packages': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['postajob.SitePackage']", 'null': 'True', 'blank': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '500', 'null': 'True', 'blank': 'True'}),
+            'title_slug': ('django.db.models.fields.SlugField', [], {'max_length': '500', 'null': 'True', 'blank': 'True'})
+        },
+        u'seo.company': {
+            'Meta': {'ordering': "['name']", 'unique_together': "(('name', 'user_created'),)", 'object_name': 'Company'},
+            'admins': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['myjobs.User']", 'through': u"orm['seo.CompanyUser']", 'symmetrical': 'False'}),
+            'canonical_microsite': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'company_slug': ('django.db.models.fields.SlugField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'digital_strategies_customer': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'enhanced': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'job_source_ids': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['seo.BusinessUnit']", 'symmetrical': 'False'}),
+            'linkedin_id': ('django.db.models.fields.CharField', [], {'max_length': '20', 'null': 'True', 'blank': 'True'}),
+            'logo_url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'member': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'og_img': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'posting_access': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'prm_access': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'prm_saved_search_sites': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['seo.SeoSite']", 'null': 'True', 'blank': 'True'}),
+            'product_access': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'site_package': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['postajob.SitePackage']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
+            'user_created': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        u'seo.companyuser': {
+            'Meta': {'unique_together': "(('user', 'company'),)", 'object_name': 'CompanyUser', 'db_table': "'mydashboard_companyuser'"},
+            'company': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['seo.Company']"}),
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'group': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['myjobs.User']"})
+        },
+        u'seo.configuration': {
+            'Meta': {'object_name': 'Configuration'},
+            'backgroundColor': ('django.db.models.fields.CharField', [], {'max_length': '6', 'null': 'True', 'blank': 'True'}),
+            'body': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'browse_city_order': ('django.db.models.fields.IntegerField', [], {'default': '5'}),
+            'browse_city_show': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'browse_city_text': ('django.db.models.fields.CharField', [], {'default': "'City'", 'max_length': '50'}),
+            'browse_company_order': ('django.db.models.fields.IntegerField', [], {'default': '7'}),
+            'browse_company_show': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'browse_company_text': ('django.db.models.fields.CharField', [], {'default': "'Company'", 'max_length': '50'}),
+            'browse_country_order': ('django.db.models.fields.IntegerField', [], {'default': '3'}),
+            'browse_country_show': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'browse_country_text': ('django.db.models.fields.CharField', [], {'default': "'Country'", 'max_length': '50'}),
+            'browse_facet_order': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'browse_facet_order_2': ('django.db.models.fields.IntegerField', [], {'default': '2'}),
+            'browse_facet_order_3': ('django.db.models.fields.IntegerField', [], {'default': '3'}),
+            'browse_facet_order_4': ('django.db.models.fields.IntegerField', [], {'default': '4'}),
+            'browse_facet_show': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'browse_facet_show_2': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'browse_facet_show_3': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'browse_facet_show_4': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'browse_facet_text': ('django.db.models.fields.CharField', [], {'default': "'Job Profiles'", 'max_length': '50'}),
+            'browse_facet_text_2': ('django.db.models.fields.CharField', [], {'default': "'Job Profiles'", 'max_length': '50'}),
+            'browse_facet_text_3': ('django.db.models.fields.CharField', [], {'default': "'Job Profiles'", 'max_length': '50'}),
+            'browse_facet_text_4': ('django.db.models.fields.CharField', [], {'default': "'Job Profiles'", 'max_length': '50'}),
+            'browse_moc_order': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'browse_moc_show': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'browse_moc_text': ('django.db.models.fields.CharField', [], {'default': "'Military Titles'", 'max_length': '50'}),
+            'browse_state_order': ('django.db.models.fields.IntegerField', [], {'default': '4'}),
+            'browse_state_show': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'browse_state_text': ('django.db.models.fields.CharField', [], {'default': "'State'", 'max_length': '50'}),
+            'browse_title_order': ('django.db.models.fields.IntegerField', [], {'default': '6'}),
+            'browse_title_show': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'browse_title_text': ('django.db.models.fields.CharField', [], {'default': "'Title'", 'max_length': '50'}),
+            'company_tag': ('django.db.models.fields.CharField', [], {'default': "'careers'", 'max_length': '50'}),
+            'defaultBlurb': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'defaultBlurbTitle': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'directemployers_link': ('django.db.models.fields.URLField', [], {'default': "'http://directemployers.org'", 'max_length': '200'}),
+            'doc_type': ('django.db.models.fields.CharField', [], {'default': '\'<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">\'', 'max_length': '255'}),
+            'facet_tag': ('django.db.models.fields.CharField', [], {'default': "'new-jobs'", 'max_length': '50'}),
+            'fontColor': ('django.db.models.fields.CharField', [], {'default': "'666666'", 'max_length': '6'}),
+            'footer': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'group': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.Group']", 'null': 'True'}),
+            'header': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'home_page_template': ('django.db.models.fields.CharField', [], {'default': "'home_page/home_page_listing.html'", 'max_length': '200'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'language_code': ('django.db.models.fields.CharField', [], {'default': "'en'", 'max_length': '16'}),
+            'location_tag': ('django.db.models.fields.CharField', [], {'default': "'jobs'", 'max_length': '50'}),
+            'meta': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'moc_helptext': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'moc_label': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'moc_placeholder': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'moc_tag': ('django.db.models.fields.CharField', [], {'default': "'vet-jobs'", 'max_length': '50'}),
+            'num_filter_items_to_show': ('django.db.models.fields.IntegerField', [], {'default': '10'}),
+            'num_job_items_to_show': ('django.db.models.fields.IntegerField', [], {'default': '15'}),
+            'num_subnav_items_to_show': ('django.db.models.fields.IntegerField', [], {'default': '9'}),
+            'percent_featured': ('django.db.models.fields.DecimalField', [], {'default': "'0.5'", 'max_digits': '3', 'decimal_places': '2'}),
+            'primaryColor': ('django.db.models.fields.CharField', [], {'default': "'990000'", 'max_length': '6'}),
+            'publisher': ('django.db.models.fields.CharField', [], {'max_length': '50', 'blank': 'True'}),
+            'revision': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'show_home_microsite_carousel': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'show_home_social_footer': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'show_saved_search_widget': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'show_social_footer': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'status': ('django.db.models.fields.IntegerField', [], {'default': '1', 'null': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True'}),
+            'title_tag': ('django.db.models.fields.CharField', [], {'default': "'jobs-in'", 'max_length': '50'}),
+            'view_all_jobs_detail': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'what_helptext': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'what_label': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'what_placeholder': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'where_helptext': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'where_label': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'where_placeholder': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'wide_footer': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'wide_header': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'})
+        },
+        u'seo.customfacet': {
+            'Meta': {'object_name': 'CustomFacet'},
+            'always_show': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'blurb': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'business_units': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['seo.BusinessUnit']", 'null': 'True', 'blank': 'True'}),
+            'city': ('django.db.models.fields.CharField', [], {'max_length': '800', 'null': 'True', 'blank': 'True'}),
+            'company': ('django.db.models.fields.CharField', [], {'max_length': '800', 'null': 'True', 'blank': 'True'}),
+            'country': ('django.db.models.fields.CharField', [], {'max_length': '800', 'null': 'True', 'blank': 'True'}),
+            'date_created': ('django.db.models.fields.DateField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'group': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.Group']", 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name_slug': ('django.db.models.fields.SlugField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'onet': ('django.db.models.fields.CharField', [], {'max_length': '10', 'null': 'True', 'blank': 'True'}),
+            'querystring': ('django.db.models.fields.CharField', [], {'max_length': '2000', 'null': 'True', 'blank': 'True'}),
+            'saved_querystring': ('django.db.models.fields.CharField', [], {'max_length': '10000', 'blank': 'True'}),
+            'show_blurb': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'show_production': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'state': ('django.db.models.fields.CharField', [], {'max_length': '800', 'null': 'True', 'blank': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '800', 'null': 'True', 'blank': 'True'}),
+            'url_slab': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'})
+        },
+        u'seo.googleanalytics': {
+            'Meta': {'object_name': 'GoogleAnalytics'},
+            'group': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.Group']", 'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'web_property_id': ('django.db.models.fields.CharField', [], {'max_length': '20'})
+        },
+        u'seo.googleanalyticscampaign': {
+            'Meta': {'object_name': 'GoogleAnalyticsCampaign'},
+            'campaign_content': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '200'}),
+            'campaign_medium': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '200'}),
+            'campaign_name': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '200'}),
+            'campaign_source': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '200'}),
+            'campaign_term': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '200'}),
+            'group': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.Group']", 'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '200'})
+        },
+        u'seo.seosite': {
+            'Meta': {'ordering': "(u'domain',)", 'object_name': 'SeoSite', '_ormbases': [u'sites.Site']},
+            'ats_source_codes': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['seo.ATSSourceCode']", 'null': 'True', 'blank': 'True'}),
+            'billboard_images': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['seo.BillboardImage']", 'null': 'True', 'blank': 'True'}),
+            'business_units': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['seo.BusinessUnit']", 'null': 'True', 'blank': 'True'}),
+            'canonical_company': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'canonical_company_for'", 'null': 'True', 'on_delete': 'models.SET_NULL', 'to': u"orm['seo.Company']"}),
+            'configurations': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['seo.Configuration']", 'symmetrical': 'False', 'blank': 'True'}),
+            'email_domain': ('django.db.models.fields.CharField', [], {'default': "'my.jobs'", 'max_length': '255'}),
+            'facets': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['seo.CustomFacet']", 'null': 'True', 'through': u"orm['seo.SeoSiteFacet']", 'blank': 'True'}),
+            'featured_companies': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['seo.Company']", 'null': 'True', 'blank': 'True'}),
+            'google_analytics': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['seo.GoogleAnalytics']", 'null': 'True', 'blank': 'True'}),
+            'google_analytics_campaigns': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['seo.GoogleAnalyticsCampaign']", 'null': 'True', 'blank': 'True'}),
+            'group': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.Group']", 'null': 'True'}),
+            'microsite_carousel': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['social_links.MicrositeCarousel']", 'null': 'True', 'on_delete': 'models.SET_NULL', 'blank': 'True'}),
+            'parent_site': ('seo.models.NonChainedForeignKey', [], {'blank': 'True', 'related_name': "'child_sites'", 'null': 'True', 'on_delete': 'models.SET_NULL', 'to': u"orm['seo.SeoSite']"}),
+            'postajob_filter_type': ('django.db.models.fields.CharField', [], {'default': "'this site only'", 'max_length': '255'}),
+            'site_description': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '200', 'blank': 'True'}),
+            'site_heading': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '200', 'blank': 'True'}),
+            'site_package': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['postajob.SitePackage']", 'null': 'True', 'on_delete': 'models.SET_NULL', 'blank': 'True'}),
+            u'site_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['sites.Site']", 'unique': 'True', 'primary_key': 'True'}),
+            'site_tags': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['seo.SiteTag']", 'null': 'True', 'blank': 'True'}),
+            'site_title': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '200', 'blank': 'True'}),
+            'special_commitments': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['seo.SpecialCommitment']", 'null': 'True', 'blank': 'True'}),
+            'view_sources': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['seo.ViewSource']", 'null': 'True', 'blank': 'True'})
+        },
+        u'seo.seositefacet': {
+            'Meta': {'object_name': 'SeoSiteFacet'},
+            'boolean_operation': ('django.db.models.fields.CharField', [], {'default': "'or'", 'max_length': '3', 'db_index': 'True'}),
+            'customfacet': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['seo.CustomFacet']"}),
+            'facet_group': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'facet_type': ('django.db.models.fields.CharField', [], {'default': "'STD'", 'max_length': '4', 'db_index': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'seosite': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['seo.SeoSite']"})
+        },
+        u'seo.sitetag': {
+            'Meta': {'object_name': 'SiteTag'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'site_tag': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '100'}),
+            'tag_navigation': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        u'seo.specialcommitment': {
+            'Meta': {'object_name': 'SpecialCommitment'},
+            'commit': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200'})
+        },
+        u'seo.viewsource': {
+            'Meta': {'object_name': 'ViewSource'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '200'}),
+            'view_source': ('django.db.models.fields.IntegerField', [], {'default': "''", 'max_length': '20'})
+        },
+        u'sites.site': {
+            'Meta': {'ordering': "(u'domain',)", 'object_name': 'Site', 'db_table': "u'django_site'"},
+            'domain': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'social_links.micrositecarousel': {
+            'Meta': {'object_name': 'MicrositeCarousel'},
+            'carousel_title': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'display_rows': ('django.db.models.fields.IntegerField', [], {}),
+            'group': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.Group']", 'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'include_all_sites': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'link_sites': ('django.db.models.fields.related.ManyToManyField', [], {'blank': 'True', 'related_name': "'linked_carousel'", 'null': 'True', 'symmetrical': 'False', 'to': u"orm['seo.SeoSite']"})
+        }
+    }
+
+    complete_apps = ['myreports']

--- a/myreports/models.py
+++ b/myreports/models.py
@@ -174,7 +174,8 @@ class PresentationType(models.Model):
 
 
 class Column(models.Model):
-    table_name = models.CharField(max_length=50)
+    app_name = models.CharField(max_length=50, null=True)
+    model_name = models.CharField(max_length=50, null=True)
     column_name = models.CharField(max_length=50)
     is_active = models.BooleanField(default=False)
 
@@ -209,3 +210,78 @@ class ConfigurationColumn(models.Model):
     column_formats = models.ManyToManyField(
         'ColumnFormat', through='ConfigurationColumnFormats')
     is_active = models.BooleanField(default=False)
+
+
+class DynamicReport(models.Model):
+    """
+    Models a Report which was generated from a Configuration.
+
+    The report can be serialized in various formats.
+
+    A report instance can access it's results in three ways:
+        `json`: returns a JSON string of the results
+        `python`: returns a `dict` of the results
+        `queryset`: returns a queryset obtained by re-running `from_search`
+                    with the report's parameters. Useful for when you need to
+                    use attributes from a related model's instances (eg.
+                    `referrals` from the `ContactRecord` model).
+    """
+    created_by = models.ForeignKey(
+        'myjobs.User', null=True, on_delete=models.SET_NULL)
+    created_on = models.DateTimeField(auto_now_add=True)
+    owner = models.ForeignKey('seo.Company')
+    configuration = models.ForeignKey('myreports.Configuration')
+    results = models.FileField(upload_to='reports')
+
+    company_ref = 'owner'
+
+    objects = SearchParameterManager()
+
+    def __init__(self, *args, **kwargs):
+        super(DynamicReport, self).__init__(*args, **kwargs)
+        self._results = '{}'
+        # XXX: Where will this come from?
+        self.filters = {}
+        # XXX: name report better
+        self.name = "Dynamic Report Name"
+
+        if self.results:
+            try:
+                self._results = self.results.read()
+            except IOError:
+                # If we are here, the file can't be found, which is usually the
+                # case when testing locally and pointing to
+                # QC/Staging/Production.
+                pass
+
+    @property
+    def json(self):
+        return self._results
+
+    @property
+    def python(self):
+        return json.loads(self._results)
+
+    @property
+    def queryset(self):
+        # XXX: Assumes all columns come from one model.
+        fc_config = (self.configuration
+                     .configurationcolumn_set
+                     .filter(is_active=True,
+                             column__is_active=True)
+                     .first())
+        model = get_model(fc_config.column.app_name,
+                          fc_config.column.model_name)
+
+        return model.objects.from_search(self.owner, self.filters)
+
+    def regenerate(self):
+        """Regenerate the report file if it doesn't already exist on disk."""
+        contents = serialize('json', self.queryset)
+        results = ContentFile(contents)
+
+        if self.results:
+            self.results.delete()
+
+        self.results.save('%s-%s.json' % (self.name, self.pk), results)
+        self._results = contents

--- a/myreports/tests/test_views.py
+++ b/myreports/tests/test_views.py
@@ -436,14 +436,14 @@ class TestDynamicReports(MyReportsTestCase):
         partner = PartnerFactory(owner=self.company)
         for i in range(0, 10):
             ContactFactory.create(name="name-%s" % i, partner=partner)
-        config = Configuration.objects.get(id=3)
-        report = DynamicReport.objects.create(
-            configuration=config,
-            owner=self.company)
-        report.regenerate()
+
+        resp = self.client.post(reverse('run_dynamic_report'),
+                                {'configuration_id': 3})
+        self.assertEqual(200, resp.status_code)
+        report_id = json.loads(resp.content)['id']
 
         resp = self.client.get(reverse('download_dynamic_report'),
-                               {'id': report.pk})
+                               {'id': report_id})
         self.assertEquals(200, resp.status_code)
         lines = resp.content.splitlines()
         self.assertEquals(11, len(lines))

--- a/myreports/urls.py
+++ b/myreports/urls.py
@@ -11,6 +11,8 @@ urlpatterns = patterns(
     url(r'^ajax/(?P<app>\w+)/(?P<model>\w+)$',
         'view_records',
         name='view_records'),
+    url(r'^view/dynamicdownload$', 'download_dynamic_report',
+        name='download_dynamic_report'),
     url(r'download$', 'download_report', name='download_report'),
     url(r'view/downloads$', 'downloads', name='downloads'),
     url(r'^view/dynamicoverview$', 'dynamicoverview', name='dynamicoverview'),

--- a/myreports/urls.py
+++ b/myreports/urls.py
@@ -20,4 +20,5 @@ urlpatterns = patterns(
         name='reporting_types_api'),
     url(r'^api/report_types$', 'report_types_api',
         name='report_types_api'),
+    url(r'^api/run_report$', 'run_dynamic_report', name='run_dynamic_report')
 )

--- a/myreports/views.py
+++ b/myreports/views.py
@@ -12,7 +12,8 @@ from django.views.generic import View
 from django.views.decorators.http import require_http_methods
 
 from myreports.helpers import humanize, serialize
-from myreports.models import Report, ReportingType, ReportType
+from myreports.models import (
+    Report, ReportingType, ReportType, Configuration, DynamicReport)
 from postajob import location_data
 from universal.helpers import get_company_or_404
 from universal.decorators import has_access
@@ -398,3 +399,45 @@ def report_types_api(request):
             dict(entry(rt) for rt in report_types)}
     return HttpResponse(content_type='application/json',
                         content=json.dumps(data))
+
+
+@has_access('prm')
+@require_http_methods(['GET'])
+def download_dynamic_report(request):
+    """
+    Download dynamic report as CSV.
+
+    Query String Parameters:
+        :id: ID of the report to download
+        :values: Fields to include in the resulting CSV, as well as the order
+                 in which to include them.
+        :order_by: The sort order for the resulting CSV.
+
+    Outputs:
+        The report with the specified options rendered as a CSV file.
+    """
+
+    report_id = request.GET.get('id', 0)
+    values = request.GET.getlist('values', None)
+    order_by = request.GET.get('order_by', None)
+
+    report = DynamicReport.objects.get(id=report_id)
+
+    if order_by:
+        report.order_by = order_by
+        report.save()
+
+    if values:
+        report.values = json.dumps(values)
+        report.save()
+
+    records = humanize(report.python)
+
+    response = HttpResponse(content_type='text/csv')
+    content_disposition = "attachment; filename=%s-%s.csv"
+    response['Content-Disposition'] = content_disposition % (
+        report.name.replace(' ', '_'), report.pk)
+
+    response.write(serialize('csv', records, values=values, order_by=order_by))
+
+    return response

--- a/myreports/views.py
+++ b/myreports/views.py
@@ -402,6 +402,26 @@ def report_types_api(request):
 
 
 @has_access('prm')
+@require_http_methods(['POST'])
+def run_dynamic_report(request):
+    config_id = request.POST['configuration_id']
+    config = Configuration.objects.get(id=config_id)
+
+    company = request.user.companyuser_set.first().company
+
+    report = DynamicReport.objects.create(
+        configuration=config,
+        owner=company)
+
+    report.regenerate()
+    report.save()
+
+    data = {'id': report.id}
+    return HttpResponse(content_type='application/json',
+                        content=json.dumps(data))
+
+
+@has_access('prm')
 @require_http_methods(['GET'])
 def download_dynamic_report(request):
     """

--- a/templates/myreports/dynamicreports.html
+++ b/templates/myreports/dynamicreports.html
@@ -19,6 +19,7 @@
     </div>
     <!-- This UI is a placeholder for QA purposes.
          It is not intended to set any precedent. -->
+    <h3>Walk through report types API</h3>
     <div id="select-container" class="row">
         <div class="span12">
             <div id="select-content"></div>
@@ -27,6 +28,21 @@
     <div id="report-types-container" class="row">
         <div class="span12">
             <div id="report-types-content"></div>
+        </div>
+    </div>
+
+    <hr>
+    <h3>Run trivial contact records report</h3>
+    <div class="row">
+        <div class="span12">
+            <input id="trivial-report-contact-id"
+                placeholder="Configuration Id; Try 3">
+            <a id="trivial-report-run" class="btn" href="#">Run</a>
+        </div>
+    </div>
+    <div class="row">
+        <div class="span12">
+            <ul id='report-links-list'></ul>
         </div>
     </div>
 {% endblock %}
@@ -38,6 +54,35 @@
 </script>
 <script type="text/javascript">
 var csrf = read_cookie("csrftoken");
+
+function runReport() {
+    var configId = $('#trivial-report-contact-id').val();
+    ajaxRunReport(configId).done(function(data) {
+        var reportId = data['id'];
+        var list = $('#report-links-list');
+        var href = '/reports/view/dynamicdownload?id=' + reportId;
+        var dom = $('<li><a href="' + href + '">Report: ' + reportId + '</a></li>');
+        list.append(dom);
+    }).fail(function(xhr, text, error) { console.error(text, error, xhr) });
+}
+
+function ajaxRunReport(configId) {
+    return $.ajax({
+        url: "/reports/api/run_report",
+        type: "POST",
+        dataType: "json",
+        data: {csrfmiddlewaretoken: csrf,
+            configuration_id: configId},
+        withCredentials: true,
+    });
+}
+
+$(document).on('ready', function() {
+    $('#trivial-report-run').click(function() {
+        runReport();
+        return false;
+    });
+});
 
 function resetReportingTypes() {
     ajaxReportingTypes().done(function(data) {


### PR DESCRIPTION
This is a first cut at enough code to make a trivial report generate CSV. It uses some of the models present, not all yet.

Changes so far:

* Switch from table_name to app_name/model_name.
* Sample data for a contact records report.
  * So far only the model_name/app_name of the columns is used.
* A model to represent a report that exists.
* Some views to run a report and download csv, etc.

To test:

1. run manage.py loaddata myreports class_and_pres
2. Go to secure.my.jobs/reports/view/dynamicoverview
3. Enter 3 in configuration id, Run.
4, Click the report link to download csv.

What I expect to do before pushing:

* Use the configuration columns for query values.
* Build a trivial filter interface around configuration columns.

I marked XXX in a few spots in the code where I was unsure about design choices.


