### PR TITLE
Remove build killer test now that Jenkins works.

### DIFF
--- a/gulp/src/reporting/spec/reportEngineSpec.js
+++ b/gulp/src/reporting/spec/reportEngineSpec.js
@@ -116,8 +116,4 @@ describe("ReportConfiguration", () => {
         expect(result).toEqual(7);
         expect(fakeComponent.newReportNote).toHaveBeenCalled();
     }));
-
-    it("will fail this test", () => {
-        fail("in order to trigger a build failure.");
-    });
 });


### PR DESCRIPTION
Now that we know Jenkins will fail a build on a bad gulp result, remove this test.