### PR TITLE
Constrain roles by current company

### DIFF
--- a/myjobs/tests/test_manage_users.py
+++ b/myjobs/tests/test_manage_users.py
@@ -396,10 +396,7 @@ class ManageUsersTests(MyJobsBase):
         # uses to make the request. Therefore, the API should only return two
         # roles
         self.assertEqual(len(roles_assigned),2)
-
-
-
-
+        
     def test_get_users(self):
         """
         Tests that the Users API returns the proper data in the proper form

--- a/myjobs/views.py
+++ b/myjobs/views.py
@@ -1013,7 +1013,7 @@ def api_get_users(request):
         ctx[user.id]["email"] = user.email
 
         # Roles
-        roles_assigned_to_user = user.roles.all()
+        roles_assigned_to_user = user.roles.filter(company=company)
         ctx[user.id]["roles"] = serializers.serialize("json",
                                                       roles_assigned_to_user,
                                                       fields=('name'))
@@ -1088,7 +1088,7 @@ def api_get_specific_user(request, user_id=0):
         available_roles)
 
     # Assigned Roles
-    roles_assigned_to_user = user[0].roles.all()
+    roles_assigned_to_user = user[0].roles.filter(company=company)
     ctx[user[0].id]["roles"]["assigned"] = serializers.serialize(
         "json",
         roles_assigned_to_user,
@@ -1149,8 +1149,11 @@ def api_create_user(request):
         matching_user = User.objects.filter(email=user_email)
         if matching_user.exists():
             # 1) Update their roles
-            # Remove all preexisting roles for this user
-            for currently_assigned_role in matching_user[0].roles.all():
+            # Remove all preexisting roles for this user associated with this
+            # company
+            for currently_assigned_role in (matching_user[0]
+                                            .roles
+                                            .filter(company=company)):
                 matching_user[0].roles.remove(currently_assigned_role.id)
             # Add new roles
             matching_user[0].roles.add(*role_ids)
@@ -1275,7 +1278,7 @@ def api_edit_user(request, user_id=0):
             user[0].roles.add(assigned_role)
 
         # Remove roles from user if not in new list
-        for currently_assigned_role in user[0].roles.all():
+        for currently_assigned_role in user[0].roles.filter(company=company):
             if currently_assigned_role.id not in assigned_roles_ids:
                 user[0].roles.remove(currently_assigned_role.id)
 


### PR DESCRIPTION
# Overview

This PR fixes a bug where, if a user belonged to multiple companies, all of their roles would display in various points in the UI. For example:

## Before

![screen shot 2016-01-14 at 11 49 01 am](https://cloud.githubusercontent.com/assets/15107331/12330831/ff95e164-bab4-11e5-8c5a-317adcfa4784.png)

## After

![screen shot 2016-01-14 at 11 49 40 am](https://cloud.githubusercontent.com/assets/15107331/12330827/fdadadf0-bab4-11e5-9661-52fd46f23438.png)

## Before
![screen shot 2016-01-14 at 11 49 22 am](https://cloud.githubusercontent.com/assets/15107331/12330851/14a7da08-bab5-11e5-989e-44fb39d0e653.png)

## After
![screen shot 2016-01-14 at 11 49 31 am](https://cloud.githubusercontent.com/assets/15107331/12330848/12fc86b8-bab5-11e5-8674-6001007eecf7.png)





# Test

Run Django tests: `dkm test myjobs.tests.test_manage_users`

Build JS and start server:
`
dkgg build
dk runsecure
`