### PR TITLE
Roles should be enabled on QC but not Stating.

### DIFF
--- a/deploy/settings.myjobs_staging.py
+++ b/deploy/settings.myjobs_staging.py
@@ -6,7 +6,7 @@ import os
 from secrets import REDIRECT_STAGING, REDIRECT_QC, ARCHIVE_STAGING
 
 DEBUG = True
-ROLES_ENABLED = True
+ROLES_ENABLED = False
 
 DATABASES = {
     'default': dict({


### PR DESCRIPTION
Rationale - QC is our testbed for new features, staging is meant to mirror production. This will also ensure that features implemented in QC don't badly interact with production.