### PR TITLE
Enabled roles on myjobs staging

### DIFF
--- a/deploy/settings.myjobs_staging.py
+++ b/deploy/settings.myjobs_staging.py
@@ -6,7 +6,6 @@ import os
 from secrets import REDIRECT_STAGING, REDIRECT_QC, ARCHIVE_STAGING
 
 DEBUG = True
-ROLES_ENABLED = False
 
 COMPRESS_ENABLED = True
 COMPRESS_OFFLINE_MANIFEST = 'manifest.json'


### PR DESCRIPTION
The settings files on staging were overriding the default settings and disabling roles.