### PR TITLE
Fix Topbar with respect to Roles

### DIFF
--- a/myjobs/decorators.py
+++ b/myjobs/decorators.py
@@ -227,7 +227,7 @@ def requires(*activities, **callbacks):
                 return access_callback(request)
             # the user should have at least the activities required by the view
             elif not bool(request.user.activities) or not set(activities).issubset(
-                    user.activities):
+                    request.user.activities):
                 return activity_callback(request)
             else:
                 return view_func(request, *args, **kwargs)

--- a/myjobs/decorators.py
+++ b/myjobs/decorators.py
@@ -222,12 +222,18 @@ def requires(*activities, **callbacks):
                     'name', flat=True).distinct())
 
             # company should have at least the access required by the view
-            if not bool(company.enabled_access) or not set(
-                    required_access).issubset(company.enabled_access):
-                return access_callback(request)
+            has_access = all([
+                bool(company.enabled_access),
+                set(required_access).issubset(company.enabled_access)])
+
             # the user should have at least the activities required by the view
-            elif not bool(request.user.activities) or not set(activities).issubset(
-                    request.user.activities):
+            has_activities = all([
+                bool(request.user.activities),
+                set(activities).issubset(requset.user.activities)])
+
+            if not has_acces:
+                return access_callback(request)
+            elif not has_activities:
                 return activity_callback(request)
             else:
                 return view_func(request, *args, **kwargs)

--- a/myjobs/decorators.py
+++ b/myjobs/decorators.py
@@ -215,11 +215,6 @@ def requires(*activities, **callbacks):
                 return view_func(request, *args, **kwargs)
 
             company = get_company_or_404(request)
-            # the app_access we have, determined by the current company
-            company_access = filter(bool, company.app_access.values_list(
-                'name', flat=True))
-            user_activities = filter(bool, request.user.roles.values_list(
-                'activities__name', flat=True))
 
             # the app_access we need, determined by the activities passed in
             required_access = filter(bool, AppAccess.objects.filter(
@@ -227,12 +222,12 @@ def requires(*activities, **callbacks):
                     'name', flat=True).distinct())
 
             # company should have at least the access required by the view
-            if not bool(company_access) or not set(required_access).issubset(
-                    company_access):
+            if not bool(company.enabled_access) or not set(
+                    required_access).issubset(company.enabled_access):
                 return access_callback(request)
             # the user should have at least the activities required by the view
-            elif not bool(user_activities) or not set(activities).issubset(
-                    user_activities):
+            elif not bool(request.user.activities) or not set(activities).issubset(
+                    user.activities):
                 return activity_callback(request)
             else:
                 return view_func(request, *args, **kwargs)

--- a/myjobs/decorators.py
+++ b/myjobs/decorators.py
@@ -229,9 +229,9 @@ def requires(*activities, **callbacks):
             # the user should have at least the activities required by the view
             has_activities = all([
                 bool(request.user.activities),
-                set(activities).issubset(requset.user.activities)])
+                set(activities).issubset(request.user.activities)])
 
-            if not has_acces:
+            if not has_access:
                 return access_callback(request)
             elif not has_activities:
                 return activity_callback(request)

--- a/myjobs/models.py
+++ b/myjobs/models.py
@@ -701,7 +701,7 @@ class User(AbstractBaseUser, PermissionsMixin):
             elif 'role' in activities:
                 return False
             else:
-                return is_company_user
+                return is_company_user and company.member
 
 
 @receiver(pre_delete, sender=User, dispatch_uid='pre_delete_user')

--- a/myjobs/templatetags/common_tags.py
+++ b/myjobs/templatetags/common_tags.py
@@ -35,6 +35,12 @@ def completion_level(level):
 
     return get_completion(level)
 
+@register.assignment_tag
+def can(user, company, *activity_names):
+    """Template tag analog to `myjobs.User.can()` method."""
+
+    return user.can(company, *activity_names)
+
 
 @register.simple_tag
 def get_description(module):
