### PR TITLE
[PD-1384]  presentation layer

### DIFF
--- a/gulp/src/reporting/wizard/WizardPageFilter.js
+++ b/gulp/src/reporting/wizard/WizardPageFilter.js
@@ -10,6 +10,13 @@ import {WizardFilterCityState} from './WizardFilterCityState';
 import {SearchInput} from 'common/ui/SearchInput';
 
 export class WizardPageFilter extends Component {
+  constructor() {
+    super();
+    this.state = {
+      reportName: 'Report Name',
+    };
+  }
+
   componentDidMount() {
     this.updateState();
   }
@@ -71,6 +78,7 @@ export class WizardPageFilter extends Component {
 
   render() {
     const {reportConfig} = this.props;
+    const {reportName} = this.state;
 
     const rows = [];
     reportConfig.filters.forEach(col => {
@@ -150,7 +158,7 @@ export class WizardPageFilter extends Component {
         <hr/>
         {this.renderRow('', 'submit',
           <Button
-            onClick={() => reportConfig.run()}>
+            onClick={() => reportConfig.run(reportName)}>
             Run Report
           </Button>)}
 

--- a/myreports/presentation/__init__.py
+++ b/myreports/presentation/__init__.py
@@ -1,9 +1,9 @@
 from myreports.presentation.csv import Csv
 from myreports.presentation.xlsx import Xlsx
-from myreports.presentation.jsonpass import JsonPass
+from myreports.presentation.jsonpass import Json
 
 presentation_drivers = {
     'csv': Csv(),
     'xlsx': Xlsx(),
-    'json_pass': JsonPass(),
+    'json_pass': Json(),
 }

--- a/myreports/presentation/__init__.py
+++ b/myreports/presentation/__init__.py
@@ -1,0 +1,8 @@
+from myreports.presentation.csv import Csv
+from myreports.presentation.xlsx import Xlsx
+
+
+presentation_drivers = {
+    'csv': Csv(),
+    'xlsx': Xlsx(),
+}

--- a/myreports/presentation/__init__.py
+++ b/myreports/presentation/__init__.py
@@ -1,8 +1,9 @@
 from myreports.presentation.csv import Csv
 from myreports.presentation.xlsx import Xlsx
-
+from myreports.presentation.jsonpass import JsonPass
 
 presentation_drivers = {
     'csv': Csv(),
     'xlsx': Xlsx(),
+    'json_pass': JsonPass(),
 }

--- a/myreports/presentation/base.py
+++ b/myreports/presentation/base.py
@@ -2,4 +2,48 @@ from abc import ABCMeta
 
 
 class Presentation:
+    """Base class for Reporting presentation types.
+
+    Implementations are responsible for selecting the content type and
+    filename extension which the user's browser will see at download time,
+    as well as writing bytes of the document to an output stream.
+    """
     ___metaclass__ = ABCMeta
+
+    def content_type(self):
+        """Content type as seen by the user's browser.
+
+        i.e. 'application/json', 'text/csv', etc.
+        """
+        pass
+
+    def filename_extension(self):
+        """Filename extension seen by the user at download time.
+
+        i.e. 'csv', 'xls', etc.
+        """
+        pass
+
+    def write_presentation(self, values, records, output):
+        """Write bytes representing the downloaded artifact.
+
+        values - Ordered list of columns to appear in the download.
+            i.e. ['a', 'c', 'b']
+        records - List of dicts containing data to appear in the download.
+            i.e. [
+            {'a': '1', 'b': '2', 'c', '3'},
+            {'a': '4', 'b': '5', 'c', '6'},
+        ],
+        output - has method output.write(bytes) which accepts bytes for
+            download
+
+        Example:
+
+            def write_presentation(self, values, records, output):
+                output.write('|'.join(values))
+                output.write('\\n')
+                for record in records:
+                    output.write("|".join(record[v] for v in values]))
+                    output.write('\\n')
+        """
+        pass

--- a/myreports/presentation/base.py
+++ b/myreports/presentation/base.py
@@ -1,0 +1,5 @@
+from abc import ABCMeta
+
+
+class Presentation:
+    ___metaclass__ = ABCMeta

--- a/myreports/presentation/base.py
+++ b/myreports/presentation/base.py
@@ -1,28 +1,22 @@
-from abc import ABCMeta
-
-
-class Presentation:
+class Presentation(object):
     """Base class for Reporting presentation types.
 
     Implementations are responsible for selecting the content type and
     filename extension which the user's browser will see at download time,
     as well as writing bytes of the document to an output stream.
     """
-    ___metaclass__ = ABCMeta
 
-    def content_type(self):
-        """Content type as seen by the user's browser.
+    """Content type as seen by the user's browser.
 
-        i.e. 'application/json', 'text/csv', etc.
-        """
-        pass
+    i.e. 'application/json', 'text/csv', etc.
+    """
+    content_type = ''
 
-    def filename_extension(self):
-        """Filename extension seen by the user at download time.
+    """Filename extension seen by the user at download time.
 
-        i.e. 'csv', 'xls', etc.
-        """
-        pass
+    i.e. 'csv', 'xls', etc.
+    """
+    filename_extension = ''
 
     def write_presentation(self, values, records, output):
         """Write bytes representing the downloaded artifact.

--- a/myreports/presentation/csv.py
+++ b/myreports/presentation/csv.py
@@ -1,0 +1,16 @@
+import unicodecsv
+from myreports.presentation.base import Presentation
+
+
+class Csv(Presentation):
+    def content_type(self):
+        return 'text/csv'
+
+    def filename_extension(self):
+        return 'csv'
+
+    def write_presentation(self, values, records, output):
+        csvwriter = unicodecsv.writer(output, encoding='utf-8')
+        csvwriter.writerow(values)
+        for record in records:
+            csvwriter.writerow(unicode(record[v]) for v in values)

--- a/myreports/presentation/csv.py
+++ b/myreports/presentation/csv.py
@@ -4,11 +4,9 @@ from myreports.presentation.base import Presentation
 
 class Csv(Presentation):
     """Write csv based presentation formats."""
-    def content_type(self):
-        return 'text/csv'
+    content_type = 'text/csv'
 
-    def filename_extension(self):
-        return 'csv'
+    filename_extension = 'csv'
 
     def write_presentation(self, values, records, output):
         csvwriter = unicodecsv.writer(output, encoding='utf-8')

--- a/myreports/presentation/csv.py
+++ b/myreports/presentation/csv.py
@@ -3,6 +3,7 @@ from myreports.presentation.base import Presentation
 
 
 class Csv(Presentation):
+    """Write csv based presentation formats."""
     def content_type(self):
         return 'text/csv'
 

--- a/myreports/presentation/disposition.py
+++ b/myreports/presentation/disposition.py
@@ -5,5 +5,13 @@ filename_bad_chars = re.compile(r'\W')
 
 
 def get_content_disposition(report_name, extension):
+    """Build the contents of a Content-Disposition header.
+
+    Takes care of removing spaces and other problematic characteres from
+    filenames.
+
+    report_name - name of the report. Can contain arbitrary characters.
+    extension - file extension for the report filename.
+    """
     filename = filename_bad_chars.sub('_', report_name)
     return 'attachment; filename=%s.%s' % (filename, extension)

--- a/myreports/presentation/disposition.py
+++ b/myreports/presentation/disposition.py
@@ -1,0 +1,9 @@
+import re
+
+
+filename_bad_chars = re.compile(r'\W')
+
+
+def get_content_disposition(report_name, extension):
+    filename = filename_bad_chars.sub('_', report_name)
+    return 'attachment; filename=%s.%s' % (filename, extension)

--- a/myreports/presentation/jsonpass.py
+++ b/myreports/presentation/jsonpass.py
@@ -2,16 +2,14 @@ import json
 from myreports.presentation.base import Presentation
 
 
-class JsonPass(Presentation):
+class Json(Presentation):
     """Write report data as a single json file.
 
     Useful as a rough passthrough for testing.
     """
-    def content_type(self):
-        return 'application/json'
+    content_type = 'application/json'
 
-    def filename_extension(self):
-        return 'json'
+    filename_extension = 'json'
 
     def write_presentation(self, values, records, output):
         output.write(json.dumps({

--- a/myreports/presentation/jsonpass.py
+++ b/myreports/presentation/jsonpass.py
@@ -1,0 +1,16 @@
+import json
+from myreports.presentation.base import Presentation
+
+
+class JsonPass(Presentation):
+    def content_type(self):
+        return 'application/json'
+
+    def filename_extension(self):
+        return 'json'
+
+    def write_presentation(self, values, records, output):
+        output.write(json.dumps({
+            'values': values,
+            'records': records,
+        }))

--- a/myreports/presentation/jsonpass.py
+++ b/myreports/presentation/jsonpass.py
@@ -3,6 +3,10 @@ from myreports.presentation.base import Presentation
 
 
 class JsonPass(Presentation):
+    """Write report data as a single json file.
+
+    Useful as a rough passthrough for testing.
+    """
     def content_type(self):
         return 'application/json'
 

--- a/myreports/presentation/xlsx.py
+++ b/myreports/presentation/xlsx.py
@@ -3,13 +3,11 @@ from myreports.presentation.base import Presentation
 
 
 class Xlsx(Presentation):
-    def content_type(self):
-        return (
-            'application/vnd.openxmlformats-' +
-            'officedocument.spreadsheetml.sheet')
+    content_type = (
+        'application/vnd.openxmlformats-' +
+        'officedocument.spreadsheetml.sheet')
 
-    def filename_extension(self):
-        return 'xlsx'
+    filename_extension = 'xlsx'
 
     def write_presentation(self, values, records, output):
         workbook = Workbook(output, {'constant_memory': True})

--- a/myreports/presentation/xlsx.py
+++ b/myreports/presentation/xlsx.py
@@ -1,0 +1,23 @@
+from xlsxwriter import Workbook
+from myreports.presentation.base import Presentation
+
+
+class Xlsx(Presentation):
+    def content_type(self):
+        return (
+            'application/vnd.openxmlformats-' +
+            'officedocument.spreadsheetml.sheet')
+
+    def filename_extension(self):
+        return 'xlsx'
+
+    def write_presentation(self, values, records, output):
+        workbook = Workbook(output, {'constant_memory': True})
+        worksheet = workbook.add_worksheet()
+        for column, value in enumerate(values):
+            worksheet.write_string(0, column, value)
+        for row, record in enumerate(records):
+            value_iterator = enumerate([unicode(record[v]) for v in values])
+            for column, text in value_iterator:
+                worksheet.write_string(row + 1, column, text)
+        workbook.close()

--- a/myreports/tests/setup.py
+++ b/myreports/tests/setup.py
@@ -204,6 +204,11 @@ def create_full_fixture():
         id=3, presentation_type="csv", description="Unformatted CSV")
     pre_xlsx = PresentationTypeFactory.create(
         id=4, presentation_type="xlsx", description="Excel xlsx")
+    pre_json = PresentationTypeFactory.create(
+        id=5,
+        is_active=False,
+        presentation_type="json_pass",
+        description="JSON Passthrough")
 
     Configuration.objects.all().delete()
     con_dead = ConfigurationFactory.create(
@@ -536,4 +541,16 @@ def create_full_fixture():
     ReportPresentationFactory.create(
         id=9, presentation_type=pre_xlsx, configuration=con_comm,
         display_name="Communication Record Excel Spreadsheet",
+        report_data=rtdt_comm_unagg, is_active=True)
+    ReportPresentationFactory.create(
+        id=10, presentation_type=pre_json, configuration=con_part,
+        display_name="Partner JSON Passthrough",
+        report_data=rtdt_part_unagg, is_active=True)
+    ReportPresentationFactory.create(
+        id=11, presentation_type=pre_json, configuration=con_con,
+        display_name="Contact JSON Passthrough",
+        report_data=rtdt_con_unagg, is_active=True)
+    ReportPresentationFactory.create(
+        id=12, presentation_type=pre_json, configuration=con_comm,
+        display_name="Communication Record JSON Passthrough",
         report_data=rtdt_comm_unagg, is_active=True)

--- a/myreports/tests/setup.py
+++ b/myreports/tests/setup.py
@@ -188,7 +188,7 @@ def create_full_fixture():
         report_type=rt_con, data_type=dt_dead)
     ReportTypeDataTypesFactory.create(
         report_type=rt_con, data_type=dt_maybe_dead, is_active=False)
-    rtdt_conn_unagg = ReportTypeDataTypesFactory.create(
+    rtdt_con_unagg = ReportTypeDataTypesFactory.create(
         report_type=rt_con, data_type=dt_unagg)
     rtdt_part_unagg = ReportTypeDataTypesFactory.create(
         report_type=rt_partners, data_type=dt_unagg)
@@ -197,11 +197,13 @@ def create_full_fixture():
 
     PresentationType.objects.all().delete()
     pre_dead = PresentationTypeFactory.create(
-        id=1, presentation_type="Inactive", is_active=False)
+        id=1, description="Inactive", is_active=False)
     pre_maybe_dead = PresentationTypeFactory.create(
-        id=2, presentation_type="Maybe Inactive")
+        id=2, description="Maybe Inactive")
     pre_csv = PresentationTypeFactory.create(
-        id=3, presentation_type="Unformatted CSV")
+        id=3, presentation_type="csv", description="Unformatted CSV")
+    pre_xlsx = PresentationTypeFactory.create(
+        id=4, presentation_type="xlsx", description="Excel xlsx")
 
     Configuration.objects.all().delete()
     con_dead = ConfigurationFactory.create(
@@ -502,19 +504,19 @@ def create_full_fixture():
     ReportPresentation.objects.all().delete()
     ReportPresentationFactory.create(
         id=1, presentation_type=pre_maybe_dead, configuration=con_con,
-        display_name="Dead", report_data=rtdt_conn_unagg, is_active=False)
+        display_name="Dead", report_data=rtdt_con_unagg, is_active=False)
     ReportPresentationFactory.create(
         id=2, presentation_type=pre_dead, configuration=con_con,
         display_name="Dead Presentation",
-        report_data=rtdt_conn_unagg, is_active=True)
+        report_data=rtdt_con_unagg, is_active=True)
     ReportPresentationFactory.create(
         id=3, presentation_type=pre_csv, configuration=con_con,
         display_name="Contact CSV",
-        report_data=rtdt_conn_unagg, is_active=True)
+        report_data=rtdt_con_unagg, is_active=True)
     ReportPresentationFactory.create(
         id=4, presentation_type=pre_csv, configuration=con_dead,
         display_name="Dead Configuration",
-        report_data=rtdt_conn_unagg, is_active=True)
+        report_data=rtdt_con_unagg, is_active=True)
     ReportPresentationFactory.create(
         id=5, presentation_type=pre_csv, configuration=con_part,
         display_name="Partner CSV",
@@ -522,4 +524,16 @@ def create_full_fixture():
     ReportPresentationFactory.create(
         id=6, presentation_type=pre_csv, configuration=con_comm,
         display_name="Communication Record CSV",
+        report_data=rtdt_comm_unagg, is_active=True)
+    ReportPresentationFactory.create(
+        id=7, presentation_type=pre_xlsx, configuration=con_con,
+        display_name="Contact Excel Spreadsheet",
+        report_data=rtdt_con_unagg, is_active=True)
+    ReportPresentationFactory.create(
+        id=8, presentation_type=pre_xlsx, configuration=con_part,
+        display_name="Partner Excel Spreadsheet",
+        report_data=rtdt_part_unagg, is_active=True)
+    ReportPresentationFactory.create(
+        id=9, presentation_type=pre_xlsx, configuration=con_comm,
+        display_name="Communication Record Excel Spreadsheet",
         report_data=rtdt_comm_unagg, is_active=True)

--- a/myreports/tests/test_models.py
+++ b/myreports/tests/test_models.py
@@ -79,7 +79,7 @@ class TestActiveModels(MyReportsTestCase):
         rps = (ReportPresentation.objects
                .active_for_report_type_data_type(rtdt))
         names = set([rp.display_name for rp in rps])
-        expected_names = set(['Contact CSV'])
+        expected_names = set(['Contact CSV', 'Contact Excel Spreadsheet'])
         self.assertEqual(expected_names, names)
 
     def test_active_columns(self):

--- a/myreports/tests/test_presentations.py
+++ b/myreports/tests/test_presentations.py
@@ -1,0 +1,78 @@
+from zipfile import ZipFile
+from cStringIO import StringIO
+from unittest import TestCase
+from defusedxml.ElementTree import fromstring
+from myreports.presentation.disposition import get_content_disposition
+from myreports.presentation.csv import Csv
+from myreports.presentation.xlsx import Xlsx
+
+
+class TestDisposition(TestCase):
+    def test_content_disposition_filename(self):
+        """Filenames in disposition should be cleaned of odd characters."""
+        self.assert_filename("abc", "abc")
+        self.assert_filename("a_bc", "a bc")
+        self.assert_filename("a_bc", "a\tbc")
+        self.assert_filename("a_bc", u"a\u2019bc")
+
+    def assert_filename(self, expected_filename, report_name):
+        expected_disposition = (
+            "attachment; filename=%s.zzz" %
+            expected_filename)
+        actual = get_content_disposition(report_name, 'zzz')
+        self.assertEqual(expected_disposition, actual)
+
+
+class TestCsv(TestCase):
+    csv = Csv()
+
+    def test_presentation(self):
+        """Happy path, puts data in csv columns, etc."""
+        expected = """A,B\r
+1,b\r
+2,bb\r
+"""
+        values = ['A', 'B']
+        records = [
+            {'A': 1, 'B': 'b'},
+            {'A': 2, 'B': 'bb'},
+        ]
+        self.assert_content(expected, values, records)
+
+    def test_presentation_unicode(self):
+        """Run a unicode character through the presentation."""
+        expected = """A\r
+aa\xe2\x80\x99zz\r
+"""
+        values = ['A']
+        records = [{'A': u'aa\u2019zz'}]
+        self.assert_content(expected, values, records)
+
+    def assert_content(self, expected, values, records):
+        output = StringIO()
+        self.csv.write_presentation(values, records, output)
+        self.assertEqual(expected, output.getvalue())
+
+
+class TestXlsx(TestCase):
+    xlsx = Xlsx()
+    ns = {
+        'ssml': 'http://schemas.openxmlformats.org/spreadsheetml/2006/main',
+    }
+
+    def test_presentation(self):
+        """Make sure the data can be found in the Excel spreadsheet."""
+        output = StringIO()
+        values = ['A', 'B']
+        records = [
+            {'A': 1, 'B': 'b'},
+            {'A': 2, 'B': 'bb'},
+        ]
+        self.xlsx.write_presentation(values, records, output)
+        sheet_entry = 'xl/worksheets/sheet1.xml'
+        sheet_content = ZipFile(output).open(sheet_entry).read()
+        root = fromstring(sheet_content)
+        cells = root.findall('.//ssml:t', self.ns)
+        values = [e.text for e in cells]
+        expected_values = ['A', 'B', '1', 'b', '2', 'bb']
+        self.assertEqual(expected_values, values)

--- a/myreports/tests/test_views.py
+++ b/myreports/tests/test_views.py
@@ -492,8 +492,10 @@ class TestDynamicReports(MyReportsTestCase):
     def setUp(self):
         super(TestDynamicReports, self).setUp()
 
-        self.xlsx = PresentationType.objects.get(
-            presentation_type='xlsx')
+        self.json_pass = PresentationType.objects.get(
+            presentation_type='json_pass')
+        self.json_pass.is_active = True
+        self.json_pass.save()
 
     def find_report_presentation(self, datasource, presentation_type):
         return ReportPresentation.objects.get(
@@ -516,7 +518,7 @@ class TestDynamicReports(MyReportsTestCase):
 
         report_presentation = self.find_report_presentation(
             'contacts',
-            'csv')
+            'json_pass')
 
         resp = self.client.post(
             reverse('run_dynamic_report'),
@@ -538,10 +540,12 @@ class TestDynamicReports(MyReportsTestCase):
         resp = self.client.get(reverse('download_dynamic_report'),
                                {'id': report_id})
         self.assertEquals(200, resp.status_code)
-        lines = resp.content.splitlines()
-        self.assertEquals(11, len(lines))
-        first_found_name = lines[1].split(',')[0]
-        expected_name = u'name-0 \u2019'.encode('utf-8')
+
+        response_data = json.loads(resp.content)
+        self.assertEquals(10, len(response_data['records']))
+
+        first_found_name = response_data['records'][0]['name']
+        expected_name = u'name-0 \u2019'
         self.assertEqual(expected_name, first_found_name)
 
     def test_dynamic_partners_report(self):
@@ -556,7 +560,7 @@ class TestDynamicReports(MyReportsTestCase):
 
         report_presentation = self.find_report_presentation(
             'partners',
-            'csv')
+            'json_pass')
 
         resp = self.client.post(
             reverse('run_dynamic_report'),
@@ -578,11 +582,12 @@ class TestDynamicReports(MyReportsTestCase):
         resp = self.client.get(reverse('download_dynamic_report'),
                                {'id': report_id})
         self.assertEquals(200, resp.status_code)
-        lines = resp.content.splitlines()
-        self.assertEquals(22, len(lines))
-        first_found_name = lines[-1].split(',')[1]
-        expected_name = u'partner-19 \u2019'.encode('utf-8')
-        self.assertEqual(expected_name, first_found_name)
+        response_data = json.loads(resp.content)
+        self.assertEquals(21, len(response_data['records']))
+
+        last_found_name = response_data['records'][-1]['name']
+        expected_name = u'partner-19 \u2019'
+        self.assertEqual(expected_name, last_found_name)
 
     def test_dynamic_comm_records_report(self):
         """Create some test data, run, list, and download a commrec report."""
@@ -600,7 +605,7 @@ class TestDynamicReports(MyReportsTestCase):
 
         report_presentation = self.find_report_presentation(
             'comm_records',
-            'csv')
+            'json_pass')
 
         resp = self.client.post(
             reverse('run_dynamic_report'),
@@ -622,11 +627,12 @@ class TestDynamicReports(MyReportsTestCase):
         resp = self.client.get(reverse('download_dynamic_report'),
                                {'id': report_id})
         self.assertEquals(200, resp.status_code)
-        lines = resp.content.splitlines()
-        self.assertEquals(21, len(lines))
-        first_found_name = lines[-1].split(',')[15]
-        expected_name = u'subject-19 \u2019'.encode('utf-8')
-        self.assertEqual(expected_name, first_found_name)
+        response_data = json.loads(resp.content)
+        self.assertEquals(20, len(response_data['records']))
+
+        last_subject = response_data['records'][-1]['subject']
+        expected_subject = u'subject-19 \u2019'
+        self.assertEqual(expected_subject, last_subject)
 
     def test_dynamic_report_with_filter(self):
         """Create some test data, run filtered, and download a report."""
@@ -643,7 +649,7 @@ class TestDynamicReports(MyReportsTestCase):
 
         report_presentation = self.find_report_presentation(
             'contacts',
-            'csv')
+            'json_pass')
 
         resp = self.client.post(
             reverse('run_dynamic_report'),
@@ -662,11 +668,12 @@ class TestDynamicReports(MyReportsTestCase):
         resp = self.client.get(reverse('download_dynamic_report'),
                                {'id': report_id})
         self.assertEquals(200, resp.status_code)
-        lines = resp.content.splitlines()
-        self.assertEquals(2, len(lines))
-        first_found_name = lines[1].split(',')[0]
-        expected_name = 'name-2'
-        self.assertEqual(expected_name, first_found_name)
+        response_data = json.loads(resp.content)
+        self.assertEquals(1, len(response_data['records']))
+
+        found_name = response_data['records'][0]['name']
+        expected_name = u'name-2'
+        self.assertEqual(expected_name, found_name)
 
     def test_dynamic_partners_report_xlsx(self):
         """Run a report through the xlsx presentation type.

--- a/myreports/views.py
+++ b/myreports/views.py
@@ -618,10 +618,10 @@ def download_dynamic_report(request):
     presentation_driver = (
         report.report_presentation.presentation_type.presentation_type)
     presentation = presentation_drivers[presentation_driver]
-    response = HttpResponse(content_type=presentation.content_type())
+    response = HttpResponse(content_type=presentation.content_type)
     disposition = get_content_disposition(
         report.name,
-        presentation.filename_extension())
+        presentation.filename_extension)
     response['Content-Disposition'] = disposition
 
     output = StringIO()

--- a/myreports/views.py
+++ b/myreports/views.py
@@ -17,6 +17,8 @@ from myjobs.decorators import requires
 from myreports.models import (
     Report, ReportingType, ReportType, ReportPresentation, DynamicReport,
     DataType, ReportTypeDataTypes)
+from myreports.presentation import presentation_drivers
+from myreports.presentation.disposition import get_content_disposition
 from postajob import location_data
 from universal.helpers import get_company_or_404
 from universal.decorators import has_access
@@ -24,7 +26,6 @@ from universal.decorators import has_access
 from myreports.datasources import ds_json_drivers
 
 from cStringIO import StringIO
-import unicodecsv
 
 
 @requires('read partner', 'read contact', 'read communication record')
@@ -614,16 +615,17 @@ def download_dynamic_report(request):
     values = report_configuration.get_header()
     records = [report_configuration.format_record(r) for r in report.python]
 
-    response = HttpResponse(content_type='text/csv')
-    content_disposition = "attachment; filename=%s-%s.csv"
-    response['Content-Disposition'] = content_disposition % (
-        report.name.replace(' ', '_'), report.pk)
+    presentation_driver = (
+        report.report_presentation.presentation_type.presentation_type)
+    presentation = presentation_drivers[presentation_driver]
+    response = HttpResponse(content_type=presentation.content_type())
+    disposition = get_content_disposition(
+        report.name,
+        presentation.filename_extension())
+    response['Content-Disposition'] = disposition
 
     output = StringIO()
-    writer = unicodecsv.writer(output, encoding='utf-8')
-    writer.writerow(values)
-    for record in records:
-        writer.writerow([unicode(record[v]) for v in values])
+    presentation.write_presentation(values, records, output)
     response.write(output.getvalue())
 
     return response

--- a/requirements.txt
+++ b/requirements.txt
@@ -54,3 +54,4 @@ django-compressor==1.4
 Markdown==2.4
 xlrd==0.9.3
 Sphinx==1.3.3
+XlsxWriter==0.8.4


### PR DESCRIPTION
~~Guidance: see comments inline.~~ Thanks.

## Review Guide

Here are some starting points:

* `myreports/presentation/base.py` has documentation.
* Note the library being used to write Excel spreadsheets. `requirements.txt`
* Previously report names were unused by the API. This will be addressed in PD-1952. With this change the backend uses the name field and the UI sets a hard coded name. `WizardPageFilter.js`

