### PR TITLE
Fix bug with webpack and bootstrap-react

### DIFF
--- a/gulp/gulpfile.js
+++ b/gulp/gulpfile.js
@@ -60,7 +60,10 @@ function webpackConfig() {
       root: path.resolve('src'),
       // you can now require('file') instead of require('file.coffee')
       extensions: ['', '.js', '.jsx'],
-
+      // Thank you internet man! http://stackoverflow.com/a/32444088
+      alias: {
+        'react': path.join(__dirname, 'node_modules', 'react'),
+      },
     },
     output: {
       path: '../static/bundle',


### PR DESCRIPTION
The bootstrap-react package was trying to load its own version of react and caused an error.