### PR TITLE
Improve mypartners factories [PD-1863]

### DIFF
--- a/mypartners/tests/factories.py
+++ b/mypartners/tests/factories.py
@@ -58,7 +58,8 @@ class ContactRecordFactory(factory.django.DjangoModelFactory):
     notes = 'Some notes go here.'
     date_time = datetime.now()
 
-    contact = factory.SubFactory(ContactFactory, name='example-contact')
+    contact = factory.SubFactory(ContactFactory, name='example-contact',
+                                 partner=factory.SelfAttribute('..partner'))
     partner = factory.SubFactory(PartnerFactory)
     approval_status = factory.SubFactory(StatusFactory)
 

--- a/mypartners/tests/test_views.py
+++ b/mypartners/tests/test_views.py
@@ -1230,8 +1230,8 @@ class EmailTests(MyPartnersTestCase):
             self.assertEqual(self.data['text'], record.notes)
             self.assertEqual(Contact.objects.all().count(), 2)
 
-            Contact.objects.filter(email=record.contact_email).delete()
-            ContactRecord.objects.filter(id=record.pk).delete()
+            Contact.objects.get(email=record.contact_email).delete()
+            record.delete()
 
     def test_double_escape_forward(self):
         self.data['to'] = 'prm@my.jobs'

--- a/myreports/tests/test_views.py
+++ b/myreports/tests/test_views.py
@@ -173,11 +173,6 @@ class TestReportView(MyReportsTestCase):
             5, contact_type='job',
             job_hires=1, partner=self.partner)
 
-        # Despite explicitly passing an already-created partner to create_batch,
-        # factory boy creates another partner for each of these and then does
-        # not use it. Clean up after it.
-        Partner.objects.exclude(pk=self.partner.pk).delete()
-
     def test_create_report(self):
         """Test that a report model instance is properly created."""
 


### PR DESCRIPTION
Fixing all factories is a bigger beast than I thought, so I'll leave it at an app-by-app basis as issues crop up.

This can still result in odd relationships as demonstrated here but this is an issue that can be fixed through correct use of the factory.
```
    assert Partner.objects.count() == 1
    contact = Contact.objects.get(pk=...)
    record = ContactRecordFactory(contact=contact)
    assert Partner.objects.count() == 2
    assert contact.partner != record.partner
```

All tests pass.