### PR TITLE
[PD-1850] Automatically add activities to Admin roles.

### DIFF
--- a/myjobs/migrations/0007_create_admin_roles.py
+++ b/myjobs/migrations/0007_create_admin_roles.py
@@ -7,11 +7,11 @@ from django.db import models
 class Migration(DataMigration):
 
     def forwards(self, orm):
-        """Create a 'Role Admin' role for existing companies."""
+        """Create a 'Admin' role for existing companies."""
 
         # create the required roles
         orm.Role.objects.bulk_create([
-            orm.Role(name="Role Admin", company=company)
+            orm.Role(name="Admin", company=company)
             for company in orm["seo.Company"].objects.all()])
 
         roles = orm.Role.objects.all()

--- a/myjobs/migrations/0007_create_admin_roles.py
+++ b/myjobs/migrations/0007_create_admin_roles.py
@@ -24,7 +24,7 @@ class Migration(DataMigration):
         # directly to reduce queries to one
         RoleActivities.objects.bulk_create([
             RoleActivities(role=role, activity=activity)
-            for role in roles for activity in activities])
+            for role in roles for activity in activities], 450)
 
         # assign the first company user of each company to that role
 

--- a/myjobs/migrations/0007_create_admin_roles.py
+++ b/myjobs/migrations/0007_create_admin_roles.py
@@ -29,7 +29,7 @@ class Migration(DataMigration):
         # assign the first company user of each company to that role
 
     def backwards(self, orm):
