### PR TITLE
[PD-2122] Add a link to PRM in invitation email [hotfix]

### DIFF
--- a/myjobs/models.py
+++ b/myjobs/models.py
@@ -973,5 +973,13 @@ class Role(models.Model):
 @invitation_context.register(Role)
 def role_invitation_context(role):
     """Returns a message and the role."""
-    return {"message": " as a(n) %s for %s." % (role.name, role.company),
-            "role": role}
+
+    ctx = {"message": " as a(n) %s for %s." % (role.name, role.company),
+           "role": role}
+
+    if role.activities.filter(name="read partner").exists():
+        href = settings.ABSOLUTE_URL + "prm/view"
+        text = "Click here to access PRM"
+        ctx['link_text'] = '<p><a href="%s">%s</a></p>' % (href, text)
+
+    return ctx

--- a/templates/registration/invitation_email.html
+++ b/templates/registration/invitation_email.html
@@ -13,6 +13,9 @@
             {{ invitation.inviting_user.email }}
         {% endif %}
         of {{ invitation.inviting_company.name }} has invited you to join My.jobs{{ message }}
+
+        {{ link_text|safe }}
+
     </p>
 
     {% if group or company_user %}


### PR DESCRIPTION
This adds a link to the invitation email to PRM when a user gets sufficient privileges to at least click that link.

This email template that I worked so hard to remove  conditional logic from is starting to regress back to its original form, which makes me sad.