### PR TITLE
[PD-1906] Admin role for new companies

### DIFF
--- a/seo/models.py
+++ b/seo/models.py
@@ -33,7 +33,7 @@ from registration.models import Invitation
 from social_links import models as social_models
 from seo.route53 import can_send_email, make_mx_record
 from seo.search_backend import DESearchQuerySet
-from myjobs.models import User
+from myjobs.models import User, Activity
 from mypartners.models import Tag
 from universal.accessibility import DOCTYPE_CHOICES, LANGUAGE_CODES_CHOICES
 from universal.helpers import get_domain, get_object_or_none
@@ -615,6 +615,10 @@ class Company(models.Model):
             ]
             for tag in default_tags:
                 Tag.objects.get_or_create(company=self, **tag)
+
+            # create the default admin role
+            admin_role = self.role_set.create(name="Admin")
+            admin_role.activities = Activity.objects.all()
 
     def associated_jobs(self):
         b_units = self.job_source_ids.all()

--- a/seo/models.py
+++ b/seo/models.py
@@ -75,11 +75,11 @@ class NonChainedForeignKey(ForeignKey):
     """
     def clean(self, value, model_instance):
         super(NonChainedForeignKey, self).clean(value, model_instance)
-        
+
         if value:
             object_class = model_instance.__class__
             potential_parent = object_class.objects.get(pk=value)
-            
+
             if value == model_instance.pk:
                 raise ValidationError('%s cannot be at parent entity of itself'
                                         % model_instance)
@@ -448,11 +448,11 @@ class SeoSite(Site):
     canonical_company = models.ForeignKey('Company', blank=True, null=True,
                                           on_delete=models.SET_NULL,
                                           related_name='canonical_company_for')
-    
+
     parent_site = NonChainedForeignKey('self', blank=True, null=True,
                                      on_delete=models.SET_NULL,
-                                     related_name='child_sites')                                      
-                                        
+                                     related_name='child_sites')
+
     email_domain = models.CharField(max_length=255, default='my.jobs')
 
     def clean_domain(self):
@@ -523,7 +523,7 @@ class SeoSite(Site):
         if profile and profile.outgoing_email_domain:
             choices.append((profile.outgoing_email_domain,
                             profile.outgoing_email_domain))
-        return choices    
+        return choices
 
     def save(self, *args, **kwargs):
         #always call clean if the parent_site entry exists to prevent invalid
@@ -531,7 +531,7 @@ class SeoSite(Site):
         if self.parent_site: self.clean_fields()
         super(SeoSite, self).save(*args, **kwargs)
         self.clear_caches([self])
-    
+
     def user_has_access(self, user):
         """
         In order for a user to have access they must be a CompanyUser
@@ -681,7 +681,7 @@ class Company(models.Model):
 
     # Permissions
     app_access = models.ManyToManyField(
-        'myjobs.AppAccess', 
+        'myjobs.AppAccess',
         blank=True, verbose_name="App-Level Access")
     prm_access = models.BooleanField(default=False)
     product_access = models.BooleanField(default=False)
@@ -1069,7 +1069,7 @@ class Configuration(models.Model):
     browse_facet_order_3 = models.IntegerField('Order', default=3,
                                                choices=ORDER_CHOICES)
     browse_facet_order_4 = models.IntegerField('Order', default=4,
-                                               choices=ORDER_CHOICES)                                               
+                                               choices=ORDER_CHOICES)
     browse_moc_order = models.IntegerField('Order', default=1,
                                            choices=ORDER_CHOICES)
     browse_company_order = models.IntegerField('Order', default=7,
@@ -1412,7 +1412,7 @@ class MessageQueue():
     MessageQueue.send_messages(request)
     """
     message_queue = Queue.Queue()
-    
+
     @classmethod
     def send_messages(self, request):
         """
@@ -1459,7 +1459,7 @@ def update_canonical_microsites(sender, old_domain, **kwargs):
     """
     Updates company's canonical microsite when an seosite domain is
     changed
-    
+
     """
     companies = Company.objects.filter(
             canonical_microsite='http://%s' % old_domain)
@@ -1474,7 +1474,7 @@ def update_canonical_microsites(sender, old_domain, **kwargs):
 def remove_canonical_microsite(sender, **kwargs):
     """
     Removes a company's canonical microsite when a SeoSite is disabled
-    
+
     """
     companies = Company.objects.filter(
             canonical_microsite='http://%s' % sender.domain)
@@ -1525,4 +1525,4 @@ def seosite_change_monitor(sender, instance, **kwargs):
     except sender.DoesNotExist:
         return None
     if old_instance.domain != instance.domain:
-        microsite_moved.send(sender=instance, old_domain=old_instance.domain) 
+        microsite_moved.send(sender=instance, old_domain=old_instance.domain)

--- a/seo/tests/test_models.py
+++ b/seo/tests/test_models.py
@@ -3,8 +3,7 @@ from django.db import IntegrityError
 from django.core.exceptions import ValidationError
 
 from seo.tests import factories
-from seo.models import CustomFacet, SeoSite, SiteTag
-from seo.tests.factories import CompanyFactory
+from seo.models import Compnay, CustomFacet, SeoSite, SiteTag
 from setup import DirectSEOBase
 
 
@@ -261,5 +260,5 @@ class SeoSitePostAJobFiltersTestCase(DirectSEOBase):
         When a new company is created, that company should have an Admin Role
         available to it.
         """
-        company = CompanyFactory()
+        company = Company.objects.create(name="Test Company")
         self.assertIn('Admin', company.role_set.values_list('name', flat=True))

--- a/seo/tests/test_models.py
+++ b/seo/tests/test_models.py
@@ -3,7 +3,7 @@ from django.db import IntegrityError
 from django.core.exceptions import ValidationError
 
 from seo.tests import factories
-from seo.models import Compnay, CustomFacet, SeoSite, SiteTag
+from seo.models import Company, CustomFacet, SeoSite, SiteTag
 from setup import DirectSEOBase
 
 

--- a/seo/tests/test_models.py
+++ b/seo/tests/test_models.py
@@ -260,5 +260,6 @@ class SeoSitePostAJobFiltersTestCase(DirectSEOBase):
         When a new company is created, that company should have an Admin Role
         available to it.
         """
+
         company = Company.objects.create(name="Test Company")
         self.assertIn('Admin', company.role_set.values_list('name', flat=True))

--- a/seo/tests/test_models.py
+++ b/seo/tests/test_models.py
@@ -4,6 +4,7 @@ from django.core.exceptions import ValidationError
 
 from seo.tests import factories
 from seo.models import CustomFacet, SeoSite, SiteTag
+from seo.tests.factories import CompanyFactory
 from setup import DirectSEOBase
 
 
@@ -254,5 +255,11 @@ class SeoSitePostAJobFiltersTestCase(DirectSEOBase):
         # postajob_sites = company_sites + network_sites + generic_sites +
         #                  new_site
         self.assertEqual(len(postajob_sites), SeoSite.objects.all().count())
-        
-        
+
+    def test_new_company_gets_admin_role(self):
+        """
+        When a new company is created, that company should have an Admin Role
+        available to it.
+        """
+        company = CompanyFactory()
+        self.assertIn('Admin', company.role_set.values_list('name', flat=True))


### PR DESCRIPTION
A previous PR added the admin role to all existing companies (but didn't assign them). This one makes sure that newly created companies have the admin role.

@JLMcLaugh , should this be a hotfix to prevent the week between where admin roles are automatically created and new companies are made without this being in place?
Alternatively, we can fake that migration backward and re-run it to catch up any stragglers (faking all the way forward after that).