### PR TITLE
[PD-1856] Custom invitation reasons

### DIFF
--- a/myjobs/models.py
+++ b/myjobs/models.py
@@ -719,7 +719,13 @@ class User(AbstractBaseUser, PermissionsMixin):
             :email: The email address of the potential user being invited.
             :company: The company inviting the user.
             :role_name: The name of the role (optional) the user is to be
-            assigned.
+                        assigned.
+            :reason: The readon for the invite, included in the email body. If
+                     a ```role_name``` is provided but reason is not, then the
+                     recipient will be notified that they are being invited to
+                     assume that role for the ```company``` which was provided.
+                     If neither is provided, a generic invitation email is sent
+                     instead.
 
         Output:
             The invited user if sucessful, otherwise None.
@@ -742,13 +748,10 @@ class User(AbstractBaseUser, PermissionsMixin):
         invitation = Invitation.objects.create(
             inviting_user=self, inviting_company=company, invitee=user)
 
-        if not reason:
-            if role_name:
-                reason = "as a(n) %s for %s." % (role_name, company)
-            else:
-                reason = "."
+        if not reason and role_name:
+            reason = "as a(n) %s for %s" % (role_name, company)
 
-        invitation.send(reason)
+        invitation.send(reason + ".")
 
         if role_name:
             if settings.ROLES_ENABLED:

--- a/myjobs/models.py
+++ b/myjobs/models.py
@@ -742,8 +742,11 @@ class User(AbstractBaseUser, PermissionsMixin):
         invitation = Invitation.objects.create(
             inviting_user=self, inviting_company=company, invitee=user)
 
-        if not reason and role_name:
-            reason = "as a(n) %s for %s" % (role_name, company)
+        if not reason:
+            if role_name:
+                reason = "as a(n) %s for %s." % (role_name, company)
+            else:
+                reason = "."
 
         invitation.send(reason)
 

--- a/mysearches/forms.py
+++ b/mysearches/forms.py
@@ -291,7 +291,8 @@ class PartnerSavedSearchForm(RequestForm):
                 'inviting_company': instance.partner.owner,
                 'added_saved_search': instance,
             }
-            Invitation(**invite_args).save()
+            invitation = Invitation.objects.create(**invite_args)
+            invitation.send()
             # Default sort_by for new Partner Saved Searches, see PD-912
         partner = instance.partner
         contact = Contact.objects.filter(partner=partner,

--- a/mysearches/tests/test_models.py
+++ b/mysearches/tests/test_models.py
@@ -427,11 +427,13 @@ class PartnerSavedSearchTests(MyJobsBase):
         # Partner searches are normally created with a form, which creates
         # invitations as a side effect. We're not testing the form, so we
         # can fake an invitation here.
-        Invitation(invitee_email=self.partner_search.email,
-                   invitee=self.partner_search.user,
-                   inviting_user=self.partner_search.created_by,
-                   inviting_company=self.partner_search.partner.owner,
-                   added_saved_search=self.partner_search).save()
+        invitation = Invitation.objects.create(
+            invitee_email=self.partner_search.email,
+            invitee=self.partner_search.user,
+            inviting_user=self.partner_search.created_by,
+            inviting_company=self.partner_search.partner.owner,
+            added_saved_search=self.partner_search).save()
+        invitation.send()
 
         self.num_occurrences = lambda text, search_str: [match.start()
                                                          for match

--- a/mysearches/tests/test_models.py
+++ b/mysearches/tests/test_models.py
@@ -432,7 +432,7 @@ class PartnerSavedSearchTests(MyJobsBase):
             invitee=self.partner_search.user,
             inviting_user=self.partner_search.created_by,
             inviting_company=self.partner_search.partner.owner,
-            added_saved_search=self.partner_search).save()
+            added_saved_search=self.partner_search)
         invitation.send()
 
         self.num_occurrences = lambda text, search_str: [match.start()

--- a/registration/forms.py
+++ b/registration/forms.py
@@ -269,4 +269,5 @@ class InvitationForm(forms.ModelForm):
             if value is not None:
                 setattr(instance, field, value)
         instance.save()
+        invitation.send()
         return instance

--- a/registration/forms.py
+++ b/registration/forms.py
@@ -269,5 +269,5 @@ class InvitationForm(forms.ModelForm):
             if value is not None:
                 setattr(instance, field, value)
         instance.save()
-        invitation.send()
+        instance.send()
         return instance

--- a/registration/models.py
+++ b/registration/models.py
@@ -184,20 +184,27 @@ class Invitation(models.Model):
         else:
             self.invitee_email = self.invitee.email
 
-        if not self.pk:
-            self.send()
-
         super(Invitation, self).save(*args, **kwargs)
 
-    def send(self):
+    def send(self, invitation_reason=""):
         ap = ActivationProfile.objects.get_or_create(user=self.invitee,
                                                      email=self.invitee_email)[0]
+        if not invitation_reason:
+            if self.added_saved_search:
+                invitation_reason = ("in order to begin receiving their "
+                                     "available job opportunities on a "
+                                     "regular basis")
+            elif self.added_permission:
+                invitation_reason = ("in order to help administer their "
+                                     "recruitment and outreach tools")
+
         if ap.activation_key_expired():
             ap.reset_activation()
             ap = ActivationProfile.objects.get(pk=ap.pk)
 
         context = {'invitation': self,
-                   'activation_key': ap.activation_key}
+                   'activation_key': ap.activation_key,
+                   'invitation_reason': invitation_reason}
 
         text_only = False
         if self.added_saved_search:

