### PR TITLE
[PD-1913, PD-1914] Deprecate the use of CompanyUser

### DIFF
--- a/mydashboard/views.py
+++ b/mydashboard/views.py
@@ -75,14 +75,17 @@ def dashboard(request, template="mydashboard/mydashboard.html",
 
     authorized_microsites, buids = get_company_microsites(company)
 
-    admins = CompanyUser.objects.filter(company=company.id)
+    # roles are only enabled during development
+    if settings.DEBUG:
+        admins = User.objects.filter(roles__company=company)
+    else:
+        admins = User.objects.filter(company=company)
 
-    # Removes main user from admin list to display other admins
-    admins = admins.exclude(user=request.user)
+    admins = admins.exclude(pk=request.user.pk)
     requested_microsite = request.REQUEST.get('microsite', '')
-    requested_date_button = request.REQUEST.get('date_button', False)    
-    candidates_page = request.REQUEST.get('page', 1)    
-          
+    requested_date_button = request.REQUEST.get('date_button', False)
+    candidates_page = request.REQUEST.get('page', 1)
+
     # the url value for 'All' in the select box is company name
     # which then gets replaced with all microsite urls for that company
     site_name = ''
@@ -447,7 +450,7 @@ def export_csv(request, candidates, models_excluded=[], fields_excluded=[]):
                 num += 1
             else:
                 break
-        
+
         instance = getattr(unit, unit.content_type.name.replace(" ", ""))
         fields = retrieve_fields(instance)
 

--- a/myemails/models.py
+++ b/myemails/models.py
@@ -147,9 +147,8 @@ class Event(models.Model):
             recipients = Role.objects.filter(company=company).values_list(
                 'user__email', flat=True)
         else:
-            recipients = CompanyUser.objects.filter(
-                company=recipient_company).values_list(
-                    'user__email', flat=True)
+            recipients = User.objects.filter(
+                company=recipent_company).values_list('email', flat=True)
 
         if hasattr(sending_company, 'companyprofile'):
             email_domain = sending_company.companyprofile.outgoing_email_domain

--- a/myemails/models.py
+++ b/myemails/models.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from django.contrib.auth.models import ContentType
 from django.contrib.contenttypes.generic import GenericForeignKey
 from django.core.mail import send_mail
+from django.conf import settings
 from django.db import models
 from django.db.models.signals import pre_save, post_save
 from django.dispatch import receiver
@@ -142,9 +143,14 @@ class Event(models.Model):
         if not subject:
             subject = 'An update on your %s' % self.model.name
 
-        recipients = CompanyUser.objects.filter(
-            company=recipient_company).values_list('user__email',
-                                                   flat=True)
+        if settings.DEBUG:
+            recipients = Role.objects.filter(company=company).values_list(
+                'user__email', flat=True)
+        else:
+            recipients = CompanyUser.objects.filter(
+                company=recipient_company).values_list(
+                    'user__email', flat=True)
+
         if hasattr(sending_company, 'companyprofile'):
             email_domain = sending_company.companyprofile.outgoing_email_domain
         else:

--- a/myjobs/templatetags/common_tags.py
+++ b/myjobs/templatetags/common_tags.py
@@ -90,7 +90,10 @@ def get_company_name(user):
 
     # Only return companies for which the user is a company user
     try:
-        return user.company_set.filter(companyuser__user=user)
+        if settings.DEBUG:
+            return Company.objects.filter(role__user=user)
+        else:
+            return user.company_set.filter(companyuser__user=user)
     except ValueError:
         return Company.objects.none()
 

--- a/myjobs/templatetags/common_tags.py
+++ b/myjobs/templatetags/common_tags.py
@@ -93,7 +93,7 @@ def get_company_name(user):
         if settings.DEBUG:
             return Company.objects.filter(role__user=user)
         else:
-            return user.company_set.filter(companyuser__user=user)
+            return user.comapny_set.all()
     except ValueError:
         return Company.objects.none()
 

--- a/myjobs/tests/factories.py
+++ b/myjobs/tests/factories.py
@@ -6,7 +6,7 @@ class UserFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = 'myjobs.User'
 
-    email = 'alice@example.com'
+    email = factory.Sequence(lambda n: 'alice%s@example.com' % n)
     gravatar = 'alice@example.com'
     password = '5UuYquA@'
     user_guid = factory.LazyAttribute(lambda n: '{0}'.format(uuid.uuid4()))

--- a/myjobs/tests/factories.py
+++ b/myjobs/tests/factories.py
@@ -6,7 +6,7 @@ class UserFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = 'myjobs.User'
 
-    email = factory.Sequence(lambda n: 'alice%s@example.com' % n)
+    email = 'alice@example.com'
     gravatar = 'alice@example.com'
     password = '5UuYquA@'
     user_guid = factory.LazyAttribute(lambda n: '{0}'.format(uuid.uuid4()))

--- a/postajob/tests/test_views.py
+++ b/postajob/tests/test_views.py
@@ -190,7 +190,7 @@ class ViewTests(PostajobTestBase):
             HTTP_HOST='test.jobs',
             follow=True)
         self.assertRedirects(
-            response, 
+            response,
             "http://" + self.site.domain + "/login?next=%2Fposting%2Fadmin%2F")
 
     def test_job_access_not_company_user(self):
