### PR TITLE
User Management - update invite_user() to handle multiple roles

### DIFF
--- a/myjobs/models.py
+++ b/myjobs/models.py
@@ -752,8 +752,10 @@ class User(AbstractBaseUser, PermissionsMixin):
         if not reason and role_name:
             # role_name could be an array like ["Admin", "PRM User"]
             if isinstance(role_name, list):
-                role_name = ', '.join(role_name)
-            reason = "as a(n) %s for %s" % (role_name, company)
+                role_name_string = ', '.join(role_name)
+            else:
+                role_name_string = role_name
+            reason = "as a(n) %s for %s" % (role_name_string, company)
 
         invitation.send(reason + ".")
 

--- a/myjobs/views.py
+++ b/myjobs/views.py
@@ -1161,7 +1161,7 @@ def api_create_user(request):
             request.user.send_invite(user_email,
                                      company,
                                      role_name=roles)
-            ctx["success"] = "false"
+            ctx["success"] = "true"
             ctx["message"] = "User already exists. Role invitation email sent."
             return HttpResponse(json.dumps(ctx),
                                 content_type="application/json")


### PR DESCRIPTION
This PR fixes a bug present with adding/editing a user with multiple roles.

When a user has multiple roles this if statement should catch it and update the user accordingly: https://github.com/DirectEmployers/MyJobs/blob/d20c487862ebce381284a15c58a754a6f35aa870/myjobs/models.py#L768 However, I was overwriting the `role_name` variable and making into a string. The program flow never got past this if statement.

# Other

This PR depends on https://github.com/DirectEmployers/MyJobs/pull/2038

As such, this PR only has one unique change: https://github.com/DirectEmployers/MyJobs/commit/bd4c4703b1afa231a3c87b41621c3de0da7409f5