### PR TITLE
Registration redesign tweak

### DIFF
--- a/registration/forms.py
+++ b/registration/forms.py
@@ -27,7 +27,6 @@ class CustomSetPasswordForm(SetPasswordForm):
                                               'Password is required.'},
                                   label=('Password'), required=True,
                                   widget=forms.PasswordInput(attrs={
-                                      'placeholder': _('Password'),
                                       'id': 'id_password1',
                                       'autocomplete': 'off'}),
                                   help_text="Must contain an uppercase "
@@ -37,8 +36,7 @@ class CustomSetPasswordForm(SetPasswordForm):
     new_password2 = forms.CharField(error_messages={'required':
                                                 'Password is required.'},
                                     label=_("Password (again)"), required=True,
-                                    widget=forms.PasswordInput(
-                                        attrs={'placeholder': _('Password (again)'),
+                                    widget=forms.PasswordInput(attrs={
                                                'id': 'id_password2',
                                                'autocomplete': 'off'},
                                         render_value=False))
@@ -83,20 +81,18 @@ class CustomAuthForm(AuthenticationForm):
     """
     username = forms.CharField(error_messages={'required':'Email is required.'},
                                label=_("Email"), required=True,
-                               widget=forms.TextInput(
-                                   attrs={'placeholder': _('Email'),
+                               widget=forms.TextInput(attrs={
                                           'id':'id_username'}))
     password = forms.CharField(error_messages={'required':'Password is required.'},
                                label=_("Password"), required=True,
-                               widget=forms.PasswordInput(
-                                   attrs={'placeholder':_('Password'),
+                               widget=forms.PasswordInput(attrs={
                                           'id':'id_password'},
                                    render_value=False,))
 
     remember_me = forms.BooleanField(label=_('Keep me logged in for 2 weeks'),
                                      required=False,
-                                     widget=forms.CheckboxInput(
-                                         attrs={'id': 'id_remember_me'}))
+                                     widget=forms.CheckboxInput(attrs={
+                                         'id': 'id_remember_me'}))
 
     def __init__(self, request=None, *args, **kwargs):
         super(CustomAuthForm, self).__init__(request, *args, **kwargs)
@@ -141,8 +137,7 @@ class CustomPasswordResetForm(PasswordResetForm):
     """
     email = forms.CharField(error_messages={'required': 'Email is required.'},
                             label=_("Email"), required=True,
-                            widget=forms.TextInput(
-                                attrs={'placeholder': _('Email'),
+                            widget=forms.TextInput(attrs={
                                        'id': 'id_email',
                                        'class': 'reset-pass-input'}))
 
@@ -178,7 +173,6 @@ class RegistrationForm(forms.Form):
     email = forms.EmailField(error_messages={'required':'Email is required.'},
                              label=_("Email"), required=True,
                              widget=forms.TextInput(attrs={
-                                 'placeholder': _('Email'),
                                  'id':'id_email',
                                  'autocomplete': 'off'}),
                              max_length=255)
@@ -186,7 +180,6 @@ class RegistrationForm(forms.Form):
                                               'Password is required.'},
                               label=('Password'), required=True,
                               widget=forms.PasswordInput(attrs={
-                                  'placeholder': _('Password'),
                                   'id': 'id_password1',
                                   'autocomplete': 'off'}),
                               help_text="Must contain an uppercase "
@@ -195,8 +188,7 @@ class RegistrationForm(forms.Form):
     password2 = forms.CharField(error_messages={'required':
                                                 'Password is required.'},
                                 label=_("Password (again)"), required=True,
-                                widget=forms.PasswordInput(
-                                    attrs={'placeholder': _('Password (again)'),
+                                widget=forms.PasswordInput(attrs={
                                            'id': 'id_password2',
                                            'autocomplete': 'off'},
                                     render_value=False))

--- a/static/my.jobs.169-26.css
+++ b/static/my.jobs.169-26.css
@@ -4427,7 +4427,6 @@ table td, table th {
 
 #saved-search-listing-table td:hover {
     background: #D5FACF;
-    cursor: pointer;
 }
 
 #saved-search-listing-details > div,

--- a/static/my.jobs.169-26.css
+++ b/static/my.jobs.169-26.css
@@ -4425,6 +4425,11 @@ table td, table th {
     font-weight: bold;
 }
 
+#saved-search-listing-table td:hover {
+    background: #D5FACF;
+    cursor: pointer;
+}
+
 #saved-search-listing-details > div,
 #saved-search-listing-details > h2 {
     padding-left: 10px;

--- a/templates/base.html
+++ b/templates/base.html
@@ -20,7 +20,7 @@
     {% block meta-extra %}{% endblock %}
 
     <link href="{{ STATIC_URL }}def.ui.152-21.css{{ gz }}" rel="stylesheet" type="text/css">
-    <link href="{{ STATIC_URL }}my.jobs.169-23.css{{ gz }}" rel="stylesheet" type="text/css">
+    <link href="{{ STATIC_URL }}my.jobs.169-26.css{{ gz }}" rel="stylesheet" type="text/css">
     <!--[if IE]>
     <link href="{{ STATIC_URL }}my.jobs.ie.163-29.css{{ gz }}" rel="stylesheet" type="text/css">
     <![endif]-->


### PR DESCRIPTION
In reviewing #1835, I made a few comments which I didn't think needed to hold back that PR. This PR addresses those points. Namely:

- On the registration form, the placeholder's seemed redundant. According to @lemniscate613 

## Before
![2015-10-26-093049_1148x1056_scrot](https://cloud.githubusercontent.com/assets/93686/10730576/3d495676-7bc7-11e5-875a-fa2f7a37bd4b.png)

## After
![2015-10-26-093117_1148x1056_scrot](https://cloud.githubusercontent.com/assets/93686/10730581/43d6b90c-7bc7-11e5-9129-a5eecd582473.png)

- On saved searches, despite each job listing having its own link, there was no hover effects to indicate that, which to me felt like clicking anywhere in the table would go to the same link

## Before
![2015-10-26-094914_1052x1056_scrot](https://cloud.githubusercontent.com/assets/93686/10730603/632e3032-7bc7-11e5-88f7-570828b04dc9.png)

## After
![2015-10-26-095046_1052x1056_scrot](https://cloud.githubusercontent.com/assets/93686/10730607/6b62b444-7bc7-11e5-8790-5a51312c147c.png)

There isn't a ticket for this as it very well be that no one else finds these points troublesome.