@@ -212,7 +212,7 @@ class ViewTests(PostajobTestBase):
         created.
         """
         self.sitepackage.sites.clear()
-        
+
         for url in ['request', 'offlinepurchase_add', 'product_add',
                     'productgrouping_add']:
             response = self.client.get(reverse(url), HTTP_HOST='test.jobs')
@@ -286,12 +286,12 @@ class ViewTests(PostajobTestBase):
 
         job = PurchasedJob.objects.get()
         self.assertEqual(job.created_by, self.user)
-    
+
     def test_purchasedjob_update(self):
         product = PurchasedProductFactory(
             product=self.product, owner=self.company)
         job = PurchasedJobFactory(
-            owner=self.company, created_by=self.user, 
+            owner=self.company, created_by=self.user,
             purchased_product=product)
         kwargs = {'pk': job.pk}
 
@@ -666,7 +666,7 @@ class ViewTests(PostajobTestBase):
     def test_purchasedproduct_delete(self):
         purchased_product = PurchasedProductFactory(
             product=self.product, owner=self.company)
-    
+
         kwargs = {'pk': purchased_product.pk}
 
         response = self.client.post(reverse('purchasedproduct_delete',
@@ -717,33 +717,6 @@ class ViewTests(PostajobTestBase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.context['active_jobs']), 3)
         self.assertEqual(len(response.context['expired_jobs']), 1)
-
-    def test_is_company_user(self):
-        # Current user is a CompanyUser
-        params = {'email': self.user.email}
-        url = build_url(reverse('is_company_user'), params)
-        response = self.client.post(url)
-        self.assertEqual(response.content, 'true')
-
-        # Non-existant user is not a CompanyUser
-        params = {'email': 'thisemail@is.madeup'}
-        url = build_url(reverse('is_company_user'), params)
-        response = self.client.post(url)
-        self.assertEqual(response.content, 'false')
-
-        # Generic User is not a CompanyUser.
-        user = UserFactory(email='anew@user.email')
-        params = {'email': user.email}
-        url = build_url(reverse('is_company_user'), params)
-        response = self.client.post(url)
-        self.assertEqual(response.content, 'false')
-
-        # Is inaccessable to non-CompanyUsers.
-        self.company_user.delete()
-        params = {'email': self.user.email}
-        url = build_url(reverse('is_company_user'), params)
-        response = self.client.post(url)
-        self.assertEqual(response.status_code, 404)
 
     def test_offlinepurchase_redeem_not_logged_in(self):
         self.client.logout()
@@ -967,7 +940,7 @@ class ViewTests(PostajobTestBase):
             # include elements from the relevant ProductGrouping and Product
             # instances
             self.assertTrue(text in response.content.decode('utf-8'))
-    
+
     def test_job_add_and_remove_locations(self):
         location = {
             'form-0-city': 'Indianapolis',
@@ -1080,11 +1053,11 @@ class ViewTests(PostajobTestBase):
         self.company_user.company = CompanyFactory(pk=41, name="Wrong Company")
         self.company_user.save()
 
-        for page in ['view_job', 'view_invoice', 
+        for page in ['view_job', 'view_invoice',
                      'purchasedmicrosite_admin_overview', 'admin_products',
                      'admin_groupings', 'admin_offlinepurchase',
-                     'admin_purchasedproduct', 'view_request', 
-                     'process_admin_request', 'resend_invoice', 
+                     'admin_purchasedproduct', 'view_request',
+                     'process_admin_request', 'resend_invoice',
                      'block_user_management']:
 
             response = self.client.get(

--- a/postajob/urls.py
+++ b/postajob/urls.py
@@ -3,7 +3,7 @@ from django.conf.urls import patterns, url
 from postajob import models, views
 from postajob.decorators import (message_when_site_misconfigured,
                                  error_when_site_misconfigured)
-from universal.decorators import company_in_sitepackages 
+from universal.decorators import company_in_sitepackages
 
 
 urlpatterns = patterns(
@@ -13,9 +13,6 @@ urlpatterns = patterns(
     url(r'^order/',
         views.order_postajob,
         name="order_postajob"),
-    url(r'^companyuser/',
-        views.is_company_user,
-        name="is_company_user"),
     url(r'list/$',
         error_when_site_misconfigured(feature='Job Listing', redirect=False)(
             views.product_listing),

--- a/postajob/views.py
+++ b/postajob/views.py
@@ -425,14 +425,6 @@ def order_postajob(request):
     return html
 
 
-@user_is_allowed()
-@company_has_access('product_access')
-def is_company_user(request):
-    email = request.REQUEST.get('email')
-    exists = CompanyUser.objects.filter(user__email=email).exists()
-    return HttpResponse(json.dumps(exists))
-
-
 @csrf_exempt
 @user_is_allowed()
 @company_has_access('product_access')
@@ -792,7 +784,7 @@ class OfflinePurchaseFormView(PostajobModelFormMixin, RequestFormViewBase):
     def get_context_data(self, **kwargs):
         context = super(OfflinePurchaseFormView, self).get_context_data(**kwargs)
         context['show_product_labels'] = True
-        
+
         return context
 
 

--- a/seo/models.py
+++ b/seo/models.py
@@ -646,10 +646,11 @@ class Company(models.Model):
         determining which company to map companyusers to when two company
         instances have very similar names.
 
-        It is treated as a property of the model.
-
         """
