### PR TITLE
[PD-1869] Added archived_on to the global blacklist for reporting.

### DIFF
--- a/myreports/views.py
+++ b/myreports/views.py
@@ -261,10 +261,10 @@ def downloads(request):
         report = get_object_or_404(
             get_model('myreports', 'report'), pk=report_id)
 
-        common_blacklist = ['pk', 'approval_status']
+        common_blacklist = ['pk', 'approval_status', 'archived_on']
         blacklist = {
             'contactrecord': common_blacklist,
-            'contact': common_blacklist + ['archived_on', 'library', 'user'],
+            'contact': common_blacklist + ['library', 'user'],
             'partner': common_blacklist + ['library', 'owner']}
 
         if report.python:


### PR DESCRIPTION
Results:
![2015-10-20-132753_1916x1056_scrot](https://cloud.githubusercontent.com/assets/93686/10615586/b05a57b6-772e-11e5-8568-97eea030b79c.png)

If you go to production now and try to create a CSV for a communication record report, you'll see that the "archived on" field is present, when it shouldn't be. This corrects that. I basically promoted that column to the common blacklist.