### PR TITLE
[PD-2086]  History support

### DIFF
--- a/gulp/src/common/ui/Loading.jsx
+++ b/gulp/src/common/ui/Loading.jsx
@@ -4,7 +4,6 @@ import React, {Component} from 'react';
 
 export class Loading extends Component {
   componentWillMount() {
-    this.mounted = true;
     this.setState({
       show: false,
     });

--- a/gulp/src/common/ui/Loading.jsx
+++ b/gulp/src/common/ui/Loading.jsx
@@ -1,0 +1,44 @@
+/* global spinnerImg */
+import React, {Component} from 'react';
+
+
+export class Loading extends Component {
+  componentWillMount() {
+    this.mounted = true;
+    this.setState({
+      show: false,
+    });
+  }
+
+  componentDidMount() {
+    this.allowShow = true;
+    setTimeout(() => this.setShowIfAllowed(), 300);
+  }
+
+  componentWillUnmount() {
+    this.allowShow = false;
+  }
+
+  setShowIfAllowed() {
+    if (this.allowShow) {
+      this.setState({show: true});
+    }
+  }
+
+  render() {
+    const {show} = this.state;
+    if (show) {
+      return (
+        <img
+          src={spinnerImg}
+          style={{
+            align: 'center',
+            padding: '1em',
+          }}/>
+      );
+    }
+    return <span/>;
+  }
+}
+
+Loading.propTypes = {};

--- a/gulp/src/common/ui/SearchInput.js
+++ b/gulp/src/common/ui/SearchInput.js
@@ -41,7 +41,8 @@ export class SearchInput extends Component {
     this.setState({mouseInMenu: value});
   }
 
-  onSelect(index) {
+  onSelect(e, index) {
+    e.preventDefault();
     const {onSelect: selectCb} = this.props;
     const {items} = this.state;
     const selected = items[index];
@@ -172,7 +173,7 @@ export class SearchInput extends Component {
                   })}>
                 <a
                   href="#"
-                  onClick={() => this.onSelect(index)}>
+                  onClick={e => this.onSelect(e, index)}>
                   {item.display}
                 </a>
               </li>

--- a/gulp/src/reporting/DynamicReportApp.js
+++ b/gulp/src/reporting/DynamicReportApp.js
@@ -1,33 +1,23 @@
 import React, {PropTypes, Component} from 'react';
 import {ReportList} from './ReportList';
-import {WizardPageReportingTypes} from './wizard/WizardPageReportingTypes';
-import {WizardPageReportTypes} from './wizard/WizardPageReportTypes';
-import {WizardPageDataTypes} from './wizard/WizardPageDataTypes';
-import {WizardPagePresentationTypes} from './wizard/WizardPagePresentationTypes';
-import {WizardPageFilter} from './wizard/WizardPageFilter';
 
 // Props for this component come directly from the store state. (see main.js).
 export class DynamicReportApp extends Component {
   constructor() {
     super();
-    this.state = {pageIndex: null, error: null, reportList: []};
+    this.state = {reportList: []};
   }
 
-  async componentDidMount() {
-    await this.refreshReportList();
-    await this.reportingTypesPage();
-  }
-
-  async reset() {
+  componentDidMount() {
     const {reportFinder} = this.props;
+    this.callbackRef =
+      reportFinder.subscribeToReportList(() => this.refreshReportList());
+    this.refreshReportList();
+  }
 
-    const reportingTypes = await reportFinder.getReportingTypes();
-
-    this.setState({
-      ...this.state,
-      pageIndex: 'reportingTypes',
-      reportingTypes: reportingTypes,
-    });
+  componentWillUnmount() {
+    const {reportFinder} = this.props;
+    reportFinder.unsubscribeToReportList(this.callbackRef);
   }
 
   async refreshReportList() {
@@ -40,125 +30,14 @@ export class DynamicReportApp extends Component {
     });
   }
 
-  async reportingTypesPage() {
-    const {reportFinder} = this.props;
-    const reportingTypes = await reportFinder.getReportingTypes();
-    this.setState({
-      ...this.state,
-      pageIndex: 'reportingTypes',
-      reportingTypes: reportingTypes,
-    });
-  }
-
-  async reportTypesPage(reportingTypeId) {
-    const {reportFinder} = this.props;
-    const reportTypes =
-            await reportFinder.getReportTypes(reportingTypeId);
-    this.setState({
-      ...this.state,
-      pageIndex: 'reportTypes',
-      reportTypes: reportTypes,
-    });
-  }
-
-  async dataTypesPage(reportTypeId) {
-    const {reportFinder} = this.props;
-    const dataTypes =
-            await reportFinder.getDataTypes(reportTypeId);
-    this.setState({
-      ...this.state,
-      reportTypeId: reportTypeId,
-      pageIndex: 'dataTypes',
-      dataTypes: dataTypes,
-    });
-  }
-
-  async presentationTypesPage(reportTypeId, dataTypeId) {
-    const {reportFinder} = this.props;
-    const presentationTypes =
-            await reportFinder.getPresentationTypes(
-                reportTypeId, dataTypeId);
-    this.setState({
-      ...this.state,
-      pageIndex: 'presentationTypes',
-      presentationTypes: presentationTypes,
-    });
-  }
-
-  async filterPage(rpId) {
-    const {reportFinder} = this.props;
-
-    const reportConfig =
-          await reportFinder.buildReportConfiguration(
-              rpId,
-              () => this.refreshReportList());
-
-    this.setState({
-      ...this.state,
-      lastRpId: rpId,
-      pageIndex: 'filter',
-      reportConfig: reportConfig,
-    });
-  }
-
   render() {
-    const {pageIndex, error, reportList} = this.state;
-    let page;
-    if (error) {
-      page = <div><h3>Error!</h3></div>;
-    } else {
-      switch (pageIndex) {
-      case 'reportingTypes':
-        const {reportingTypes} = this.state;
-        page = (
-          <WizardPageReportingTypes
-            data={reportingTypes}
-            selected={id => this.reportTypesPage(id)}/>
-        );
-        break;
-      case 'reportTypes':
-        const {reportTypes} = this.state;
-        page = (
-          <WizardPageReportTypes
-              data={reportTypes}
-              selected={id => this.dataTypesPage(id)}/>
-        );
-        break;
-      case 'dataTypes':
-        const {reportTypeId, dataTypes} = this.state;
-        page = (
-          <WizardPageDataTypes
-            data={dataTypes}
-            selected={dataTypeId =>
-              this.presentationTypesPage(
-                reportTypeId, dataTypeId)}/>
-        );
-        break;
-      case 'presentationTypes':
-        const {presentationTypes} = this.state;
-        page = (
-          <WizardPagePresentationTypes
-            data={presentationTypes}
-            selected={id => this.filterPage(id)}/>
-        );
-        break;
-      case 'filter':
-        const {reportConfig} = this.state;
-        page = (
-          <WizardPageFilter
-            reportConfig={reportConfig}/>
-        );
-        break;
-      default:
-        page = '';
-      }
-    }
+    const {reportList} = this.state;
 
     return (
       <div className="container">
         <div className="row">
           <div className="span8 panel">
-            {page}
+            {this.props.children}
           </div>
           <div className="span4">
             <ReportList reports={reportList}/>
@@ -171,4 +50,5 @@ export class DynamicReportApp extends Component {
 
 DynamicReportApp.propTypes = {
   reportFinder: PropTypes.object.isRequired,
+  children: PropTypes.node,
 };

--- a/gulp/src/reporting/WizardRouter.jsx
+++ b/gulp/src/reporting/WizardRouter.jsx
@@ -1,0 +1,48 @@
+import React, {Component, PropTypes} from 'react';
+import {Router, Route, IndexRedirect} from 'react-router';
+import {DynamicReportApp} from 'reporting/DynamicReportApp';
+import {WizardPageReportingTypes} from './wizard/WizardPageReportingTypes';
+import {WizardPageReportTypes} from './wizard/WizardPageReportTypes';
+import {WizardPageDataTypes} from './wizard/WizardPageDataTypes';
+import {WizardPageFilter} from './wizard/WizardPageFilter';
+import {
+  WizardPagePresentationTypes,
+} from './wizard/WizardPagePresentationTypes';
+
+export class WizardRouter extends Component {
+  createElement(TheComponent, componentProps) {
+    const {reportFinder} = this.props;
+    const newProps = {...componentProps, reportFinder};
+
+    return <TheComponent {...newProps}/>;
+  }
+
+  render() {
+    return (
+      <Router createElement={(c, p) => this.createElement(c, p)}>
+        <Route path="/" component={DynamicReportApp}>
+          <IndexRedirect to="reporting-types"/>
+          <Route
+            path="reporting-types"
+            component={WizardPageReportingTypes}/>
+          <Route
+            path="report-types/:reportingType"
+            component={WizardPageReportTypes}/>
+          <Route
+            path="data-types/:reportType"
+            component={WizardPageDataTypes}/>
+          <Route
+            path="presentation-types/:reportType/:dataType"
+            component={WizardPagePresentationTypes}/>
+          <Route
+            path="set-up-report/:presentationType"
+            component={WizardPageFilter}/>
+        </Route>
+      </Router>
+    );
+  }
+}
+
+WizardRouter.propTypes = {
+  reportFinder: PropTypes.object.isRequired,
+};

--- a/gulp/src/reporting/main.js
+++ b/gulp/src/reporting/main.js
@@ -3,7 +3,7 @@ import {installPolyfills} from '../util/polyfills.js';
 import Api from './api';
 import {ReportFinder, ReportConfigurationBuilder} from './reportEngine';
 import {getCsrf} from '../util/cookie';
-import {DynamicReportApp} from './DynamicReportApp.js';
+import {WizardRouter} from './WizardRouter';
 
 import React from 'react';
 import ReactDOM from 'react-dom';
@@ -16,7 +16,6 @@ const configBuilder = new ReportConfigurationBuilder(api);
 const reportFinder = new ReportFinder(api, configBuilder);
 
 ReactDOM.render(
-    <DynamicReportApp
-        reportFinder={reportFinder}/>,
-    document.getElementById('reporting-app')
+  <WizardRouter reportFinder={reportFinder}/>,
+  document.getElementById('reporting-app')
 );

--- a/gulp/src/reporting/reportEngine.js
+++ b/gulp/src/reporting/reportEngine.js
@@ -7,36 +7,54 @@
 //
 // Last call of the "walk" is buildReportConfiguration.
 export class ReportFinder {
-    constructor(api, configBuilder) {
-      this.api = api;
-      this.configBuilder = configBuilder;
-    }
+  constructor(api, configBuilder) {
+    this.api = api;
+    this.configBuilder = configBuilder;
+    this.newReportSubscribers = {};
+  }
 
-    getReportingTypes() {
-      return this.api.getReportingTypes();
-    }
+  getReportingTypes() {
+    return this.api.getReportingTypes();
+  }
 
-    getReportTypes(reportingTypeId) {
-      return this.api.getReportTypes(reportingTypeId);
-    }
+  getReportTypes(reportingTypeId) {
+    return this.api.getReportTypes(reportingTypeId);
+  }
 
-    getDataTypes(reportTypeId) {
-      return this.api.getDataTypes(reportTypeId);
-    }
+  getDataTypes(reportTypeId) {
+    return this.api.getDataTypes(reportTypeId);
+  }
 
-    getPresentationTypes(reportTypeId, dataTypeId) {
-      return this.api.getPresentationTypes(reportTypeId, dataTypeId);
-    }
+  getPresentationTypes(reportTypeId, dataTypeId) {
+    return this.api.getPresentationTypes(reportTypeId, dataTypeId);
+  }
 
-    async buildReportConfiguration(rpId, newReportNotifier) {
-      const filters = await this.api.getFilters(rpId);
-      return this.configBuilder.build(
-            rpId, filters.filters, newReportNotifier);
-    }
+  async buildReportConfiguration(rpId) {
+    const filters = await this.api.getFilters(rpId);
+    return await this.configBuilder.build(
+      rpId, filters.filters, reportId => this.noteNewReport(reportId));
+  }
 
-    async getReportList() {
-      return await this.api.listReports();
+  async getReportList() {
+    return await this.api.listReports();
+  }
+
+  subscribeToReportList(callback) {
+    this.newReportSubscribers[callback] = callback;
+    return callback;
+  }
+
+  unsubscribeToReportList(ref) {
+    delete this.newReportSubscribers[ref];
+  }
+
+  noteNewReport(reportId) {
+    for (const ref in this.newReportSubscribers) {
+      if (this.newReportSubscribers.hasOwnProperty(ref)) {
+        this.newReportSubscribers[ref](reportId);
+      }
     }
+  }
 }
 
 // Gradually build a filter for a report run with help from the api.

--- a/gulp/src/reporting/spec/reportEngineSpec.js
+++ b/gulp/src/reporting/spec/reportEngineSpec.js
@@ -33,6 +33,22 @@ describe('ReportFinder', () => {
     expect(await finder.buildReportConfiguration(2)).toEqual(
       {rpId: 2, filters: {6: 6}});
   }));
+
+  describe('subscriptions', () => {
+    let newId = null;
+    const ref = finder.subscribeToReportList((id) => { newId = id; });
+
+    it('can inform subscribers of new reports', () => {
+      finder.noteNewReport(22);
+      expect(newId).toEqual(22);
+    });
+
+    it('can unsubscribe', () => {
+      finder.unsubscribeToReportList(ref);
+      finder.noteNewReport(33);
+      expect(newId).toEqual(22);
+    });
+  });
 });
 
 describe('ReportConfiguration', () => {

--- a/gulp/src/reporting/wizard/LinkRow.js
+++ b/gulp/src/reporting/wizard/LinkRow.js
@@ -1,22 +1,21 @@
 import React, {PropTypes} from 'react';
-import {Link} from './Link';
+import {Link} from 'react-router';
 
 
 export function LinkRow(props) {
+  const {text, label, to} = props;
   return (
     <div className="row">
       <div className="span2" style={{textAlign: 'right'}}>
-        <Link
-          linkClick={() => props.linkClick(props.id)}
-          label={props.label}/>
+        <Link to={to}>{label}</Link>
       </div>
-      <div className="span4">{props.text}</div>
+      <div className="span4">{text}</div>
     </div>
   );
 }
 
 LinkRow.propTypes = {
-  linkClick: PropTypes.func.isRequired,
   text: PropTypes.string.isRequired,
+  to: PropTypes.string.isRequired,
   label: PropTypes.string.isRequired,
 };

--- a/gulp/src/reporting/wizard/WizardPageDataTypes.js
+++ b/gulp/src/reporting/wizard/WizardPageDataTypes.js
@@ -1,30 +1,64 @@
-import React, {PropTypes} from 'react';
+import React, {PropTypes, Component} from 'react';
+import {Loading} from 'common/ui/Loading';
 import {LinkRow} from './LinkRow';
 
 
-export function WizardPageDataTypes(props) {
-  const data = props.data;
-  const rows = Object.keys(data).map(k =>
-    <LinkRow key={k} id={k} label={data[k].name}
-      text={data[k].description}
-      linkClick={() => props.selected(k)}/>
-  );
+export class WizardPageDataTypes extends Component {
+  componentWillMount() {
+    this.setState({
+      loading: true,
+    });
+  }
 
-  return (
-    <div>
-      <div className="row">
-        <div className="span2" style={{textAlign: 'right'}}>
+  componentDidMount() {
+    this.loadData();
+  }
+
+  async loadData() {
+    const {reportFinder} = this.props;
+    const {reportType} = this.props.routeParams;
+    const dataTypes = await reportFinder.getDataTypes(reportType);
+    this.setState({
+      loading: false,
+      data: dataTypes,
+    });
+  }
+
+  render() {
+    const {loading, data} = this.state;
+    const {reportType} = this.props.routeParams;
+
+    let rows;
+    if (loading) {
+      rows = <Loading/>;
+    } else {
+      rows = Object.keys(data).map(k =>
+        <LinkRow
+          key={k}
+          label={data[k].name}
+          text={data[k].description}
+          to={`/presentation-types/${reportType}/${k}`}/>
+      );
+    }
+
+    return (
+      <div>
+        <div className="row">
+          <div className="span2" style={{textAlign: 'right'}}>
+          </div>
+          <div className="span4">
+            <h4>Data Types</h4>
+          </div>
         </div>
-        <div className="span4">
-          <h4>Data Types</h4>
-        </div>
+        {rows}
       </div>
-      {rows}
-    </div>
-  );
+    );
+  }
 }
 
 WizardPageDataTypes.propTypes = {
-  data: PropTypes.object.isRequired,
-  selected: PropTypes.func.isRequired,
+  routeParams: PropTypes.shape({
+    reportType: PropTypes.string.isRequired,
+  }).isRequired,
+  reportFinder: PropTypes.object.isRequired,
 };

--- a/gulp/src/reporting/wizard/WizardPageFilter.js
+++ b/gulp/src/reporting/wizard/WizardPageFilter.js
@@ -1,6 +1,7 @@
 import React, {PropTypes, Component} from 'react';
 import Button from 'react-bootstrap/lib/Button';
 import warning from 'warning';
+import {Loading} from 'common/ui/Loading';
 
 import {WizardFilterDateRange} from './WizardFilterDateRange';
 import {WizardFilterSearchDropdown} from './WizardFilterSearchDropdown';
@@ -10,47 +11,68 @@ import {WizardFilterCityState} from './WizardFilterCityState';
 import {SearchInput} from 'common/ui/SearchInput';
 
 export class WizardPageFilter extends Component {
+  constructor() {
+    super();
+    this.state = {
+      loading: true,
+    };
+  }
+
   componentDidMount() {
-    this.updateState();
+    this.loadData();
   }
 
   async getHints(filter, partial) {
-    const {reportConfig} = this.props;
+    const {reportConfig} = this.state;
     return await reportConfig.getHints(filter, partial);
   }
 
+  async loadData() {
+    await this.buildReportConfig();
+    this.updateState();
+    this.setState({loading: false});
+  }
+
+  async buildReportConfig() {
+    const {reportFinder} = this.props;
+    const {presentationType} = this.props.routeParams;
+    const reportConfig = await reportFinder.buildReportConfiguration(
+      presentationType);
+    this.setState({reportConfig});
+  }
+
   updateFilter(filter, value) {
-    const {reportConfig} = this.props;
+    const {reportConfig} = this.state;
     reportConfig.setFilter(filter, value);
     this.updateState();
   }
 
   addToMultifilter(filter, value) {
-    const {reportConfig} = this.props;
+    const {reportConfig} = this.state;
     reportConfig.addToMultifilter(filter, value);
     this.updateState();
   }
 
   removeFromMultifilter(filter, value) {
-    const {reportConfig} = this.props;
+    const {reportConfig} = this.state;
     reportConfig.removeFromMultifilter(filter, value);
     this.updateState();
   }
 
   addToAndOrFilter(filter, index, value) {
-    const {reportConfig} = this.props;
+    const {reportConfig} = this.state;
     reportConfig.addToAndOrFilter(filter, index, value);
     this.updateState();
   }
 
   removeFromAndOrFilter(filter, index, value) {
-    const {reportConfig} = this.props;
+    const {reportConfig} = this.state;
     reportConfig.removeFromAndOrFilter(filter, index, value);
     this.updateState();
   }
 
   updateState() {
-    const {reportConfig} = this.props;
+    const {reportConfig} = this.state;
     this.setState({
       filter: reportConfig.getFilter(),
     });
@@ -70,7 +92,11 @@ export class WizardPageFilter extends Component {
   }
 
   render() {
-    const {reportConfig} = this.props;
+    const {loading, reportConfig} = this.state;
+
+    if (loading) {
+      return <Loading/>;
+    }
 
     const rows = [];
     reportConfig.filters.forEach(col => {
@@ -160,5 +186,8 @@ export class WizardPageFilter extends Component {
 }
 
 WizardPageFilter.propTypes = {
-  reportConfig: PropTypes.object.isRequired,
+  routeParams: PropTypes.shape({
+    presentationType: PropTypes.string.isRequired,
+  }).isRequired,
+  reportFinder: PropTypes.object.isRequired,
 };

--- a/gulp/src/reporting/wizard/WizardPagePresentationTypes.js
+++ b/gulp/src/reporting/wizard/WizardPagePresentationTypes.js
@@ -1,35 +1,72 @@
-import React, {PropTypes} from 'react';
-import {Link} from './Link';
+import React, {PropTypes, Component} from 'react';
+import {Loading} from 'common/ui/Loading';
+import {Link} from 'react-router';
 
 
-export function WizardPagePresentationTypes(props) {
-  const data = props.data;
-  const rows = Object.keys(data).map(k =>
-    <div key={k} className="row">
-      <div className="span2" style={{textAlign: 'right'}}>
-      </div>
-      <div className="span4">
-        <Link id={k} label={data[k].name}
-          linkClick={() => props.selected(k)}/>
-      </div>
-    </div>
-  );
+export class WizardPagePresentationTypes extends Component {
+  constructor() {
+    super();
+    this.state = {
+      loading: true,
+    };
+  }
 
-  return (
-    <div>
-      <div className="row">
-        <div className="span2" style={{textAlign: 'right'}}>
+  componentDidMount() {
+    this.loadData();
+  }
+
+  async loadData() {
+    const {reportFinder} = this.props;
+    const {reportType, dataType} = this.props.routeParams;
+    const reportTypes = await reportFinder.getPresentationTypes(
+      reportType, dataType);
+    this.setState({
+      loading: false,
+      data: reportTypes,
+    });
+  }
+
+
+  render() {
+    const {loading, data} = this.state;
+
+    let rows;
+    if (loading) {
+      rows = <Loading/>;
+    } else {
+      rows = Object.keys(data).map(k =>
+        <div key={k} className="row">
+          <div className="span2" style={{textAlign: 'right'}}>
+          </div>
+          <div className="span4">
+            <Link
+              to={`/set-up-report/${k}`}>
+              {data[k].name}
+            </Link>
+          </div>
         </div>
-        <div className="span4">
-          <h4>Presentation Types</h4>
+      );
+    }
+
+    return (
+      <div>
+        <div className="row">
+          <div className="span2" style={{textAlign: 'right'}}>
+          </div>
+          <div className="span4">
+            <h4>Presentation Types</h4>
+          </div>
         </div>
+        {rows}
       </div>
-      {rows}
-    </div>
-  );
+    );
+  }
 }
 
 WizardPagePresentationTypes.propTypes = {
-  data: PropTypes.object.isRequired,
-  selected: PropTypes.func.isRequired,
+  routeParams: PropTypes.shape({
+    reportType: PropTypes.string.isRequired,
+    dataType: PropTypes.string.isRequired,
+  }).isRequired,
+  reportFinder: PropTypes.object.isRequired,
 };

--- a/gulp/src/reporting/wizard/WizardPageReportTypes.js
+++ b/gulp/src/reporting/wizard/WizardPageReportTypes.js
@@ -1,30 +1,63 @@
-import React, {PropTypes} from 'react';
+import React, {PropTypes, Component} from 'react';
+import {Loading} from 'common/ui/Loading';
 import {LinkRow} from './LinkRow';
 
 
-export function WizardPageReportTypes(props) {
-  const data = props.data;
-  const rows = Object.keys(data).map(k =>
-    <LinkRow key={k} id={k} label={data[k].name}
-      text={data[k].description}
-      linkClick={() => props.selected(k)}/>
-  );
+export class WizardPageReportTypes extends Component {
+  componentWillMount() {
+    this.setState({
+      loading: true,
+    });
+  }
 
-  return (
-    <div>
-      <div className="row">
-        <div className="span2" style={{textAlign: 'right'}}>
+  componentDidMount() {
+    this.loadData();
+  }
+
+  async loadData() {
+    const {reportFinder} = this.props;
+    const {reportingType} = this.props.routeParams;
+    const reportTypes = await reportFinder.getReportTypes(reportingType);
+    this.setState({
+      loading: false,
+      data: reportTypes,
+    });
+  }
+
+  render() {
+    const {loading, data} = this.state;
+
+    let rows;
+    if (loading) {
+      rows = <Loading/>;
+    } else {
+      rows = Object.keys(data).map(k =>
+        <LinkRow
+          key={k}
+          label={data[k].name}
+          text={data[k].description}
+          to={`/data-types/${k}`}/>
+      );
+    }
+
+    return (
+      <div>
+        <div className="row">
+          <div className="span2" style={{textAlign: 'right'}}>
+          </div>
+          <div className="span4">
+            <h4>Report Types</h4>
+          </div>
         </div>
-        <div className="span4">
-          <h4>Report Types</h4>
-        </div>
+        {rows}
       </div>
-      {rows}
-    </div>
-  );
+    );
+  }
 }
 
 WizardPageReportTypes.propTypes = {
-  data: PropTypes.object.isRequired,
-  selected: PropTypes.func.isRequired,
+  routeParams: PropTypes.shape({
+    reportingType: PropTypes.string.isRequired,
+  }).isRequired,
+  reportFinder: PropTypes.object.isRequired,
 };

--- a/gulp/src/reporting/wizard/WizardPageReportingTypes.js
+++ b/gulp/src/reporting/wizard/WizardPageReportingTypes.js
@@ -1,29 +1,58 @@
-import React, {PropTypes} from 'react';
+import React, {PropTypes, Component} from 'react';
+import {Loading} from 'common/ui/Loading';
 import {LinkRow} from './LinkRow';
 
-export function WizardPageReportingTypes(props) {
-  const data = props.data;
-  const rows = Object.keys(data).map(k =>
-    <LinkRow key={k} id={k} label={data[k].name}
-      text={data[k].description}
-      linkClick={() => props.selected(k)}/>
-  );
+export class WizardPageReportingTypes extends Component {
+  componentWillMount() {
+    this.setState({
+      loading: true,
+    });
+  }
 
-  return (
-    <div>
-      <div className="row">
-        <div className="span2" style={{textAlign: 'right'}}>
+  componentDidMount() {
+    this.loadData();
+  }
+
+  async loadData() {
+    const {reportFinder} = this.props;
+    const reportingTypes = await reportFinder.getReportingTypes();
+    this.setState({
+      loading: false,
+      data: reportingTypes,
+    });
+  }
+
+  render() {
+    const {loading, data} = this.state;
+
+    let rows;
+    if (loading) {
+      rows = <Loading/>;
+    } else {
+      rows = Object.keys(data).map(k =>
+        <LinkRow
+          key={k}
+          label={data[k].name}
+          text={data[k].description}
+          to={`/report-types/${k}`}/>
+      );
+    }
+
+    return (
+      <div>
+        <div className="row">
+          <div className="span2" style={{textAlign: 'right'}}>
+          </div>
+          <div className="span4">
+            <h4>Reporting Types</h4>
+          </div>
         </div>
-        <div className="span4">
-          <h4>Reporting Types</h4>
-        </div>
+        {rows}
       </div>
-      {rows}
-    </div>
-  );
+    );
+  }
 }
 
 WizardPageReportingTypes.propTypes = {
-  data: PropTypes.object.isRequired,
-  selected: PropTypes.func.isRequired,
+  reportFinder: PropTypes.object.isRequired,
 };

--- a/myjobs/api.py
+++ b/myjobs/api.py
@@ -1,6 +1,5 @@
 import datetime
 from urlparse import urlparse
-from urllib import unquote
 
 from django.db import IntegrityError
 

--- a/myreports/urls.py
+++ b/myreports/urls.py
@@ -15,7 +15,7 @@ urlpatterns = patterns(
         name='download_dynamic_report'),
     url(r'download$', 'download_report', name='download_report'),
     url(r'view/downloads$', 'downloads', name='downloads'),
-    url(r'^view/dynamicoverview$', 'dynamicoverview', name='dynamicoverview'),
+    url(r'^view/dynamicoverview/$', 'dynamicoverview', name='dynamicoverview'),
     url(r'^api/reporting_types$', 'reporting_types_api',
         name='reporting_types_api'),
     url(r'^api/report_types$', 'report_types_api',

--- a/templates/myreports/dynamicreports.html
+++ b/templates/myreports/dynamicreports.html
@@ -28,6 +28,9 @@
 {% endblock %}
 
 {% block extra-js %}
+<script>
+spinnerImg = "{% static "images/ajax-loader.gif" %}";
+</script>
 {% compress js %}
 <script src="{% static "bundle/vendor.js" %}"></script>
 <script src="{% static "bundle/reporting.js" %}"></script>


### PR DESCRIPTION
Replace the ad-hoc routing with no history support in DynamicReportApp with react-router.

This PR may be easier to review commit by commit. The commit "Refactor reporting wizard" touches a lot of files. The other commits are small.

The refactor does a couple of things:

* Make each page responsible for loading its own data.
* Adds the Router.
* ReportEngine's interface for notifying a react component of newly created reports moved to ReportFinder. This simplified routing.