### PR TITLE
Create Home Page Template for Cross Site

### DIFF
--- a/templates/home_page/CS_TEST_home_page_listing.html
+++ b/templates/home_page/CS_TEST_home_page_listing.html
@@ -1,0 +1,82 @@
+{% extends "seo_base.html" %}
+{% load i18n %}
+{% load seo_extras %}
+{% load cache %}
+{% cache 600 joblisting %}
+
+{% block direct_extraHeaderContent %}
+<link rel="stylesheet" href="/style/def.ui.dotjobs.results.css" type="text/css">
+{% endblock direct_extraHeaderContent %}
+
+{% block publisher %}
+    {% if site_config.publisher and "network" not in site_tags %}
+        <link href="https://plus.google.com/{{ site_config.publisher }}" rel="publisher" />
+    {% else %}
+        <link href="https://plus.google.com/100406566063094579991" rel="publisher" />
+    {% endif %}
+{% endblock %}
+
+{% block directseo_title %}
+    {{site_title}} 
+{% endblock directseo_title %}
+
+{% block rss_feed %}
+<link rel="alternate" type="application/rss+xml" title="Jobs - {{site_title}}" href="{{request.build_absolute_uri}}feed/rss">
+{% endblock rss_feed %}
+{% block directseo_primary_navigation %}{% endblock directseo_primary_navigation %}
+
+{% block directseo_blurb %}
+<div id="direct_blurbDiv">
+    {% if site_config.defaultBlurbTitle %}<h3>{{site_config.defaultBlurbTitle}}</h3>{% endif %}
+    <div id="direct_blurbContents">
+        <p>{{site_config.defaultBlurb|safe}}</p>
+    </div>
+</div>
+{% endblock directseo_blurb %}
+
+{% block directseo_main_content %}
+<a href="#filters" class="direct_mobileJumpLink">{% blocktrans %}Jump to Filters{% endblocktrans %}</a>
+<h3 class="direct_highlightedText">{% trans "Jobs" %}</h3>
+{% include 'includes/job_list.html' %}
+{% endblock directseo_main_content %}
+
+{% block directseo_right_hand_column %}
+{% if default_jobs or featured_jobs %}
+<a name="filters"></a>  
+<div id="direct_shareDiv" class="direct_rightColBox direct_shareSolo" role="menu">
+    <h3>{% trans "Share" %}</h3>
+    {% include 'includes/add_this.html' %}<!--temp rollback of my.jobs sharing [JPS 10.4.12]-->
+</div>
+<a href="#top" class="direct_mobileJumpLink">{% blocktrans %}Return to top{% endblocktrans %}</a>
+{% if "network" in site_tags or site_config.show_saved_search_widget %}
+    <div data-secure-block-id="saved-search"></div>
+{% endif %}
+<div data-secure-block-id="saved-search-list"></div>
+<div id="direct_disambiguationDiv" class="direct_rightColBox">
+{% for widget in widgets %}
+{% if widget.render %}
+{{ widget.render }}
+{% endif %}
+{% endfor %}
+</div>
+{% endif %}
+{% endblock directseo_right_hand_column %}
+
+{% block directseo_off_site_links %}
+    {% if site_config.show_home_social_footer %}
+        {% include "off_site_links.html" %}
+    {% else %}
+        <div id="direct_clearDiv"></div>
+    {% endif %}
+{% endblock directseo_off_site_links%}
+
+{% block directseo_micrositecarousel %}
+    {% if site_config.show_home_microsite_carousel %}
+    <div id="listing_microsite_carousel">
+        {{ block.super }}
+    </div>
+    {% endif %}
+{% endblock directseo_micrositecarousel %}  
+
+
+{% endcache %}

--- a/templates/job_listing.html
+++ b/templates/job_listing.html
@@ -72,7 +72,6 @@
     <a href="#top" class="direct_mobileJumpLink">{% blocktrans %}Return to top{% endblocktrans %}</a>
 
 {% endif %}
-<div data-secure-block-id="saved-search-list"></div>
 <div id="direct_disambiguationDiv" class="direct_rightColBox" role="menu">
     {# If clear_breadcrumb exists, we know at least one search term that can be removed has been applied, so include the breadbox #}
     {% if breadbox.clear_breadcrumb %}


### PR DESCRIPTION
## Overview

I am creating a new home page template for the purposes of testing and developing secure blocks widgets. This template will not be tied to any existing configurations, but will be a copy of the home_page_listing.html home page. This allows testing of secure blocks widgets without including non-functional hooks on existing templates.

## Testing

The new template contains hooks for both saved_search_list and saved_search, but only saved_search_list exists in QC. To verify that the list hook works, change the template in my.jobs configuration to use CS_TEST_home_page_listing.html .. If you have not done so already, do the steps below as well

### Addtl. Cross Site Testing Steps (from old PR)
NOTE: This currently only works for Docker environments due to limitations of cross-site functionality on regular localhost. Outside of docker, if you can setup port forwarding so that your secure instance resolves to secure.my.jobs rather than secure.my.jobs:8000, go for it.

Next, head to SeoSite and make secure.my.jobs a parent of my.jobs

Following that, head to admin -> myblocks -> Saved Search List Widget Block -> Add

Leave the defaults for everything except for element id, which is `saved-search-list`
- 0 for Span and Offset

Navigate to my.jobs and click "search". The list will be on the right if you..
* Are logged in
* Have saved searches