### PR TITLE
Stop using seo/secure middleware for redirect [PD-1560]

### DIFF
--- a/redirect_settings.py
+++ b/redirect_settings.py
@@ -1,5 +1,5 @@
 from datetime import timedelta
-from default_settings import MIDDLEWARE_CLASSES
+from django.conf import global_settings
 
 PROJECT = 'redirect'
 
@@ -28,7 +28,7 @@ EXCLUDED_VIEW_SOURCE_CACHE_KEY = 'excluded_view_sources'
 
 CUSTOM_EXCLUSION_CACHE_KEY = 'custom_excluded_view_sources'
 
-MIDDLEWARE_CLASSES += (
+MIDDLEWARE_CLASSES = global_settings.MIDDLEWARE_CLASSES + (
     'redirect.middleware.ExcludedViewSourceMiddleware',
     'redirect.middleware.MyJobsRedirectMiddleware',
 )


### PR DESCRIPTION
Test on QC:
![2015-11-02-095942_722x1215_scrot](https://cloud.githubusercontent.com/assets/3379265/10886207/04a98f88-814f-11e5-88b2-4428bfeebee3.png)

Test on redirect-middleware (not sure why this is a 301 but it resolves in a browser):
![2015-11-02-101501_744x1208_scrot](https://cloud.githubusercontent.com/assets/3379265/10886209/063e0db0-814f-11e5-8438-f97d8e299322.png)

Once any issues are dealt with and we decide on the final change set, I'll open PRs for staging/master.

Tests  pass with the exception of those involving imports.