--- a/registration/models.py
+++ b/registration/models.py
@@ -186,10 +186,10 @@ class Invitation(models.Model):
 
         super(Invitation, self).save(*args, **kwargs)
 
-    def send(self, invitation_reason=""):
+    def send(self, reason=""):
         """
         Inputs:
-            :invitation_reason: A custom reason to be included in the email.
+            :reason: A custom reason to be included in the email.
                                 This reason should not include punctuation.
 
         Outputs:
@@ -197,19 +197,19 @@ class Invitation(models.Model):
             the ```Invitation.email``` address. Tailored messages are sent if
             ```Invitation.added_saved_search``` or
             ```Invitation.added_permission are set. If neither are set and no
-            ```invitation_reason``` is set, a generic email is sent.
+            ```reason``` is set, a generic email is sent.
 
         """
         activiation_profile, _ = ActivationProfile.objects.get_or_create(
             user=self.invitee, email=self.invitee.email)
 
-        if not invitation_reason:
+        if not reason:
             if self.added_saved_search:
-                invitation_reason = ("in order to begin receiving their "
+                reason = ("in order to begin receiving their "
                                      "available job opportunities on a "
                                      "regular basis.")
             elif self.added_permission:
-                invitation_reason = ("in order to help administer their "
+                reason = ("in order to help administer their "
                                      "recruitment and outreach tools.")
 
         if activiation_profile.activation_key_expired():
@@ -218,7 +218,7 @@ class Invitation(models.Model):
 
         context = {'invitation': self,
                    'activation_key': activiation_profile.activation_key,
-                   'invitation_reason': invitation_reason + "."}
+                   'reason': reason + "."}
 
         text_only = False
         if self.added_saved_search:

--- a/registration/models.py
+++ b/registration/models.py
@@ -211,13 +211,16 @@ class Invitation(models.Model):
                 reason = ("in order to help administer their recruitment and "
                           "outreach tools")
 
+        reason = " " if reason else "" + reason + "."
+
         if activiation_profile.activation_key_expired():
             activiation_profile.reset_activation()
-            ap = ActivationProfile.objects.get(pk=activiation_profile.pk)
+            application_profile  = ActivationProfile.objects.get(
+                pk=activiation_profile.pk)
 
         context = {'invitation': self,
                    'activation_key': activiation_profile.activation_key,
-                   'reason': "{}{}.".format(" " if reason else "", reason)}
+                   'reason': reason}
 
         text_only = False
         if self.added_saved_search:

