### PR TITLE
Template modification for saved search widget

### DIFF
--- a/templates/home_page/home_page_listing.html
+++ b/templates/home_page/home_page_listing.html
@@ -48,6 +48,7 @@
     {% include 'includes/add_this.html' %}<!--temp rollback of my.jobs sharing [JPS 10.4.12]-->
 </div>
 <a href="#top" class="direct_mobileJumpLink">{% blocktrans %}Return to top{% endblocktrans %}</a>
+<div data-secure-block-id="saved-search-list"></div>
 <div id="direct_disambiguationDiv" class="direct_rightColBox">
 {% for widget in widgets %}
 {% if widget.render %}


### PR DESCRIPTION
Inclusion of saved search widget in another site config template. This is the one that qc.my.jobs uses. This has no effect other than being an anchor for the saved search list to be inserted on the page using the Home Page Template: home_page_listing.html

In the interim, I changed the home page template that qc.my.jobs uses to home_page_static_header_footer to display the widget.