### PR TITLE
Documentation cleanup

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -20,6 +20,7 @@ import os
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.abspath('../..'))
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'settings')
+import settings
 
 # -- General configuration ------------------------------------------------
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -20,6 +20,8 @@ import os
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.abspath('../..'))
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'settings')
+# django misbehaves without this, and setup_environ() was deprecated with
+# Django 1.4
 import settings
 
 # -- General configuration ------------------------------------------------

--- a/doc/source/developers/postajob/00_quickstart.rst
+++ b/doc/source/developers/postajob/00_quickstart.rst
@@ -1,0 +1,69 @@
+===========
+Quick Start
+===========
+
+This section is designed to get you publishing and/or selling job postings
+quickly. For a more detailed look at how the  various parts are related and
+funtion, see the :ref:`product-life-cycle`.
+
+Posting Directly to a Microsite
+===============================
+
+.. note:: 
+
+  In the future, it will be possible to enable postajob access via the Django
+  admin by visiting the "Companies" page and checking the appropriate app-level
+  permission.
+
+Enabling job posting for a single site is a three-step process:
+
+  #. Enable posting access for the company who owns the microsite::
+
+       >>> from seo.models import Company
+       >>> company = Company.objects.get(name="Example Company")
+       >>> company.posting_access = True
+       >>> company.save()
+
+  #. Ensure that the canonical company for the microsite is the same as the
+     company above::
+
+       >>> from seo.models import Company, SeoSite
+       >>> company = Company.objects.get(name="Example Company")
+       >>> site = SeoSite.objects.get(domain="example-company.com")
+       >>> site.canonical_company = company
+       >>> site.save()
+
+  #. Verify access by visiting the job posting page on the microsite::
+
+     $ firefox http://example-company.com/posting/all
+
+Selling Job Postings to Others
+==============================
+
+.. todo::
+
+  - Determine the need for explicit site-package creation steps.
+  
+  - Update these instructions when Roles are released
+
+Enabling the selling of jobs to other microsites is only sligtly more
+complicated, and is a four-step process:
+
+  #. Enable product access for the company who will be selling job postings::
+
+       >>> from seo.models import Company
+       >>> company = Company.objects.get(name="Example Company")
+       >>> company.product_access = True
+       >>> company.save()
+
+  #. Create a site package for the company, which will determine on which
+     domains the sold jobs appear.
+
+  #. Create an ``seo.CompanyUser`` for each user who needs to be able to manage
+     these postings.
+
+  #. Verify access by visiting the posting admin page::
+
+       $ firefox http://example-company.com/posting/admin
+
+

--- a/doc/source/developers/postajob/overview.rst
+++ b/doc/source/developers/postajob/overview.rst
@@ -1,71 +1,8 @@
-Quick Start
-===========
-
-This section is designed to get you publishing and/or selling job postings
-quickly. For a more detailed look at how the  various parts are related and
-funtion, see the :ref:`product-life-cycle` section.
-
-Posting Directly to a Microsite
--------------------------------
-
-.. note:: 
-
-  In the future, it will be possible to enable postajob access via the Django
-  admin by visiting the "Companies" page and checking the appropriate app-level
-  permission.
-
-Enabling job posting for a single site is a three-step process:
-
-  #. Enable posting access for the company who owns the microsite::
-
-       >>> from seo.models import Company
-       >>> company = Company.objects.get(name="Example Company")
-       >>> company.posting_access = True
-       >>> company.save()
-
-  #. Ensure that the canonical company for the microsite is the same as the
-     company above::
-
-       >>> from seo.models import Company, SeoSite
-       >>> company = Company.objects.get(name="Example Company")
-       >>> site = SeoSite.objects.get(domain="example-company.com")
-       >>> site.canonical_company = company
-       >>> site.save()
-
-  #. Verify access by visiting the job posting page on the microsite::
-
-     $ firefox http://example-company.com/posting/all
-
-Selling Job Postings to Others
-------------------------------
-
-.. todo::
-
-  - Determine the need for explicit site-package creation steps.
-  
-  - Update these instructions when Roles are released
-
-Enabling the selling of jobs to other microsites is only sligtly more
-complicated, and is a four-step process:
-
-  #. Enable product access for the company who will be selling job postings::
-
-       >>> from seo.models import Company
-       >>> company = Company.objects.get(name="Example Company")
-       >>> company.product_access = True
-       >>> company.save()
-
-  #. Create a site package for the company, which will determine on which
-     domains the sold jobs appear.
-
-  #. Create an ``seo.CompanyUser`` for each user who needs to be able to manage
-     these postings.
-
-  #. Verify access by visiting the posting admin page::
-
-       $ firefox http://example-company.com/posting/admin
-
 .. _product-life-cycle:
+
+========
+Overview
+========
 
 Product Life Cycle
 ==================

--- a/doc/source/developers/postajob/overview.rst
+++ b/doc/source/developers/postajob/overview.rst
@@ -1,4 +1,3 @@
-===========
 Quick Start
 ===========
 
@@ -7,7 +6,7 @@ quickly. For a more detailed look at how the  various parts are related and
 funtion, see the :ref:`product-life-cycle` section.
 
 Posting Directly to a Microsite
-===============================
+-------------------------------
 
 .. note:: 
 
@@ -38,7 +37,7 @@ Enabling job posting for a single site is a three-step process:
      $ firefox http://example-company.com/posting/all
 
 Selling Job Postings to Others
-==============================
+------------------------------
 
 .. todo::
 

--- a/doc/source/developers/styleguides/documentation.rst
+++ b/doc/source/developers/styleguides/documentation.rst
@@ -2,11 +2,6 @@
 Writing Documentation
 =====================
 
-.. contents::
-  :depth: 2
-  :local:
-  :backlinks: entry
-
 This guide sets the standard to be used for documentation that exists outside
 of source code. For guidance on how to document your source code, see the
 :doc:`programming` and :doc:`javascript` guides. If you find that this guide

--- a/doc/source/developers/styleguides/javascript.rst
+++ b/doc/source/developers/styleguides/javascript.rst
@@ -2,11 +2,6 @@
 JavaScript Coding Standard
 ===========================
 
-.. contents::
-  :depth: 2
-  :local:
-  :backlinks: entry
-
 Goals
 =====
 

--- a/doc/source/developers/styleguides/programming.rst
+++ b/doc/source/developers/styleguides/programming.rst
@@ -2,11 +2,6 @@
 Programming Guide
 =================
 
-.. contents::
-  :depth: 2
-  :local:
-  :backlinks: entry
-
 Goal of this Guide
 ==================
 

--- a/doc/source/faq.rst
+++ b/doc/source/faq.rst
@@ -2,9 +2,6 @@
 Frequently Asked Questions
 ==========================
 
-.. contents::
-  :local:
-
 User Management
 ===============
 


### PR DESCRIPTION
- moved quickstart into it's own document for consistency, named 00_* to enforce order in toc since we use globs
- re-added import of settings as things broke for me otherwise
- removed contents from all pages as the current theme already adds navigation to sections on the left sidebar