### PR TITLE
fix jslint error, companyName is coming in from the base template

### DIFF
--- a/gulp/src/manageusers/main.jsx
+++ b/gulp/src/manageusers/main.jsx
@@ -1,4 +1,5 @@
 /* global $ */
+/* global companyName */
 
 import React from 'react';
 import {render} from 'react-dom';

--- a/gulp/src/nonuseroutreach/components/Container.jsx
+++ b/gulp/src/nonuseroutreach/components/Container.jsx
@@ -1,3 +1,5 @@
+/* global companyName */
+
 import React, {Component, PropTypes} from 'react';
 
 import {Content} from './Content';


### PR DESCRIPTION
The dynamic companyName feature worked, but JSLint was pitching a fit:
```
"companyName" is not defined
```