### PR TITLE
Another prefix tweak for saved search lists

### DIFF
--- a/myjobs/cross_site_verify.py
+++ b/myjobs/cross_site_verify.py
@@ -23,6 +23,11 @@ def extract_hostname(url):
 
 
 def remove_test_prefix(url):
+    """
+    Removes test prefix (qc, staging) from incoming requests, if it exists.
+    :param url:
+    :return: url without qc, staging prefixes
+    """
     if not url:
         return url
     url_split = url.split('.', 1)
@@ -136,6 +141,16 @@ def cross_site_verify(fn):
             parse_request_meta(request.META))
 
         host_site = settings.SITE
+
+        if remove_test_prefix(host_site.domain) != host_site.domain:
+            """
+            If the host site has a testing prefix, try to remove it.
+            This is to prevent data refreshed from production from breaking
+            the cross-site verify logic.
+            """
+            trimmed_domain = remove_test_prefix(host_site.domain)
+            non_test_site = SeoSite.objects.filter(domain=trimmed_domain).first()
+            host_site = (non_test_site or host_site)
 
         try:
             verify_cross_site_request(get_site, method, host_site, origin,

--- a/seo/cache.py
+++ b/seo/cache.py
@@ -134,8 +134,7 @@ def get_site_config(request):
 def get_url_prefix_qc_staging(request):
     """
     Returns the url prefix of the current host if the current host url starts
-    with qc or staging. For use with indicating which secure host to ping for
-    secure blocks API
+    with qc or staging.
     :param request:
     :return: url prefix of qc or staging, if applicable, otherwise empty string
 


### PR DESCRIPTION
## Site tweaking

As I was working through the issues with making the QC servers communicate, I realized that qc.secure.my.jobs is a SeoSite of its own rather than just using the regular secure.my.jobs SeoSite. Due to this, I modified my logic to use the main (secure.my.jobs) SeoSite when doing cross-site verification. This is so that production database refreshes will not constantly break parent-child relationships in cross site logic. 