-        return self.companyuser_set.count()
+        if settings.DEBUG:
+            return self.role_set.values('user').distinct().count()
+        else:
+            return self.companyuser_set.count()
 
     admins = models.ManyToManyField(User, through='CompanyUser')
     name = models.CharField('Name', max_length=200)

--- a/seo/models.py
+++ b/seo/models.py
@@ -643,9 +643,8 @@ class Company(models.Model):
     def company_user_count(self):
         """
         Counts how many users are mapped to this company. This is useful for
-        determining which company to map companyusers to when two company
-        instances have very similar names.
-
+        determining which user to map a company to when two company instances
+        have very similar names.
         """
         if settings.DEBUG:
             return self.role_set.values('user').distinct().count()
@@ -715,11 +714,11 @@ class Company(models.Model):
 
     def user_has_access(self, user):
         """
-        In order for a user to have access they must be a CompanyUser
-        for the Company.
+        Returns whether or not the given user can be tied back to the company.
         """
+
         if settings.DEBUG:
-            return user.pk in self.values_list('role__user', flat=True)
+            return user.pk in self.role_set.values_list('user', flat=True)
         else:
             return user in self.admins.all()
 

--- a/seo/models.py
+++ b/seo/models.py
@@ -718,7 +718,10 @@ class Company(models.Model):
         In order for a user to have access they must be a CompanyUser
         for the Company.
         """
-        return user in self.admins.all()
+        if settings.DEBUG:
+            return user.pk in self.values_list('role__user', flat=True)
+        else:
+            return user in self.admins.all()
 
     @property
     def has_packages(self):

--- a/seo/tests/test_models.py
+++ b/seo/tests/test_models.py
@@ -149,14 +149,10 @@ class TestRoles(DirectSEOBase):
 
     def test_seosite_user_has_access(self):
         """
