### PR TITLE
Fix summary template for myprofile [PD-1947]

### DIFF
--- a/myprofile/tests/test_views.py
+++ b/myprofile/tests/test_views.py
@@ -38,6 +38,9 @@ class MyProfileViewsTests(MyJobsBase):
         self.assertTrue(soup.findAll('tr', {'class': 'profile-section'}))
 
     def test_edit_summary(self):
+        """
+        See test_edit_profile
+        """
         summary = SummaryFactory(user=self.user)
         resp = self.client.get(reverse('view_profile'))
         soup = BeautifulSoup(resp.content)

--- a/myprofile/tests/test_views.py
+++ b/myprofile/tests/test_views.py
@@ -27,7 +27,7 @@ class MyProfileViewsTests(MyJobsBase):
         """
         resp = self.client.get(reverse('view_profile'))
         soup = BeautifulSoup(resp.content)
-        item_id = Name.objects.all()[0].id
+        item_id = self.name.id
 
         # The existing name object should be rendered on the main content
         # section
@@ -36,6 +36,18 @@ class MyProfileViewsTests(MyJobsBase):
         # profile-section contains the name of a profile section that has no
         # information filled out yet and shows up in the sidebar
         self.assertTrue(soup.findAll('tr', {'class': 'profile-section'}))
+
+    def test_edit_summary(self):
+        summary = SummaryFactory(user=self.user)
+        resp = self.client.get(reverse('view_profile'))
+        soup = BeautifulSoup(resp.content)
+
+        item = soup.find('div', id='summary-' + str(summary.id) + '-item')
+        self.assertIsNotNone(item)
+
+        link = item.find('a').attrs['href']
+        resp = self.client.get(link)
+        self.assertEqual(resp.status_code, 200)
 
     def test_handle_form_get_new(self):
         """

--- a/templates/myprofile/modules/summary.html
+++ b/templates/myprofile/modules/summary.html
@@ -1,11 +1,11 @@
 {% load i18n %}
 
-<div class="product-card" id="{{item.get_model_name}}-{{item.id}}-item">
+<div class="product-card" id="{{module.0.get_model_name}}-{{module.0.id}}-item">
     <div class="big-title">
         {{ module.0.headline }}
     </div>
     <div class="product-details">
         {{ module.0.the_summary }}
     </div>
-    <a class="btn" href="{% url 'handle_form' %}?id={{ item.id }}&module={{ item.get_verbose.title }}">{% trans 'Edit' %}</a>
+    <a class="btn" href="{% url 'handle_form' %}?id={{ module.0.id }}&module={{ module.0.get_verbose.title }}">{% trans 'Edit' %}</a>
 </div>


### PR DESCRIPTION
We only allow one summary but the template had been copy/pasted from another module. As such, we weren't grabbing the id and module type of the object being edited.

Tests failed locally but that may be due to me having to extricate myself from a Django 1.8 upgrade before doing this.