### PR TITLE
fixed cyclic imports

### DIFF
--- a/mysearches/models.py
+++ b/mysearches/models.py
@@ -10,7 +10,6 @@ from django.utils.translation import ugettext_lazy as _
 from django.template.loader import render_to_string
 import uuid
 
-from myjobs.models import User
 from mypartners.models import Contact, ContactRecord, Partner, EMAIL
 from mysearches.helpers import (parse_feed, update_url_if_protected,
                                 url_sort_options)
@@ -546,7 +545,7 @@ class PartnerSavedSearch(SavedSearch):
                               "of this saved search.")
     unsubscribed = models.BooleanField(default=False)
     tags = models.ManyToManyField('mypartners.Tag', null=True)
-    created_by = models.ForeignKey(User, editable=False,
+    created_by = models.ForeignKey('myjobs.User', editable=False,
                                    related_name='created_by',
                                    on_delete=models.SET_NULL,
                                    null=True)
@@ -634,7 +633,7 @@ class SavedSearchLog(models.Model):
                                        "SendGrid may not have responded yet - "
                                        "give it a few minutes."))
     reason = models.TextField()
-    recipient = models.ForeignKey(User, on_delete=models.SET_NULL, null=True)
+    recipient = models.ForeignKey('myjobs.User', on_delete=models.SET_NULL, null=True)
     recipient_email = models.EmailField(max_length=255, blank=False)
     new_jobs = models.IntegerField()
     backfill_jobs = models.IntegerField()

--- a/postajob/models.py
+++ b/postajob/models.py
@@ -14,7 +14,6 @@ from django.db.models.signals import pre_delete, m2m_changed
 from django.template.loader import render_to_string
 from django.utils.translation import ugettext_lazy as _
 
-from import_jobs import delete_by_guid
 from location_data import countries, all_regions, country_list, state_list
 from universal.helpers import send_email
 
@@ -272,6 +271,10 @@ def update_job_in_solr(sender, instance, action, **kwargs):
     Once a job is no longer associated with any locations, it should be removed
     from SOLR.
     """
+
+    # circular imports; I hate this
+    from import_jobs import delete_by_guid
+
     if action in ['post_remove', 'post_clear']:
         guids = JobLocation.objects.filter(
             jobs__isnull=True).values_list('guid', flat=True)


### PR DESCRIPTION
**bugfix**

We have 19 cyclic imports. A common workaround that we have used (that I don't like) is to use local imports within a function. I used that work around here because a) qc is broken right **now**, so I wanted this fixed sooner than later, and b) we already do similar within the same module for the same reason (using stuff from import_jobs). @mklauber had mentioned refactoring import_jobs.py, tasks.py, and xmlparse.py to take care cyclic imports in a more satisfactory way.