-        When activities are enabled, a user must be assigned a role in the
-        company owned by an SeoSite in order to gain access.
-
-        When activities are disabled, that user mus instead be company user for
-        one the SeoSite's companies.
+        Tests that a user has access if that user can be tied back to one of
+        the companies associated with an seo site's business units.
         """
 
-        # activities enabled
         with self.settings(DEBUG=False):
             # no company user, so shouldn't have access
             self.assertFalse(self.site.user_has_access(self.user))
@@ -164,7 +160,6 @@ class TestRoles(DirectSEOBase):
             factories.CompanyUserFactory(company=self.company, user=self.user)
             self.assertTrue(self.site.user_has_access(self.user))
 
-        # activities disabled
         with self.settings(DEBUG=True):
             # user not assigned a role in company, so shouldn't have access
             self.assertFalse(self.site.user_has_access(self.user))
@@ -172,6 +167,25 @@ class TestRoles(DirectSEOBase):
             role = RoleFactory(company=self.company)
             self.user.roles.add(role)
             self.assertTrue(self.site.user_has_access(self.user))
+
+    def test_company_user_has_access(self):
+        """
+        Test that a user has access if the user can be tied to a company.
+        """
+
+        with self.settings(DEBUG=False):
+            self.assertFalse(self.company.user_has_access(self.user))
+
+            factories.CompanyUserFactory(company=self.company, user=self.user)
+            self.assertTrue(self.company.user_has_access(self.user))
+
+        with self.settings(DEBUG=True):
+            # user not assigned a role in company, so shouldn't have access
+            self.assertFalse(self.company.user_has_access(self.user))
+
+            role = RoleFactory(company=self.company)
+            self.user.roles.add(role)
+            self.assertTrue(self.company.user_has_access(self.user))
 
     def test_company_user_count(self):
         """

--- a/seo/tests/test_models.py
+++ b/seo/tests/test_models.py
@@ -207,7 +207,11 @@ class TestRoles(DirectSEOBase):
             self.assertEqual(self.company.company_user_count, 0)
             role = RoleFactory(company=self.company)
 
-            factories.UserFactory.create_batch(10, roles=[role])
+            # can't use create_batch since emails need to be unique and
+            # updating the User model disrupts other tests
+            for i in range(10):
+                factories.UserFactory(
+                    email="alice%s@gmail.com" % i, roles=[role])
             self.assertEqual(self.company.company_user_count, 10)
 
 

--- a/seo/tests/test_models.py
+++ b/seo/tests/test_models.py
@@ -4,7 +4,8 @@ from django.core.exceptions import ValidationError
 
 from seo.tests import factories
 from seo.models import Company, CustomFacet, SeoSite, SiteTag
-from setup import DirectSEOBase
+from myjobs.tests.factories import RoleFactory
+from seo.tests.setup import DirectSEOBase
 
 
 class ModelsTestCase(DirectSEOBase):
