### PR TITLE
Removed military stuff from non-military pages.

### DIFF
--- a/mysearches/tests/local/careers.html
+++ b/mysearches/tests/local/careers.html
@@ -94,8 +94,6 @@ function goalClick(goalURL, the_url){
 
 
 
-<script src="//d2e48ltfsb5exy.cloudfront.net/content_ms/files/military_family_loc.json"></script>
-
 
 <link rel="alternate" type="application/rss+xml" title="My.jobs - Nurse Jobs in chicago" href="http://www.my.jobs/jobs/feed/rss?location=chicago&amp;amp;q=nurse">
 

--- a/mysearches/tests/local/jobs.html
+++ b/mysearches/tests/local/jobs.html
@@ -94,8 +94,6 @@ function goalClick(goalURL, the_url){
 
 
 
-<script src="//d2e48ltfsb5exy.cloudfront.net/content_ms/files/military_family_loc.json"></script>
-
 
 <link rel="alternate" type="application/rss+xml" title="My.jobs - Jobs " href="http://www.my.jobs/jobs/feed/rss%(qs)s">
 

--- a/templates/seo_base.html
+++ b/templates/seo_base.html
@@ -68,8 +68,6 @@
     {% endif %}
 
 
-    <script src="{{ STATIC_URL }}military_family_loc.json"></script>
-
     {% block rss_feed %}{% endblock %}
 
 


### PR DESCRIPTION
Basically we were loading extra data that wasn't being used. No new tests because this is a template-only change. The only way I can think of to test what this is doing is to render every template and ensure that the json file is only used on the military template, but that seems pointless and would necessitate that any new template would require an update of that test.