### PR TITLE
Stop trying to shadow the "partner" property [PD-1976]

### DIFF
--- a/mypartners/models.py
+++ b/mypartners/models.py
@@ -785,7 +785,7 @@ class PRMAttachment(models.Model):
                 key.key = self.attachment.name
                 key.set_acl('private')
         except AttributeError:
-            # If we're using(ileSystemStorage, default_storage will not have
+            # If we're using FileSystemStorage, default_storage will not have
             # a "connection" attribute and we don't need to worry about
             # S3 permissions.
             pass

--- a/mypartners/tests/test_activities.py
+++ b/mypartners/tests/test_activities.py
@@ -308,13 +308,3 @@ class TestViewLevelActivities(MyJobsBase):
         self.assertRequires(
             "manage_outreach_inboxes", "create partner", "create contact",
             "create communication record")
-
-    def test_process_email(self):
-        """
-        /prm/email requires "create partner", "create contact", and
-        "create communication record"
-        """
-
-        self.assertRequires(
-            "process_email", "create partner", "create contact",
-            "create communication record")

--- a/mypartners/tests/test_views.py
+++ b/mypartners/tests/test_views.py
@@ -1158,19 +1158,25 @@ class EmailTests(MyPartnersTestCase):
         """
         Confirms that files posted by SendGrid will be attached correctly.
         """
+        # Sanity checks for initial state.
         self.assertEqual(len(mail.outbox), 0,
                          'We should have no emails at test start')
         self.assertEqual(
             ContactRecord.objects.count(), 0,
             'We should have no communication records at test start')
+
+        # Testing file attachments seems to require either a RequestFactory
+        # or a custom middleware. I chose the factory.
         factory = RequestFactory()
+
+        # Add some necessary data to our post dict.
         self.data['attachments'] = 1
         self.data['to'] = self.contact.email
 
         request = factory.post(reverse('process_email'), self.data)
-        request.method = 'POST'
         request.user = AnonymousUser()
 
+        # Grab our test file and attach it to the request.
         actual_file = path.join(path.abspath(path.dirname(__file__)), 'data',
                                 'test.txt')
         f = SimpleUploadedFile('test.txt', open(actual_file).read())

--- a/mypartners/tests/test_views.py
+++ b/mypartners/tests/test_views.py
@@ -1182,7 +1182,8 @@ class EmailTests(MyPartnersTestCase):
         self.assertEqual(len(mail.outbox), 1,
                          'process_email should have sent one email')
         self.assertEqual(ContactRecord.objects.count(), 1,
-                         'After ')
+                         ('After process_email finishes, we should have one'
+                          'communication record'))
         record = ContactRecord.objects.get()
         self.assertEqual(record.prmattachment_set.count(), 1,
                          ('The file posted earlier should be attached to the'

--- a/mypartners/views.py
+++ b/mypartners/views.py
@@ -1306,7 +1306,7 @@ def process_email(request):
                 prm_attachment = PRMAttachment()
                 prm_attachment.attachment = attachment
                 prm_attachment.contact_record = record
-                setattr(prm_attachment, 'partner', contact.partner)
+                prm_attachment._partner = contact.partner
                 prm_attachment.save()
                 # The file pointer for this attachment is now at the end of the
                 # file; reset it to the beginning for future use.

--- a/mypartners/views.py
+++ b/mypartners/views.py
@@ -1163,7 +1163,6 @@ def prm_export(request):
 
 
 @csrf_exempt
-@requires("create partner", "create contact", "create communication record")
 def process_email(request):
     """
     Creates a contact record from an email received via POST.


### PR DESCRIPTION
# Testing
Run tests. They pass.
If you want to test the old behavior, you'll have to copy the `test_attachments_attach` test from mypartners/tests/test_views.py to QC and run it. It should fail because there are no PRMAttachments.