### PR TITLE
Misc Changes to Docker, Secure Blocks

### DIFF
--- a/dk2/dockerdev.sh
+++ b/dk2/dockerdev.sh
@@ -104,9 +104,15 @@ backgroundstop() {
 }
 
 restartsecure() {
-    docker stop secure.my.jobs
-    docker rm secure.my.jobs
-    runsecure
+    docker stop secure.my.jobs || true
+    docker rm secure.my.jobs || true
+    runsecure || true
+}
+
+restartmicrosites() {
+    docker stop star.jobs || true
+    docker rm star.jobs || true
+    runmicrosites || true
 }
 
 maint() {

--- a/myjobs/cross_site_verify.py
+++ b/myjobs/cross_site_verify.py
@@ -19,14 +19,7 @@ def extract_hostname(url):
     if url is None:
         return None
     else:
-        return remove_test_prefix(urlparse(url).hostname)
-
-
-def remove_test_prefix(url):
-    if not url:
-        return url
-    url_split = url.split('.', 1)
-    return url_split[1] if url_split[0] in settings.ENV_URL_PREFIXES else url
+        return urlparse(url).hostname
 
 
 def parse_request_meta(meta):
@@ -147,7 +140,7 @@ def cross_site_verify(fn):
             logger.warn(
                 "Rejected cross site request; reason : %s\n" +
                 "data: %s", e.message, data)
-            return return_404()
+            return return_404(return_message=e.message)
         return fn(request)
 
     return verify

--- a/seo/cache.py
+++ b/seo/cache.py
@@ -131,19 +131,19 @@ def get_site_config(request):
     return site_config
 
 
-def get_url_prefix_qc_staging(request):
+def is_testing_environment(request):
     """
-    Returns the url prefix of the current host if the current host url starts
-    with qc or staging. For use with indicating which secure host to ping for
-    secure blocks API
+    Returns whether or not the host is a testing environment. Currently used
+    in seo_base.html template to determine whether to use http or https for
+    cross site requests
     :param request:
-    :return: url prefix of qc or staging, if applicable, otherwise empty string
+    :return: True if qc or staging, otherwise False
 
     """
     if not request.META.get('HTTP_HOST'):
-        return ''
+        return False
     host_prefix = request.META.get('HTTP_HOST').split('.', 1)[0]
-    return host_prefix if host_prefix in settings.ENV_URL_PREFIXES else ''
+    return True if host_prefix in settings.ENV_URL_PREFIXES else False
 
 
 def get_secure_blocks_site(request):

--- a/seo/context_processors.py
+++ b/seo/context_processors.py
@@ -1,8 +1,8 @@
 from seo.cache import get_site_config, get_secure_blocks_site, \
-    get_url_prefix_qc_staging
+    is_testing_environment
 
 
 def site_config_context(request):
     return {'site_config': get_site_config(request),
-            'testing_host_prefix': get_url_prefix_qc_staging(request),
+            'is_testing_environment': is_testing_environment(request),
             'secure_blocks_domain': get_secure_blocks_site(request)}

--- a/templates/seo_base.html
+++ b/templates/seo_base.html
@@ -37,7 +37,7 @@
     <script type="text/javascript">
       var pager_num_items = {{ site_config.num_subnav_items_to_show }};
       $(document).on("ready", function() {
-        var secure_block_url = "https://{% if testing_host_prefix %}{{testing_host_prefix}}.{% endif %}{{ secure_blocks_domain }}/secure-blocks/";
+        var secure_block_url = "{% if is_testing_environment %}http{% else %}https{% endif %}://{{ secure_blocks_domain }}/secure-blocks/";
         load_secure_blocks(secure_block_url);
       });
     </script>


### PR DESCRIPTION
This is a small PR.

I had not intended on lumping the changes to Docker with the changes to secure blocks, but it happened that way.

## Docker

Fixed/Add functions restartsecure and restartmicrosites. These functions will stop and remove any running containers for either and subsequently restart their respective container.

## Secure Blocks

Modified the logic for determining the url of the parent site to no longer affix/remove the qc/staging prefix, but rather modify https/http based on the environment. This is due to the fact that QC and Staging do not use HTTPS.

I also added the exception/authentication error from cross site verify to the response. I may remove this in a later PR, but it will help as I attempt to get cross site verify running on QC.