### PR TITLE
Upgrade requests

### DIFF
--- a/mypartners/tests/test_views.py
+++ b/mypartners/tests/test_views.py
@@ -1476,7 +1476,6 @@ class PartnerLibraryTestCase(MyPartnersTestCase):
         cls.partner_library = PartnerLibrary.objects.all()
 
 
-@skip("Update the code being tested to support SNI")
 class PartnerLibraryViewTests(PartnerLibraryTestCase):
 
     def test_errd_reachable(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,7 +44,7 @@ pyflakes==0.5.0
 pynliner==0.5.1
 pysolr==3.2.0
 python-memcached==1.53
-requests==2.3.0
+requests==2.9.1
 selenium==2.46.0
 unicodecsv==0.9.4
 bidict==0.3.1


### PR DESCRIPTION
requests doesn't use urllib. Newer versions can handle SNI just fine.