### PR TITLE
Fix so build fails on webpack errors.

### DIFF
--- a/gulp/gulpfile.js
+++ b/gulp/gulpfile.js
@@ -111,6 +111,10 @@ gulp.task('bundle', function(callback) {
       throw new util.PluginError("webpack", err);
     }
     util.log(stats.toString("minimal"));
+    if (stats.hasErrors()) {
+      callback('webpack error');
+      return;
+    }
     fs.writeFile('profile.json', JSON.stringify(stats.toJson(), null, 4));
     callback();
   });
@@ -141,6 +145,10 @@ gulp.task('dev-bundle', function(callback) {
       throw new util.PluginError("webpack", err);
     }
     util.log(stats.toString('minimal'));
+    if (stats.hasErrors()) {
+      callback('webpack error');
+      return;
+    }
     fs.writeFile('profile.json', JSON.stringify(stats.toJson(), null, 4));
     callback();
   });


### PR DESCRIPTION
This was causing gulp to not fail on certain webpack specific errors.