### PR TITLE
[PD-2010, PD-2011, PD-2012] Fix topbar-new mobile issues, which uses Bootstrap3

### DIFF
--- a/static/custom.css
+++ b/static/custom.css
@@ -4258,6 +4258,7 @@ a.btn.pull-right {
   }
   #nav .main-nav{
     height: 50px !important;
+    width: 50px !important;
   }
 }
 @media(min-width:992px){

--- a/static/custom.css
+++ b/static/custom.css
@@ -3901,7 +3901,6 @@ span.helptext {
 
 
 
-
 /*Manage Users*/
 /*New*/
 
@@ -4246,8 +4245,6 @@ a.btn.pull-right {
 	#no-more-tables td:before {
     content: attr(data-title);
   }
-
-
 }
 @media(min-width:768px){
 
@@ -4260,11 +4257,19 @@ a.btn.pull-right {
     height: 50px !important;
     width: 50px !important;
   }
+  /* New Topbar based on Bootstrap 3 */
+  .topbar-new #logged-in-li {
+    height: 33px !important;
+    font-size: 2em !important;
+  }
+  .topbar-new #nav ul#pop-menu li a {
+    height: 45px !important;
+  }
 }
 @media(min-width:992px){
   .topbar-inner {
     height: 30px !important;
-    }
+  }
 }
 @media(min-width:1200px){
 

--- a/static/topbar.directseo.165-10.css
+++ b/static/topbar.directseo.165-10.css
@@ -503,6 +503,9 @@ ul.submenu > li > a:hover {
         font-size: 2em;
         height: 25px;
         padding: 10px;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
     }
 
     #pop-menu {

--- a/static/topbar.myjobs.165-10.css
+++ b/static/topbar.myjobs.165-10.css
@@ -503,6 +503,9 @@ ul.submenu > li > a:hover {
         font-size: 2em;
         height: 25px;
         padding: 10px;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
     }
 
     #pop-menu {

--- a/templates/includes/topbar-new.html
+++ b/templates/includes/topbar-new.html
@@ -7,7 +7,7 @@
 <link href="{{ STATIC_URL }}topbar.myjobs.165-10.css" rel="stylesheet" type="text/css">
 {% endif %}
 
-<div class="topbar" data-dropdown="dropdown" role="menubar">
+<div class="topbar topbar-new" data-dropdown="dropdown" role="menubar">
     <div class="topbar-inner">
         <div id="de-topbar-content" class="wrapper">
             <div id="logo-block" class="de-topbar-item">


### PR DESCRIPTION
Overview
=========

New projects (like Manage Users) use Bootstrap 3, but this broke the toolbar on mobile.

This PR fixes the "[hamburger](https://en.wikipedia.org/wiki/Hamburger_button)" button:

![screen shot 2015-12-23 at 11 23 32 am](https://cloud.githubusercontent.com/assets/15107331/11980297/e16c2490-a967-11e5-98ad-a738496acba7.png)

And the expanded view:

![screen shot 2015-12-23 at 11 23 53 am](https://cloud.githubusercontent.com/assets/15107331/11980295/df27d80a-a967-11e5-81c8-886858472f39.png)

Review
=========

* Run `gulp build`
* Visit https://local/manage-users
* Make browser smaller

Home
=========

It's tiny.

![home](https://cloud.githubusercontent.com/assets/15107331/11980243/7088f988-a967-11e5-9546-ee02061fce68.png)