### PR TITLE
[PD-939] Fixed regression with job form

### DIFF
--- a/postajob/forms.py
+++ b/postajob/forms.py
@@ -155,7 +155,7 @@ class BaseJobLocationFormSet(BaseModelFormSet):
     def clean(self):
         forms_changed = any([form.has_changed() for form in self.forms])
 
-        if any(self.errors) or not forms_changed:
+        if any(self.errors):
             return
 
         has_locations = any([not data['DELETE'] for data in self.cleaned_data])

--- a/postajob/tests/test_views.py
+++ b/postajob/tests/test_views.py
@@ -979,6 +979,18 @@ class ViewTests(PostajobTestBase):
                          data=self.job_form_data, follow=True)
         self.assertEqual(JobLocation.objects.count(), 1)
 
+    def test_that_location_is_required(self):
+        """User should not be able to submit a job form without a location."""
+
+        # remove locations from the form
+        self.job_form_data.pop('form-0-city')
+        self.job_form_data.pop('form-0-state')
+        self.job_form_data.pop('form-0-country')
+        self.client.post(reverse('job_add'), data=self.job_form_data)
+        self.assertEqual(Job.objects.count(), 0)
+        self.assertEqual(JobLocation.objects.count(), 0)
+
+
     def test_purchasedjob_form(self):
         purchased_product = PurchasedProductFactory(
             product=self.product, owner=self.company)


### PR DESCRIPTION
# TODO
- [x] regression test

Basically, my last fix allowed no locations to be added, when instead it should have enforced that at least one location was required. I'm confused as one of the tests seems to be doing that already....