-        "Write your backwards methods here."
+        orm.Role.objects.filter(name="Admin").delete()
 
     models = {
         u'auth.group': {

--- a/myjobs/models.py
+++ b/myjobs/models.py
@@ -771,7 +771,7 @@ class Activity(models.Model):
 def update_role_admins(sender, instance, created, *args, **kwargs):
     """
     When a new activity is created, that activity should immediately be
-    associated with the Role Admin role.
+    associated with the Admin role.
     """
 
     if created:

--- a/myjobs/models.py
+++ b/myjobs/models.py
@@ -775,7 +775,7 @@ def update_role_admins(sender, instance, created, *args, **kwargs):
     """
 
     if created:
-        roles = Role.objects.filter(name="Role Admin")
+        roles = Role.objects.filter(name="Admin")
         RoleActivities = Role.activities.through
         RoleActivities.objects.bulk_create([
             RoleActivities(role=role, activity=instance) for role in roles])

--- a/myjobs/tests/factories.py
+++ b/myjobs/tests/factories.py
@@ -44,13 +44,14 @@ class ActivityFactory(factory.django.DjangoModelFactory):
 
     app_access = factory.SubFactory(AppAccessFactory)
     name = factory.Sequence(lambda n: 'test activity %s' % n)
+    description = "Just a description of some test activity."
 
 
 class RoleFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = 'myjobs.Role'
 
-    company = factory.SubFactory('myjobs.tests.factories.CompanyFactory')
+    company = factory.SubFactory('seo.tests.factories.CompanyFactory')
     name = factory.Sequence(lambda n: 'test role %s' % n)
 
     @factory.post_generation

--- a/myjobs/tests/test_data_migrations.py
+++ b/myjobs/tests/test_data_migrations.py
@@ -24,7 +24,7 @@ class TestAdminRoleCreation(TestCase):
 
         with self.assertNumQueries(2):
             Role.objects.bulk_create([
-                Role(name="Role Admin", company=company)
+                Role(name="Admin", company=company)
                 for company in Company.objects.all()])
 
         self.assertEqual(Role.objects.count(), 100)
@@ -35,7 +35,7 @@ class TestAdminRoleCreation(TestCase):
         single query.
         """
 
-        roles = [RoleFactory(name="Role Admin", company=company)
+        roles = [RoleFactory(name="Admin", company=company)
                  for company in self.companies]
 
         with self.assertNumQueries(1):

--- a/myjobs/tests/test_models.py
+++ b/myjobs/tests/test_models.py
@@ -224,24 +224,24 @@ class ActivityTests(MyJobsBase):
 
     def test_automatic_role_admin_activities(self):
         """
-        New activities should be added to all Role Admin roles automatically.
+        New activities should be added to all Admin roles automatically.
         """
 
         # add role to existing company
-        RoleFactory(company=self.company, name="Role Admin",
+        RoleFactory(company=self.company, name="Admin",
                     activities=self.activities)
         role_admins = RoleFactory.create_batch(
-            50, name="Role Admin", activities=self.activities)
+            50, name="Admin", activities=self.activities)
 
         # sanity check for initial numbers
-        for admin in Role.objects.filter(name="Role Admin"):
+        for admin in Role.objects.filter(name="Admin"):
             self.assertEqual(admin.activities.count(), 5)
 
         new_activity =  ActivityFactory(
             name="new activity", description="Just a new test activity.")
 
         # new activity should be available for admins
-        for admin in Role.objects.filter(name="Role Admin"):
+        for admin in Role.objects.filter(name="Admin"):
             self.assertIn(new_activity, admin.activities.all())
 
         # existing role should not have new activity

--- a/myjobs/tests/test_models.py
+++ b/myjobs/tests/test_models.py
@@ -8,7 +8,7 @@ from django.db.models import Q
 from django.utils.http import urlquote
 
 from setup import MyJobsBase
-from myjobs.models import User
+from myjobs.models import User, Role
 from myjobs.tests.test_views import TestClient
 from myjobs.tests.factories import (UserFactory, AppAccessFactory,
                                     ActivityFactory, RoleFactory)
@@ -199,7 +199,7 @@ class ActivityTests(MyJobsBase):
 
         try:
             # This should be allowed since the company is different
-            RoleFactory(name=self.role.name, company=CompanyFactory())
+            RoleFactory(name=self.role.name)
         except IntegrityError:
             self.fail("Creating a similar role for a different company should " 
                       "be allowed, but it isn't.")
@@ -221,3 +221,29 @@ class ActivityTests(MyJobsBase):
 
         with self.assertRaises(IntegrityError):
             AppAccessFactory(name=self.app_access.name)
+
+    def test_automatic_role_admin_activities(self):
+        """
+        New activities should be added to all Role Admin roles automatically.
+        """
+
+        # add role to existing company
+        RoleFactory(company=self.company, name="Role Admin",
+                    activities=self.activities)
+        role_admins = RoleFactory.create_batch(
+            50, name="Role Admin", activities=self.activities)
+
+        # sanity check for initial numbers
+        for admin in Role.objects.filter(name="Role Admin"):
+            self.assertEqual(admin.activities.count(), 5)
+
+        new_activity =  ActivityFactory(
+            name="new activity", description="Just a new test activity.")
+
+        # new activity should be available for admins
+        for admin in Role.objects.filter(name="Role Admin"):
+            self.assertIn(new_activity, admin.activities.all())
+
+        # existing role should not have new activity
+        self.assertNotIn(new_activity, self.role.activities.all())
+


### PR DESCRIPTION
*This depends on #1823 , which in turn depends on #1820.*
This makes it so that creating a new activity automatically adds that activity to the "Role Admin" role. In my tests, it takes ~5 seconds to add a new activity to ~30,000 "Role Admin" roles (in 4 queries).

~~The actual differences are [here](https://github.com/DirectEmployers/MyJobs/compare/activity-migration...pd-1850?expand=1)~~

# Hotfix
*update:* I changed Role Admin -> Admin. I didn't create another migration since this hasn't hit production, and I didn't want to run two nearly identical data migrations with the second undoing the work of the first.

The other migration wouldn't work on QC because the max packet size there is 4M vs 16M locally. With @mklauber 's guidance, I decided to batch the bulk create at 450 rows. 