### PR TITLE
Return app_access in /manage-users/api/roles/ API

### DIFF
--- a/myjobs/tests/test_manage_users.py
+++ b/myjobs/tests/test_manage_users.py
@@ -218,10 +218,15 @@ class ManageUsersTests(MyJobsBase):
         activities_available = json.loads(activities['available'])
         activity_available_name = activities_available[0]['fields']['name']
         self.assertIsInstance(activity_available_name, unicode)
+        activity_available_app_access = activities_available[0]['fields']['app_access']
+        self.assertIsInstance(activity_available_app_access, int)
 
         activities_assigned = json.loads(activities['assigned'])
         activity_assigned_name = activities_assigned[0]['fields']['name']
         self.assertIsInstance(activity_assigned_name, unicode)
+        activity_available_app_access = activities_available[0]['fields']['app_access']
+        self.assertIsInstance(activity_available_app_access, int)
+
 
     def test_get_roles_contain_users(self):
         """

--- a/myjobs/views.py
+++ b/myjobs/views.py
@@ -658,13 +658,13 @@ def api_get_roles(request):
         ctx[role_id]['activities']['available'] = serializers.serialize(
             "json",
             available_activities,
-            fields=('name', 'description'))
+            fields=('name', 'description', 'app_access'))
         # Retrieve all activities assigned to this role
         assigned_activities = role.activities.all()
         ctx[role_id]['activities']['assigned'] = serializers.serialize(
             "json",
             assigned_activities,
-            fields=('name', 'description'))
+            fields=('name', 'description', 'app_access'))
 
         # Retrieve users already assigned to this role
         users_assigned = User.objects.filter(roles__id=role_id)


### PR DESCRIPTION
The /manage-users/api/roles/ API returns, among other things, available and assigned activities. For each, the front-end needs the name and description, but it also needs app_access. This enables us to break up the activities by app for use in the accordion:

![screen shot 2016-01-13 at 9 15 22 am](https://cloud.githubusercontent.com/assets/15107331/12296636/ef90c326-b9d6-11e5-92ce-966a700ba0bb.png)

# Test

Run tests:
`dkm test myjobs.tests.test_manage_users`

Visit locally:
https://secure.my.jobs/manage-users/#/role/add?action=Add