--- a/registration/models.py
+++ b/registration/models.py
@@ -205,12 +205,11 @@ class Invitation(models.Model):
 
         if not reason:
             if self.added_saved_search:
-                reason = ("in order to begin receiving their "
-                                     "available job opportunities on a "
-                                     "regular basis")
+                reason = ("in order to begin receiving their available job "
+                          "opportunities on a regular basis")
             elif self.added_permission:
-                reason = ("in order to help administer their "
-                                     "recruitment and outreach tools")
+                reason = ("in order to help administer their recruitment and "
+                          "outreach tools")
 
         if activiation_profile.activation_key_expired():
             activiation_profile.reset_activation()
@@ -218,7 +217,7 @@ class Invitation(models.Model):
 
         context = {'invitation': self,
                    'activation_key': activiation_profile.activation_key,
-                   'reason': reason + "."}
+                   'reason': "{}{}.".format(" " if reason else "", reason)}
 
         text_only = False
         if self.added_saved_search:

--- a/registration/models.py
+++ b/registration/models.py
@@ -207,10 +207,10 @@ class Invitation(models.Model):
             if self.added_saved_search:
                 reason = ("in order to begin receiving their "
                                      "available job opportunities on a "
-                                     "regular basis.")
+                                     "regular basis")
             elif self.added_permission:
                 reason = ("in order to help administer their "
-                                     "recruitment and outreach tools.")
+                                     "recruitment and outreach tools")
 
         if activiation_profile.activation_key_expired():
             activiation_profile.reset_activation()

--- a/registration/models.py
+++ b/registration/models.py
@@ -193,10 +193,12 @@ class Invitation(models.Model):
             if self.added_saved_search:
                 invitation_reason = ("in order to begin receiving their "
                                      "available job opportunities on a "
-                                     "regular basis")
+                                     "regular basis.")
             elif self.added_permission:
                 invitation_reason = ("in order to help administer their "
-                                     "recruitment and outreach tools")
+                                     "recruitment and outreach tools.")
+            else:
+                invitation_reason = "."
 
         if ap.activation_key_expired():
             ap.reset_activation()

--- a/registration/models.py
+++ b/registration/models.py
@@ -211,7 +211,7 @@ class Invitation(models.Model):
                 reason = ("in order to help administer their recruitment and "
                           "outreach tools")
 
-        reason = " " if reason else "" + reason + "."
+        reason = (" " if reason else "") + reason + "."
 
         if activiation_profile.activation_key_expired():
             activiation_profile.reset_activation()

--- a/registration/tests/test_models.py
+++ b/registration/tests/test_models.py
@@ -289,7 +289,7 @@ class InvitationModelTests(MyJobsBase):
             # but not a normal user creation email
             self.assertEqual(len(mail.outbox), 1)
             email = mail.outbox.pop()
-            self.assertTrue('reserved' in email.body)
+            self.assertIn("invited you to join My.jobs.", email.body)
 
         self.assertEqual(len(users), 2)
         self.assertItemsEqual(users, set(users))

