### PR TITLE
Stop double-unquoting [PD-2060]

### DIFF
--- a/myjobs/api.py
+++ b/myjobs/api.py
@@ -118,7 +118,6 @@ class SavedSearchResource(ModelResource):
 
         # Confirm that url was provided, and that it's a valid .jobs search
         url = request.GET.get('url', '')
-        url = unquote(url)
 
         if not url:
             data = {'error': 'No .JOBS feed provided'}

--- a/myjobs/tests/test_api.py
+++ b/myjobs/tests/test_api.py
@@ -80,7 +80,7 @@ class SavedSearchResourceTests(MyJobsBase):
         self.assertEqual(response.status_code, 200)
         search = SavedSearch.objects.last()
         self.assertFalse(search.feed.endswith('#'))
-        self.assertTrue(search.feed.endsWith('%23'))
+        self.assertTrue(search.feed.endswith('%23'))
 
     def test_new_search_existing_user(self):
         for data in [('alice@example.com', 'www.my.jobs/search?q=django'),


### PR DESCRIPTION
With a bit of hand-testing, I determined that some Django magic happens earlier in request processing which unquotes the thing we're unquoting. That results in "%2523" getting unquoted all the way to "#" rather than stopping at "%23". Since octothorpes have meaning as far as urls go, this is bad.
