### PR TITLE
Allow filtering users on secondary email [PD-2053]

### DIFF
--- a/myjobs/admin.py
+++ b/myjobs/admin.py
@@ -22,8 +22,9 @@ class EmailLogAdmin(admin.ModelAdmin):
 
 class UserAdmin(admin.ModelAdmin):
     list_display = ['email', 'date_joined', 'last_response', 'is_active',
-                    'is_verified', 'deactivate_type', 'source',]
-    search_fields = ['email', 'source']
+                    'is_verified', 'deactivate_type', 'secondary_emails',
+                    'source']
+    search_fields = ['email', 'source', 'profileunits__secondaryemail__email']
     list_filter = ['is_active', 'is_verified', 'is_disabled', 'is_superuser',
                    'is_staff', 'deactivate_type']
 

--- a/myjobs/models.py
+++ b/myjobs/models.py
@@ -768,6 +768,13 @@ class User(AbstractBaseUser, PermissionsMixin):
 
         return user
 
+    def secondary_emails(self):
+        return "<br />".join(self.profileunits_set.filter(
+            secondaryemail__isnull=False).values_list(
+            'secondaryemail__email', flat=True)) or "None"
+    secondary_emails.short_description = "secondary emails"
+    secondary_emails.allow_tags = True
+
 
 @receiver(pre_delete, sender=User, dispatch_uid='pre_delete_user')
 def delete_user(sender, instance, using, **kwargs):

--- a/myjobs/models.py
+++ b/myjobs/models.py
@@ -771,7 +771,7 @@ class User(AbstractBaseUser, PermissionsMixin):
     def secondary_emails(self):
         return "<br />".join(self.profileunits_set.filter(
             secondaryemail__isnull=False).values_list(
-            'secondaryemail__email', flat=True)) or "None"
+                'secondaryemail__email', flat=True)) or "None"
     secondary_emails.short_description = "secondary emails"
     secondary_emails.allow_tags = True
 

--- a/myjobs/tests/test_views.py
+++ b/myjobs/tests/test_views.py
@@ -176,7 +176,7 @@ class MyJobsViewsTests(MyJobsBase):
 
     def test_change_password_success(self):
         resp = self.client.post(reverse('edit_account')+'?password',
-                                data={'password': '5UuYquA@',
+                                data={'password': self.password,
                                       'new_password1': '7dY=Ybtk',
                                       'new_password2': '7dY=Ybtk'},
                                 follow=True)
@@ -186,7 +186,7 @@ class MyJobsViewsTests(MyJobsBase):
 
     def test_change_password_failure(self):
         resp = self.client.post(reverse('edit_account')+'?password',
-                                data={'password': '5UuYquA@',
+                                data={'password': self.password,
                                       'new_password1': '7dY=Ybtk',
                                       'new_password2': 'notNew'}, follow=True)
 
@@ -198,7 +198,7 @@ class MyJobsViewsTests(MyJobsBase):
 
     def test_password_without_lowercase_failure(self):
         resp = self.client.post(reverse('edit_account')+'?password',
-                                data={'password': '5UuYquA@',
+                                data={'password': self.password,
                                       'new_password1': 'SECRET',
                                       'new_password2': 'SECRET'}, follow=True)
 
@@ -213,7 +213,7 @@ class MyJobsViewsTests(MyJobsBase):
 
     def test_password_without_uppercase_failure(self):
         resp = self.client.post(reverse('edit_account')+'?password',
-                                data={'password': '5UuYquA@',
+                                data={'password': self.password,
                                       'new_password1': 'secret',
                                       'new_password2': 'secret'}, follow=True)
 
@@ -228,7 +228,7 @@ class MyJobsViewsTests(MyJobsBase):
 
     def test_password_without_digit_failure(self):
         resp = self.client.post(reverse('edit_account')+'?password',
-                                data={'password': '5UuYquA@',
+                                data={'password': self.password,
                                       'new_password1': 'Secret',
                                       'new_password2': 'Secret'}, follow=True)
 
@@ -242,7 +242,7 @@ class MyJobsViewsTests(MyJobsBase):
 
     def test_password_without_punctuation_failure(self):
         resp = self.client.post(reverse('edit_account')+'?password',
-                                data={'password': '5UuYquA@',
+                                data={'password': self.password,
                                       'new_password1': 'S3cr37',
                                       'new_password2': 'S3cr37'}, follow=True)
 
@@ -719,7 +719,7 @@ class MyJobsViewsTests(MyJobsBase):
         self.assertEqual(response.status_code, 200)
 
         response = self.client.post(reverse('edit_account')+'?password',
-                                    data={'password': '5UuYquA@',
+                                    data={'password': self.password,
                                           'new_password1': '7dY=Ybtk',
                                           'new_password2': '7dY=Ybtk'})
 
@@ -774,7 +774,7 @@ class MyJobsViewsTests(MyJobsBase):
         for email in [self.user.email, self.user.email.upper()]:
             response = self.client.post(reverse('home'),
                                         data={'username': email,
-                                              'password': '5UuYquA@',
+                                              'password': self.password,
                                               'action': 'login'})
 
             self.assertEqual(response.status_code, 200)
@@ -794,7 +794,7 @@ class MyJobsViewsTests(MyJobsBase):
         """
         response = self.client.post(reverse('home'),
                                     data={'username': self.user.email,
-                                          'password': '5UuYquA@',
+                                          'password': self.password,
                                           'action': 'login'})
 
         self.assertTrue(response.cookies['myguid'])
@@ -1019,8 +1019,8 @@ class MyJobsViewsTests(MyJobsBase):
         self.client.post(reverse('home'),
                          {'action': 'register',
                           'email': 'default@example.com',
-                          'password1': '5UuYquA@',
-                          'password2': '5UuYquA@'})
+                          'password1': self.password,
+                          'password2': self.password})
         user = User.objects.get(email='default@example.com')
         # settings.SITE.domain == jobs.directemployers.org.
         self.assertEqual(user.source, 'jobs.directemployers.org')
@@ -1036,8 +1036,8 @@ class MyJobsViewsTests(MyJobsBase):
         self.client.post(reverse('home'),
                          {'action': 'register',
                           'email': 'microsite@example.com',
-                          'password1': '5UuYquA@',
-                          'password2': '5UuYquA@'})
+                          'password1': self.password,
+                          'password2': self.password})
 
         user = User.objects.get(email='microsite@example.com')
         self.assertEqual(user.source, last_site)
@@ -1085,8 +1085,8 @@ class MyJobsViewsTests(MyJobsBase):
         self.client.logout()
         self.assertEqual(len(mail.outbox), 0)
         self.client.post(reverse('home'), data={'email': 'new@example.com',
-                                                'password1': '5UuYquA@',
-                                                'password2': '5UuYquA@',
+                                                'password1': self.password,
+                                                'password2': self.password,
                                                 'action': 'register'})
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(mail.outbox[0].subject,


### PR DESCRIPTION
This search would normally be empty.
![2016-01-15-104244_1088x223_scrot](https://cloud.githubusercontent.com/assets/3379265/12357233/bf03f486-bb74-11e5-8b1e-449acc7e6b98.png)

9001. Steps to test:
15. Open admin
300. Click "Users"
2. Search for a secondary email
65535. ...
1337. Profit