@@ -71,7 +77,9 @@ def is_a_group_member(company, user, group):
     """
 
     if settings.ROLES_ENABLED:
-        return getattr(company, 'has_features', False)
+        return any([
+            user.can(company, 'read role'),
+            user.can(company, 'read partner')])
     else:
         try:
             return User.objects.is_group_member(user, group)

--- a/myjobs/tests/setup.py
+++ b/myjobs/tests/setup.py
@@ -17,6 +17,7 @@ class MyJobsBase(TestCase):
         self.ms_solr = Solr('http://127.0.0.1:8983/solr/seo')
         self.ms_solr.delete(q='*:*')
         setattr(settings, "PROJECT", 'myjobs')
+        settings.ROLES_ENABLED = False
 
         self.base_context_processors = settings.TEMPLATE_CONTEXT_PROCESSORS
         context_processors = self.base_context_processors + (

--- a/myjobs/tests/test_activities.py
+++ b/myjobs/tests/test_activities.py
@@ -10,7 +10,7 @@ As such, these tests assume that the settings.ENABLE_ROLES is True.
 """
 
 from django.core.urlresolvers import reverse
-from django.test.utils import override_settings
+from django.conf import settings
 
 from myjobs.decorators import MissingActivity
 from myjobs.tests.factories import (AppAccessFactory, RoleFactory, UserFactory,
@@ -20,12 +20,12 @@ from myjobs.tests.test_views import TestClient
 from seo.tests.factories import CompanyFactory
 
 
-@override_settings(ROLES_ENABLED=True)
 class TestViewLevelActivities(MyJobsBase):
     """Test views wrapped with activities."""
 
     def setUp(self):
         super(TestViewLevelActivities, self).setUp()
+        settings.ROLES_ENABLED = True
 
         self.app_access = AppAccessFactory()
         self.activities = [

--- a/myjobs/tests/test_decorators.py
+++ b/myjobs/tests/test_decorators.py
@@ -1,5 +1,7 @@
+"""Tests the decorators in the myjobs app."""
+
 from django.test import RequestFactory
-from django.test.utils import override_settings
+from django.conf import settings
 from django.http import HttpResponse, Http404
 
 from myjobs.tests.setup import MyJobsBase
@@ -15,12 +17,12 @@ def dummy_view(request):
 
 
 # TODO: remove this when the feature goes live
-@override_settings(ROLES_ENABLED=True)
 class DecoratorTests(MyJobsBase):
     """Tests that the various decorators in MyJobs work as expected."""
 
     def setUp(self):
         super(DecoratorTests, self).setUp()
+        settings.ROLES_ENABLED = True
         self.app_access = AppAccessFactory()
         self.company = CompanyFactory(app_access=[self.app_access])
         self.activity = ActivityFactory(app_access=self.app_access)

--- a/myjobs/tests/test_models.py
+++ b/myjobs/tests/test_models.py
@@ -188,8 +188,8 @@ class TestActivities(MyJobsBase):
     def setUp(self):
         super(TestActivities, self).setUp()
 
-        self.company = CompanyFactory()
         self.app_access = AppAccessFactory()
+        self.company = CompanyFactory(app_access=[self.app_access])
         self.activities = ActivityFactory.create_batch(
             5, app_access=self.app_access)
         self.role = RoleFactory(
@@ -290,7 +290,7 @@ class TestActivities(MyJobsBase):
 
         self.assertItemsEqual(user.activities, [])
 
-        self.user.roles.add(self.role)
+        user.roles.add(self.role)
         activities = self.role.activities.values_list('name', flat=True)
 
         self.assertItemsEqual(user.activities, activities)

--- a/myjobs/tests/test_models.py
+++ b/myjobs/tests/test_models.py
@@ -280,3 +280,17 @@ class TestActivities(MyJobsBase):
             self.assertFalse(user.can(
                 self.company, activities[0], "eat a burrito"))
 
+    def test_activities(self):
+        """
+        `User.activities` should return a list of activities associated with
+        this user.
+        """
+
+        user = UserFactory()
+
+        self.assertItemsEqual(user.activities, [])
+
+        self.roles.add(self.role)
+        activities = self.role.activities.values_list('name', flat=True)
+
+        self.assertItemsEqual(user.activities, activities)

--- a/myjobs/tests/test_models.py
+++ b/myjobs/tests/test_models.py
@@ -290,7 +290,7 @@ class TestActivities(MyJobsBase):
 
         self.assertItemsEqual(user.activities, [])
 
-        self.roles.add(self.role)
+        self.user.roles.add(self.role)
         activities = self.role.activities.values_list('name', flat=True)
 
         self.assertItemsEqual(user.activities, activities)

--- a/mypartners/tests/test_activities.py
+++ b/mypartners/tests/test_activities.py
@@ -11,7 +11,7 @@ As such, these tests assume that the settings.ENABLE_ROLES is True.
 
 
 from django.core.urlresolvers import reverse
-from django.test.utils import override_settings
+from django.conf import settings
 
 from myjobs.decorators import MissingActivity
 from myjobs.tests.factories import (AppAccessFactory, RoleFactory, UserFactory,
@@ -21,12 +21,12 @@ from myjobs.tests.test_views import TestClient
 from seo.tests.factories import CompanyFactory
 
 
-@override_settings(ROLES_ENABLED=True)
 class TestViewLevelActivities(MyJobsBase):
     """Test views wrapped with activities."""
 
     def setUp(self):
         super(TestViewLevelActivities, self).setUp()
+        settings.ROLES_ENABLED = True
 
         self.app_access = AppAccessFactory()
         self.activities = [

--- a/myreports/tests/setup.py
+++ b/myreports/tests/setup.py
@@ -1,4 +1,5 @@
 from django.test import TestCase
+from django.conf import settings
 
 from myjobs.tests.test_views import TestClient
 from myjobs.tests.factories import UserFactory
@@ -25,6 +26,7 @@ class MyReportsTestCase(TestCase):
     except that it provides a MyJobs TestClient instance and a logged in user.
     """
     def setUp(self):
+        settings.ROLES_ENABLED = False
         self.client = TestClient()
         self.user = UserFactory(email='testuser@directemployers.org')
         self.user.set_password('aa')

--- a/myreports/tests/test_activities.py
+++ b/myreports/tests/test_activities.py
@@ -10,21 +10,22 @@ As such, these tests assume that the settings.ENABLE_ROLES is True.
 """
 
 from django.core.urlresolvers import reverse
-from django.test import TestCase
-from django.test.utils import override_settings
+from django.conf import settings
 
 from myjobs.decorators import MissingActivity
 from myjobs.tests.factories import (AppAccessFactory, RoleFactory, UserFactory,
                                     ActivityFactory)
 from mypartners.tests.test_views import TestClient
 from seo.tests.factories import CompanyFactory
+from myreports.tests.setup import MyReportsTestCase
 
 
-@override_settings(ROLES_ENABLED=True)
-class TestViewLevelActivities(TestCase):
+class TestViewLevelActivities(MyReportsTestCase):
     """Test views wrapped with activities."""
 
     def setUp(self):
+        super(TestViewLevelActivities, self).setUp()
+        settings.ROLES_ENABLED = True
         self.app_access = AppAccessFactory()
         self.activities = [
             ActivityFactory(name=activity, app_access=self.app_access)

--- a/seo/models.py
+++ b/seo/models.py
@@ -746,6 +746,12 @@ class Company(models.Model):
         return self.sitepackage_set.filter(
             sites__in=settings.SITE.postajob_site_list()).exists()
 
+    @property
+    def enabled_access(self):
+        """Returns a list of app access names associated with this company."""
+
+        return filter(bool, self.app_access.values_list('name', flat=True))
+
 
 class FeaturedCompany(models.Model):
     """

--- a/seo/tests/test_models.py
+++ b/seo/tests/test_models.py
@@ -4,6 +4,7 @@ from django.core.exceptions import ValidationError
 
 from seo.tests import factories
 from seo.models import Company, CustomFacet, SeoSite, SiteTag
+from myjobs.models import AppAccess
 from myjobs.tests.factories import RoleFactory
 from seo.tests.setup import DirectSEOBase
 
@@ -355,4 +356,16 @@ class SeoSitePostAJobFiltersTestCase(DirectSEOBase):
         # postajob_sites = company_sites + network_sites + generic_sites +
         #                  new_site
         self.assertEqual(len(postajob_sites), SeoSite.objects.all().count())
+
+    def test_enabled_access(self):
+        """
+        `Company.enabled_access` should return  list of app access names.
+        """
+        self.assertItemsEqual(self.company.enabled_access, [])
+
+        app_access = AppAccessFactory(name='Test Access')
+        self.company.app_access.add(app_access)
+
+        self.assertItemsEqual(self.company.enabled_access, ['Test Access'])
+
 

--- a/seo/tests/test_models.py
+++ b/seo/tests/test_models.py
@@ -4,7 +4,7 @@ from django.core.exceptions import ValidationError
 
 from seo.tests import factories
 from seo.models import Company, CustomFacet, SeoSite, SiteTag
-from myjobs.models import AppAccess
+from myjobs.tests.factories import AppAccessFactory
 from myjobs.tests.factories import RoleFactory
 from seo.tests.setup import DirectSEOBase
 

--- a/templates/includes/topbar-new.html
+++ b/templates/includes/topbar-new.html
@@ -45,16 +45,18 @@
                         </ul>
                     </li>
                     {% get_company_from_cookie as company %}
+                    {% can user company "read partner" as can_read_partner %}
+                    {% can user company "read role" as can_read_role %}
                     {% is_a_group_member company user "Employer" as group_member %}
                     {% get_company_name user as company_name %}
                     {% if group_member %}
                     <li class="{% active_tab 'employer-tools' %} has-drop">
                         <a>{% trans "Employers" %}</a>
                         <ul id="employer-apps" class="submenu">
-                            {% if company.prm_access %}
+                            {% if can_read_partner %}
                                 <li><a id="partner-tab" href="{{ ABSOLUTE_URL }}prm/view">{% trans "PRM" %}</a></li>
                             {% endif %}
-                            {% if company.prm_access %}
+                            {% if can_read_partner %}
                                 <li><a id="reports-tab" href="{{ ABSOLUTE_URL }}reports/view/overview">{% trans "Reports" %}</a></li>
                             {% endif %}
                             {% if company.product_access %}
@@ -66,7 +68,7 @@
                             {% if company.posting_access %}
                                 <li><a id="posted-jobs-tab" href="{% url 'jobs_overview' %}">{% trans "Posted Jobs" %}</a></li>
                             {% endif %}
-                            {% if request.user.is_staff %}
+                            {% if request.user.is_staff and can_read_role %}
                               <li><a id="posted-jobs-tab" href="{{ ABSOLUTE_URL }}manage-users">{% trans "Manage Users" %}</a></li>
                             {% endif %}
                         </ul>

--- a/templates/includes/topbar-new.html
+++ b/templates/includes/topbar-new.html
@@ -125,7 +125,7 @@
 
                                         <li><a id="savedsearch-link" class="no-show seeker-menu" href="{{ ABSOLUTE_URL }}saved-search/view/">{% trans "My Saved Searches" %}</a></li>
 
-                                        {% if company.prm_access  %}
+                                        {% if can_read_partner %}
 
                                             <li><a id="employer-tools" class="no-show desktop_hide" style="cursor: pointer;">{% trans "Employer" %}</a></li>
 
@@ -133,7 +133,7 @@
                                             <li><a id="partner-link" class="no-show sub-nav-item employer-menu" href="{{ ABSOLUTE_URL }}prm/view?company={{ company.id }}">{% trans "PRM" %}</a></li>
 
                                         {% endif %}
-                                        {% if company.prm_access %}
+                                        {% if can_read_partner %}
                                             <li><a id="reports-link" class="no-show sub-nav-item employer-menu" href="{{ ABSOLUTE_URL }}reports/view/overview">{% trans "Reports" %}</a></li>
                                         {% endif %}
                                         {% if company.product_access %}
@@ -144,6 +144,9 @@
                                         {% endif %}
                                         {% if company.posting_access %}
                                             <li><a id="purchased-microsite-link" class="no-show sub-nav-item employer-menu" href="{{ ABSOLUTE_URL }}{% url 'jobs_overview' %}">{% trans "Posted Jobs" %}</a></li>
+                                        {% endif %}
+                                        {% if request.user.is_staff and can_read_role %}
+                                          <li><a id="posted-jobs-tab" class="no-show sub-nav-item employer-menu" href="{{ ABSOLUTE_URL }}manage-users">{% trans "Manage Users" %}</a></li>
                                         {% endif %}
                                     {% endif %}
                                     <li><a id="account-link" href="{{ ABSOLUTE_URL }}account/edit">{% trans "Account Settings" %}</a></li>

--- a/templates/includes/topbar.html
+++ b/templates/includes/topbar.html
@@ -45,16 +45,18 @@
                         </ul>
                     </li>
                     {% get_company_from_cookie as company %}
+                    {% can user company "read partner" as can_read_partner %}
+                    {% can user company "read role" as can_read_role %}
                     {% is_a_group_member company user "Employer" as group_member %}
                     {% get_company_name user as company_name %}
                     {% if group_member %}
                     <li class="{% active_tab 'employer-tools' %} has-drop">
                         <a>{% trans "Employers" %}</a>
                         <ul id="employer-apps" class="submenu">
-                            {% if company.prm_access %}
+                            {% if can_read_partner %}
                                 <li><a id="partner-tab" href="{{ ABSOLUTE_URL }}prm/view">{% trans "PRM" %}</a></li>
                             {% endif %}
-                            {% if company.prm_access %}
+                            {% if can_read_partner %}
                                 <li><a id="reports-tab" href="{{ ABSOLUTE_URL }}reports/view/overview">{% trans "Reports" %}</a></li>
                             {% endif %}
                             {% if company.product_access %}
@@ -66,7 +68,7 @@
                             {% if company.posting_access %}
                                 <li><a id="posted-jobs-tab" href="{% url 'jobs_overview' %}">{% trans "Posted Jobs" %}</a></li>
                             {% endif %}
-                            {% if request.user.is_staff %}
+                            {% if request.user.is_staff and can_read_role %}
                               <li><a id="posted-jobs-tab" href="{{ ABSOLUTE_URL }}manage-users">{% trans "Manage Users" %}</a></li>
                             {% endif %}
                         </ul>

--- a/templates/includes/topbar.html
+++ b/templates/includes/topbar.html
@@ -125,7 +125,7 @@
 
                                         <li><a id="savedsearch-link" class="no-show seeker-menu" href="{{ ABSOLUTE_URL }}saved-search/view/">{% trans "My Saved Searches" %}</a></li>
 
-                                        {% if company.prm_access  %}
+                                        {% if can_read_partner %}
 
                                             <li><a id="employer-tools" class="no-show desktop_hide" style="cursor: pointer;">{% trans "Employer" %}</a></li>
 
@@ -133,7 +133,7 @@
                                             <li><a id="partner-link" class="no-show sub-nav-item employer-menu" href="{{ ABSOLUTE_URL }}prm/view?company={{ company.id }}">{% trans "PRM" %}</a></li>
 
                                         {% endif %}
-                                        {% if company.prm_access %}
+                                        {% if can_read_partner %}
                                             <li><a id="reports-link" class="no-show sub-nav-item employer-menu" href="{{ ABSOLUTE_URL }}reports/view/overview">{% trans "Reports" %}</a></li>
                                         {% endif %}
                                         {% if company.product_access %}
@@ -144,6 +144,9 @@
                                         {% endif %}
                                         {% if company.posting_access %}
                                             <li><a id="purchased-microsite-link" class="no-show sub-nav-item employer-menu" href="{{ ABSOLUTE_URL }}{% url 'jobs_overview' %}">{% trans "Posted Jobs" %}</a></li>
+                                        {% endif %}
+                                        {% if request.user.is_staff and can_read_role %}
+                                          <li><a id="posted-jobs-tab" class="no-show sub-nav-item employer-menu" href="{{ ABSOLUTE_URL }}manage-users">{% trans "Manage Users" %}</a></li>
                                         {% endif %}
                                     {% endif %}
                                     <li><a id="account-link" href="{{ ABSOLUTE_URL }}account/edit">{% trans "Account Settings" %}</a></li>


### PR DESCRIPTION
# Changes
- Added a few more convenience methods and refactored
- user management was missing from mobile views
- user management only shows up when role are enabled
- prm only shows up when prm is enabled
- if no features are enabled, Employers is disabled all together
- wrote tests for new template tag that I needed to support this
- wrote tests for new convenience methods

# Annotations
One complaint that I've heard often is that PRs aren't reviewed because people are either not familiar with the code or the amount of changes is daunting. I've annotated all my changes as an experiment to see if it hinders or improves the process. Please give feedback (negative or positive, but always constructive) with respect to this aspect. Note that the annotations are cleaner if you read them inline under "File changes"' rather than as part of "Conversation".