@@ -18,10 +19,10 @@ class ModelsTestCase(DirectSEOBase):
         Test to ensure that we can't create a redirect for the same
         SeoSite more than once (enforcing the "unique_together"
         constraint on the SeoSiteRedirect model.
-        
+
         """
         site = factories.SeoSiteFactory()
-        ssr1 = factories.SeoSiteRedirectFactory(seosite=site)
+        factories.SeoSiteRedirectFactory(seosite=site)
         ssr2 = factories.SeoSiteRedirectFactory.build()
         self.assertRaises(IntegrityError, ssr2.save, ())
 
@@ -30,7 +31,7 @@ class ModelsTestCase(DirectSEOBase):
         Test that the Configuration instances associated with a
         particular SeoSite instance have their ``revision`` value
         incremented when the SeoSite is saved.
-        
+
         """
         site = factories.SeoSiteFactory.build()
         site.save()
@@ -61,22 +62,22 @@ class ModelsTestCase(DirectSEOBase):
         """
             Verify that a NonChainedForeignKey field will allow a typical
             one to many relationship with children elements.
-            
+
             Uses SeoSite.parent_site as example field.
         """
         failed = False
         parent_site = factories.SeoSiteFactory()
         child_sites = [factories.SeoSiteFactory() for x in range(0,9)]
         for child in child_sites:
-            child.parent_site = parent_site 
+            child.parent_site = parent_site
             child.clean_fields()
             child.save()
-                    
+
     def test_child_nonchainfk_cant_have_children(self):
         """
-            Verify that a NonChainedForeignKey field that has a parent_site entry 
+            Verify that a NonChainedForeignKey field that has a parent_site entry
             cannot be made the parent of another NonChainedForeignKey field.
-            
+
             Uses SeoSite.parent_site as example field.
         """
         parent_site = factories.SeoSiteFactory()
@@ -92,11 +93,11 @@ class ModelsTestCase(DirectSEOBase):
 
     def test_parent_nonchainfk_cannot_become_child(self):
         """
-            Verify that a NonChainedForeignKey field that has child sites cannot 
-            become the child of another NonChainedForeignKey field. 
-            
+            Verify that a NonChainedForeignKey field that has child sites cannot
+            become the child of another NonChainedForeignKey field.
+
             Uses SeoSite.parent_site as example field.
-        """        
+        """
         initial_parent_site = factories.SeoSiteFactory()
         child_site = factories.SeoSiteFactory()
         super_parent_site = factories.SeoSiteFactory()
@@ -111,16 +112,58 @@ class ModelsTestCase(DirectSEOBase):
     def test_nonchainfk_cant_be_its_own_parent(self):
         """
             Verify that a NonChainedForeignKey field cannot be its own parent.
-            
+
             Uses SeoSite.parent_site as example field.
-        """        
+        """
         orphan_site = factories.SeoSiteFactory()
         orphan_site.parent_site = orphan_site
         with self.assertRaises(ValidationError):
             orphan_site.clean_fields()
         with self.assertRaises(ValidationError):
-            orphan_site.save()        
-        
+            orphan_site.save()
+
+    def test_new_company_gets_admin_role(self):
+        """
+        When a new company is created, that company should have an Admin Role
+        available to it.
+        """
+
+        company = Company.objects.create(name="Test Company")
+        self.assertIn('Admin', company.role_set.values_list('name', flat=True))
+
+    def test_seosite_user_has_access(self):
+        """
+        When activities are enabled, a user must be assigned a role in the
+        company owned by an SeoSite in order to gain access.
+
+        When activities are disabled, that user mus instead be company user for
+        one the SeoSite's companies.
+        """
+
+        user = factories.UserFactory()
+        business_unit = factories.BusinessUnitFactory()
+        company = factories.CompanyFactory()
+        company.job_source_ids.add(business_unit)
+        site = factories.SeoSiteFactory()
+        site.business_units.add(business_unit)
+        # activities enabled
+        with self.settings(DEBUG=False):
+            # no company user, so shouldn't have access
+            self.assertFalse(site.user_has_access(user))
+
+            factories.CompanyUserFactory(company=company, user=user)
+            self.assertTrue(site.user_has_access(user))
+
+        # activities disabled
+        with self.settings(DEBUG=True):
+            # user not assigned a role in company, so shouldn't have access
+            self.assertFalse(site.user_has_access(user))
+
+            role = RoleFactory(company=company)
+            user.roles.add(role)
+            self.assertTrue(site.user_has_access(user))
+
+
 class SeoSitePostAJobFiltersTestCase(DirectSEOBase):
     def setUp(self):
         super(SeoSitePostAJobFiltersTestCase, self).setUp()
@@ -255,11 +298,3 @@ class SeoSitePostAJobFiltersTestCase(DirectSEOBase):
         #                  new_site
         self.assertEqual(len(postajob_sites), SeoSite.objects.all().count())
 
-    def test_new_company_gets_admin_role(self):
-        """
-        When a new company is created, that company should have an Admin Role
-        available to it.
-        """
-
-        company = Company.objects.create(name="Test Company")
-        self.assertIn('Admin', company.role_set.values_list('name', flat=True))

--- a/templates/mydashboard/profile.html
+++ b/templates/mydashboard/profile.html
@@ -16,9 +16,9 @@
                                 </li>
                                 {% endwith %}
                                 {% for admin in company_admins %}
-                                    {% with user_name=admin.user.get_full_name %}
+                                    {% with user_name=user.get_full_name %}
                                     <li>
-                                        {% if not user_name %}{{ admin.user.email }}{% else %}{{ user_name }}{% endif %}
+                                        {% if not user_name %}{{ user.email }}{% else %}{{ user_name }}{% endif %}
                                     </li>
                                     {% endwith %}
                                 {% endfor %} 

--- a/universal/helpers.py
+++ b/universal/helpers.py
@@ -101,8 +101,12 @@ def get_company(request):
     if hasattr(settings, "SITE") and settings.SITE.canonical_company:
         company = settings.SITE.canonical_company
 
-        if company.companyuser_set.filter(user=request.user).exists():
-            return company
+        if settings.DEBUG:
+            if company.role_set.filter(user=request.user).exists():
+                return company
+        else:
+            if company.companyuser_set.filter(user=request.user).exists():
+                return company
 
     # If the current hit is for a non-microsite admin, we don't know what
     # company we should be using; don't guess.


### PR DESCRIPTION
# Note
I am not intending here to completely remove the CompanyUser model, but rather make its inclusion redundant.

# Description
With the introduction of roles, there is no need for a company user table, as a user can be tied to a company merely by seeing if that user is assigned a role which belongs to the company in question. That said, as the activities system isn't deployed, it would be unwise to simply remove any use of the company user model. Instead, what this PR does is ensure that when debugging is enabled, roles are checked and when debugging is disabled, the original behavior which relies upon company users is preserved.

# Branch
This is based off of #1854. The core changes are [here](https://github.com/DirectEmployers/MyJobs/compare/pd-1906...pd-1913?expand=1).

# Caveats
- There are a few things done with CompanyUser that I am intentionally ignoring for the moment, such as post save hooks, as my primary concern with these edits is ensuring that functionality can be properly reached without first having to create a company user.
- Per @JLMcLaugh, I'm ignoring anything to do with selenium/functional tests.
-  I intentionally ignored all of postajobs as it is tightly coupled to company user.
- MyDashboard admin is only to expose company users to django admin, which doesn't make sense to write alternate behavior for

# Progress
This is probably going to take a while, as there are 13 files which reference company user in some way and I need to write regression tests to ensure both behaviors. As such, I'll be updating this PR with my progress as I tackle these issues.

## Files to update
Each will be marked complete once occurrences are resolved and a regression test is written.
- [x] seo/models.py (7 occurrences)
- [x] universal/helpers.py (1 occurrence)
- [x] myjobs/templatetags/common_tags.py (1 occurrence)
- [x] myemails/models.py (2 occurrences)
- [x] mydashboard/views.py (2 occurrences)