### PR TITLE
[PD-1974] Wrote helper method to invite a user.

### DIFF
--- a/myjobs/tests/test_models.py
+++ b/myjobs/tests/test_models.py
@@ -298,22 +298,27 @@ class TestActivities(MyJobsBase):
 
         with self.settings(ROLES_ENABLED=True):
             user = admin_user.send_invite('regular@joe.com', self.company)
-
-            self.assertFalse(user.can(self.company, 'create user'))
+            self.assertFalse(
+                user.can(self.company, 'create user'),
+                "User shouldn't be able to 'create user', but can")
 
             user = admin_user.send_invite(
                 'regular@joe.com', self.company, role_name=self.role.name)
-            self.assertTrue(user.can(self.company, 'create user'))
+            self.assertTrue(
+                user.can(self.company, 'create user'),
+                "User should be able to 'create user' but can't.")
 
         with self.settings(ROLES_ENABLED=False):
             user = admin_user.send_invite('regular@joe.com', self.company)
-
-            self.assertFalse(user.can(self.company, 'create user'))
+            self.assertFalse(
+                user.can(self.company, 'create user'),
+                "User shouldn't be able to 'create user', but can.")
 
             user = admin_user.send_invite(
                 'regular@joe.com', self.company, True)
-
-            self.assertTrue(user.can(self.company, 'create user'))
+            self.assertTrue(
+                user.can(self.company, 'create user'),
+                "User should be able to 'create user', but can't")
 
 
     def test_activities(self):

--- a/myjobs/tests/test_models.py
+++ b/myjobs/tests/test_models.py
@@ -280,6 +280,42 @@ class TestActivities(MyJobsBase):
             self.assertFalse(user.can(
                 self.company, activities[0], "eat a burrito"))
 
+    def test_send_invite_method(self):
+        """
+        `User.send_invite called without a role should send an invitation
+        email, optionally assiging the reserved user to a role if one was
+        passed in.
+        """
+
+        activity = ActivityFactory(
+            name="create user", app_access=self.app_access)
+        self.role.activities.add(activity)
+        admin_user = UserFactory(email="admin@users.com", roles=[self.role])
+        CompanyUserFactory(user=admin_user, company=self.company)
+
+        # sanity check
+        self.assertTrue(admin_user.can(self.company, 'create user'))
+
+        with self.settings(ROLES_ENABLED=True):
+            user = admin_user.send_invite('regular@joe.com', self.company)
+
+            self.assertFalse(user.can(self.company, 'create user'))
+
+            user = admin_user.send_invite(
+                'regular@joe.com', self.company, role_name=self.role.name)
+            self.assertTrue(user.can(self.company, 'create user'))
+
+        with self.settings(ROLES_ENABLED=False):
+            user = admin_user.send_invite('regular@joe.com', self.company)
+
+            self.assertFalse(user.can(self.company, 'create user'))
+
+            user = admin_user.send_invite(
+                'regular@joe.com', self.company, True)
+
+            self.assertTrue(user.can(self.company, 'create user'))
+
+
     def test_activities(self):
         """
         `User.activities` should return a list of activities associated with

--- a/templates/registration/invitation_email.html
+++ b/templates/registration/invitation_email.html
@@ -38,8 +38,7 @@
             {% else %}
                 {{ invitation.inviting_user.email }}
             {% endif %}
-            has reserved a spot for you to join My.jobs in order to access and
-            administer your job board.
+            has reserved a spot for you to join My.jobs.
         </p>
     {% endif %}
 


### PR DESCRIPTION
# Overview
To allow for invites to be sent from anywhere in a simple fashion, I added a `send_invite` method to `User`.

# Testing
-  call `./manage.py shell`
- import `User` from `myjobs.models` and `Company` from `seo.models`
- assign a user and a compnay for which that user has a role (or assign a role to that user from that company
- call `user.send_invite` with an arbitrary email address (that you own), the company retrieved above, and either `True` if `settings.ROLES_ENABLED` is set to `False` or a valid role name
- You should receive an invitation email, and that user should now exist, assigned the appropriate role (or as a company user if roles aren't enabled)

# Future Work
- [PD-1972](https://directemployersfoundation.atlassian.net/browse/PD-1972) At the moment, the `Invitation` model is tied to saved search due to the original requirements of the feature. Ideally, we'd like the invitation system to be independent of any other models, but decoupling them at this point was more work that we were prepared to deal with in order to get Roles and Activities out the door
- [PD-1856](https://directemployersfoundation.atlassian.net/browse/PD-1856) The messaging here is really generic because the invitation email template doesn't take a parameter to explain the origin of the invite. Future template work should take care of this and allow targeted messaging such as "You've been invited to be an Admin for DirectEmployers"

# Screenshot of resulting email
![2015-12-01-080731_1435x382_scrot](https://cloud.githubusercontent.com/assets/93686/11501488/8a23a5bc-9802-11e5-927b-7d2046a43a64.png)

