### PR TITLE
[PD-2101] Add lodash

### DIFF
--- a/gulp/npm-shrinkwrap.json
+++ b/gulp/npm-shrinkwrap.json
@@ -32,6 +32,11 @@
       "from": "fetch-polyfill@^0.8.1",
       "resolved": "https://registry.npmjs.org/fetch-polyfill/-/fetch-polyfill-0.8.2.tgz"
     },
+    "lodash-compat": {
+      "version": "3.10.1",
+      "from": "lodash-compat@~3.10.1",
+      "resolved": "https://registry.npmjs.org/lodash-compat/-/lodash-compat-3.10.1.tgz"
+    },
     "react-dom": {
       "version": "0.14.3",
       "from": "react-dom@^0.14.0",

--- a/gulp/package.json
+++ b/gulp/package.json
@@ -27,6 +27,7 @@
     "gulp-jasmine": "^2.2.1",
     "gulp-util": "^3.0.7",
     "history": "^1.17.0",
+    "less": "~1.6.1",
     "react": "^0.14.3",
     "react-autosuggest": "^2.1.1",
     "react-bootstrap": "^0.28.0",
@@ -35,6 +36,7 @@
     "react-router": "^1.0.0",
     "tinycolor2": "~1.3.0",
     "warning": "^2.1.0",
-    "webpack": "^1.12.9"
+    "webpack": "^1.12.9",
+    "lodash-compat": "~3.10.1"
   }
 }


### PR DESCRIPTION
Add lodash as an available dependency.

Use lodash 3.x "compat" as this supports ancient browsers including IE8. Lodash 4.0 is IE9+.

Also, less was included in shrinkwrap but somehow got merged out of package.json. So I'm restoring it.