--- a/registration/tests/test_models.py
+++ b/registration/tests/test_models.py
@@ -229,6 +229,7 @@ class InvitationModelTests(MyJobsBase):
         Ensures that there is no way to edit an invitation once it is sent
         """
         invitation = InvitationFactory()
+        invitation.send()
         resp = self.client.get(reverse(
             'admin:registration_invitation_changelist'))
         contents = BeautifulSoup(resp.content)
@@ -260,6 +261,7 @@ class InvitationModelTests(MyJobsBase):
             'admin:registration_invitation_add'),
             {'invitee_email': 'email@example.com'})
         invitation = Invitation.objects.get()
+        invitation.send()
         self.assertEqual(invitation.inviting_user, self.admin)
 
     def test_invitation_form_creates_invitee(self):
@@ -298,7 +300,8 @@ class InvitationModelTests(MyJobsBase):
                      {'invitee': self.admin},
                      {'invitee_email': 'new_user@example.com'}]:
             args.update({'inviting_user': self.admin})
-            Invitation(**args).save()
+            invitation = Invitation.objects.create(**args)
+            invitation.send()
         self.assertEqual(User.objects.count(), 2)
 
     def test_invitation_model_save_failure(self):
@@ -312,7 +315,7 @@ class InvitationModelTests(MyJobsBase):
                                       'Invitee information does not match'),
                                      ({}, 'Invitee not provided')]:
             with self.assertRaises(ValidationError) as e:
-                Invitation(**args).save()
+                invitation = Invitation.objects.create(**args)
             self.assertEqual(e.exception.messages, [exception_text])
 
     def companyuser_invitation(self, user, company):
@@ -389,8 +392,10 @@ class InvitationModelTests(MyJobsBase):
 
     def test_invitation_emails_new_user(self):
         self.assertEqual(len(mail.outbox), 0)
-        Invitation(invitee_email='prm_user@company.com',
-                   inviting_user=self.admin).save()
+        invitation = Invitation.objects.create(
+            invitee_email='prm_user@company.com',
+            inviting_user=self.admin)
+        invitation.send()
         self.assertEqual(len(mail.outbox), 1)
 
         user = User.objects.get(email='prm_user@company.com')
@@ -421,8 +426,9 @@ class InvitationModelTests(MyJobsBase):
     def test_invitation_email_with_name(self):
         PrimaryNameFactory(user=self.admin)
 
-        Invitation(invitee_email='prm_user@company.com',
-                   inviting_user=self.admin).save()
+        invitation = Invitation.objects.create(
+            invitee_email='prm_user@company.com', inviting_user=self.admin)
+        invitation.send()
 
         email = mail.outbox.pop()
         self.assertTrue(self.admin.get_full_name() in email.body)

--- a/registration/tests/test_views.py
+++ b/registration/tests/test_views.py
@@ -26,7 +26,6 @@ class RegistrationViewTests(MyJobsBase):
     Test the registration views.
 
     """
-
     def setUp(self):
         """
         These tests use the default backend, since we know it's
@@ -165,6 +164,7 @@ class RegistrationViewTests(MyJobsBase):
         prompted to change their password.
         """
         invitation = InvitationFactory(inviting_user=self.user)
+        invitation.send()
         key = invitation.invitee.activationprofile_set.first().activation_key
         response = self.client.get(
             reverse('invitation_activate', kwargs={'activation_key': key}),
@@ -181,6 +181,7 @@ class RegistrationViewTests(MyJobsBase):
         has already been used.
         """
         invitation = InvitationFactory(invitee_email=self.user.email)
+        invitation.send()
         self.assertFalse(invitation.accepted)
         profile = self.user.activationprofile_set.all()[0]
         key = profile.activation_key
@@ -195,9 +196,36 @@ class RegistrationViewTests(MyJobsBase):
         response = self.client.get(reverse('invitation_activate', args=[key]))
         self.assertTrue('Thanks for registering!' in response.content)
         invitation = Invitation.objects.get()
+        invitation.send()
         self.assertTrue(invitation.accepted)
         user = User.objects.get(pk=self.user.pk)
         self.assertFalse(user.in_reserve)
+
+    def test_saved_search_invitation_message(self):
+        """
+        Tests that saved search invitation emails are formatted correctly.
+
+        """
+
+    def test_permission_invitation_message(self):
+        """
+        Tests that invitation emails where permissions are changed are
+        formatted correctly.
+
+        """
+
+    def test_generic_invitation_message(self):
+        """
+        Tests that generic invitation emails are formatted correctly.
+
+        """
+
+    def test_custom_invitation_message(self):
+        """
+        Test that invitation messages with custom reasons are formatted
+        correctly.
+
+        """
 
 
 class MergeUserTests(MyJobsBase):

--- a/seo/models.py
+++ b/seo/models.py
@@ -1409,7 +1409,8 @@ class CompanyUser(models.Model):
             invitation = Invitation.objects.create(
                 invitee=self.user, inviting_company=self.company,
                 added_permission=group,
-                inviting_user=inviting_user).save(using=using)
+                inviting_user=inviting_user)
+            invitation.save(using=using)
             invitation.send()
 
         return super(CompanyUser, self).save(*args, **kwargs)

--- a/seo/models.py
+++ b/seo/models.py
@@ -1406,9 +1406,11 @@ class CompanyUser(models.Model):
         # and not being invited, so only create an invitation if we can
         # determine who is inviting them.
         if not self.pk and inviting_user:
-            Invitation(invitee=self.user, inviting_company=self.company,
-                       added_permission=group,
-                       inviting_user=inviting_user).save(using=using)
+            invitation = Invitation.objects.create(
+                invitee=self.user, inviting_company=self.company,
+                added_permission=group,
+                inviting_user=inviting_user).save(using=using)
+            invitation.send()
 
         return super(CompanyUser, self).save(*args, **kwargs)
 

--- a/templates/registration/invitation_email.html
+++ b/templates/registration/invitation_email.html
@@ -12,7 +12,8 @@
         {% else %}
             {{ invitation.inviting_user.email }}
         {% endif %}
-        of {{ invitation.inviting_company.name }} has invited you to join My.jobs{{ reason }}
+        of {{ invitation.inviting_company.name }} has invited you to join
+        My.jobs {{ reason }}
     </p>
 
     {% if invitation.added_permission %}

--- a/templates/registration/invitation_email.html
+++ b/templates/registration/invitation_email.html
@@ -6,43 +6,18 @@
     Dear {% if invitation.invitee.get_full_name %}{{ invitation.invitee.get_full_name }}{% else %}{{ invitation.invitee_email }}{% endif %},
 
     {% url 'invitation_activate' activation_key as url %}
-    {% if invitation.added_saved_search %}
-        <p>
-            {% if inviting_user_name %}
-                {{ inviting_user_name }}
-            {% else %}
-                {{ invitation.inviting_user.email }}
-            {% endif %}
-            of {{ invitation.inviting_company.name }} has invited you to join My.jobs in order to begin receiving
-            {{ invitation.inviting_company.name }}'s available job opportunities on
-            a regular basis.
-        </p>
-    {% elif invitation.added_permission %}
-        <p>
-            {% if inviting_user_name %}
-                {{ inviting_user_name }}
-            {% else %}
-                {{ invitation.inviting_user.email }}
-            {% endif %}
-            has reserved a spot for you to join My.jobs in order to help
-            administer {{ invitation.inviting_company.name }}'s recruitment
-            and outreach tools.
-        </p>
+    <p>
+        {% if inviting_user_name %}
+            {{ inviting_user_name }}
+        {% else %}
+            {{ invitation.inviting_user.email }}
+        {% endif %}
+        of {{ invitation.inviting_company.name }} has invited you to join My.jobs {{ invitation_reason }}.
+    </p>
 
+    {% if invitation.invitee.is_verified %}
         <p>You can <a href="https://secure.my.jobs{% url 'home' %}">log in here.</a></p>
     {% else %}
-        <p>
-            Your colleague
-            {% if inviting_user_name %}
-                {{ inviting_user_name }}
-            {% else %}
-                {{ invitation.inviting_user.email }}
-            {% endif %}
-            has reserved a spot for you to join My.jobs.
-        </p>
-    {% endif %}
-
-    {% if not invitation.invitee.is_verified %}
         <p>Please click on the Activate Account button below to get started.</p>
 
         <p><a href="https://secure.my.jobs{{ url }}?verify={{ invitation.invitee.user_guid}}" class="btn">Activate Account</a></p>

--- a/templates/registration/invitation_email.html
+++ b/templates/registration/invitation_email.html
@@ -15,9 +15,10 @@
         of {{ invitation.inviting_company.name }} has invited you to join My.jobs{{ reason }}
     </p>
 
-    {% if invitation.invitee.is_verified %}
+    {% if invitation.added_permission %}
         <p>You can <a href="https://secure.my.jobs{% url 'home' %}">log in here.</a></p>
-    {% else %}
+    {% endif %}
+    {% if not invitation.invitee.is_verified %}
         <p>Please click on the Activate Account button below to get started.</p>
 
         <p><a href="https://secure.my.jobs{{ url }}?verify={{ invitation.invitee.user_guid}}" class="btn">Activate Account</a></p>

--- a/templates/registration/invitation_email.html
+++ b/templates/registration/invitation_email.html
@@ -12,7 +12,7 @@
         {% else %}
             {{ invitation.inviting_user.email }}
         {% endif %}
-        of {{ invitation.inviting_company.name }} has invited you to join My.jobs {{ reason }}
+        of {{ invitation.inviting_company.name }} has invited you to join My.jobs{{ reason }}
     </p>
 
     {% if invitation.added_permission %}

--- a/templates/registration/invitation_email.html
+++ b/templates/registration/invitation_email.html
@@ -12,7 +12,7 @@
         {% else %}
             {{ invitation.inviting_user.email }}
         {% endif %}
-        of {{ invitation.inviting_company.name }} has invited you to join My.jobs{{ invitation_reason }}
+        of {{ invitation.inviting_company.name }} has invited you to join My.jobs{{ reason }}
     </p>
 
     {% if invitation.invitee.is_verified %}

--- a/templates/registration/invitation_email.html
+++ b/templates/registration/invitation_email.html
@@ -12,7 +12,7 @@
         {% else %}
             {{ invitation.inviting_user.email }}
         {% endif %}
-        of {{ invitation.inviting_company.name }} has invited you to join My.jobs {{ invitation_reason }}.
+        of {{ invitation.inviting_company.name }} has invited you to join My.jobs{{ invitation_reason }}
     </p>
 
     {% if invitation.invitee.is_verified %}

--- a/templates/registration/invitation_email.html
+++ b/templates/registration/invitation_email.html
@@ -12,8 +12,7 @@
         {% else %}
             {{ invitation.inviting_user.email }}
         {% endif %}
-        of {{ invitation.inviting_company.name }} has invited you to join
-        My.jobs {{ reason }}
+        of {{ invitation.inviting_company.name }} has invited you to join My.jobs {{ reason }}
     </p>
 
     {% if invitation.added_permission %}


### PR DESCRIPTION
# Description
At the moment, we send send specific invitation emails depending on whether or not the invitation is associated with a saved search or a group. This PR abstracts that functionality from the template and moves it to the backend, in addition to allowing for a custom reason to be provided in the email. 

# Key Changes
- `registration.models.Invitation.send` now takes an optional `reason` parameter
- `myjobs.models.User.send_invite` now takes an optional `reason` parameter
- `registration.models.Invitation` no longer automatically sends an email on creation
- Conditional messages inside of the invitation email template has been moved to the `send` method.
- New tests to cover each of these different template use cases. Note that I didn't give the tests a custom failure message as the default was more informative than anything I could have come up with (I tried).

# Testing
You can either:
- use the UI to generate the different invitation emails:
    - create a saved search
    - with ROLES_ENABLED set to False, create a company user
    - ~~with ROLES_ENABLED add a user to a role [1]~~
- generate the three conditions from the the './manage.py shell' prompt and call user.send_invite:
    - with a user and company, call user.send_invite
        - with and without a role
        - with and without a reason
    - create an invitation with and without a reason:
        - attach a saved search and call send
        - attach a group and call send

~~[1] I don't remember if the User Management frontend allows inviting of users yet, so this may not yet be possible from a UI~~