### PR TITLE
[PD-2135] Initial Invitations

### DIFF
--- a/myjobs/models.py
+++ b/myjobs/models.py
@@ -741,12 +741,6 @@ class User(AbstractBaseUser, PermissionsMixin):
         sent.
         """
 
-        can_invite = company.user_has_access(self) and self.can(
-            company, 'create user')
-
-        if not can_invite:
-            return None
-
         user, _ = User.objects.create_user(
             email=email, send_email=False, in_reserve=True)
         Invitation = get_model('registration', 'Invitation')

--- a/myjobs/tests/test_models.py
+++ b/myjobs/tests/test_models.py
@@ -258,11 +258,6 @@ class TestActivities(MyJobsBase):
         # sanity check
         self.assertTrue(self.user.can(self.company, 'create user'))
 
-        user = self.user.send_invite('regular@joe.com', self.company)
-        self.assertFalse(
-            user.can(self.company, 'create user'),
-            "User shouldn't be able to 'create user', but can")
-
         user = self.user.send_invite(
             'regular@joe.com', self.company, role_name=self.role.name)
         self.assertTrue(

--- a/myjobs/views.py
+++ b/myjobs/views.py
@@ -1139,8 +1139,9 @@ def api_create_user(request):
 
         # Send one invitation per new role. This will handle creating the user
         # if one doesn't exist.
-        for role in set(new_roles).difference(existing_roles):
-            request.user.send_invite(user_email, company, role.name)
+        if request.user.can(company, "create user"):
+            for role in set(new_roles).difference(existing_roles):
+                request.user.send_invite(user_email, company, role.name)
 
         return HttpResponse(json.dumps(ctx), content_type="application/json")
 
@@ -1242,8 +1243,9 @@ def api_edit_user(request, user_id=0):
                 user[0].roles.remove(currently_assigned_role.id)
 
         # Notify the user
-        for role in assigned_roles:
-            request.user.send_invite(user[0].email, company, role)
+        if request.user.can(company, "create user"):
+            for role in assigned_roles:
+                request.user.send_invite(user[0].email, company, role)
         # # RETURN - boolean
         ctx["success"] = "true"
         return HttpResponse(json.dumps(ctx), content_type="application/json")

--- a/seo/admin.py
+++ b/seo/admin.py
@@ -1178,6 +1178,13 @@ class CompanyAdmin(admin.ModelAdmin):
         ('PRM', {'fields': ['prm_saved_search_sites']}),
     ]
 
+    def save_model(self, request, instance, form, change):
+        invitee_email = form.cleaned_data.get('admin_email')
+        if invitee_email:
+            request.user.send_invite(invitee_email, instance, "Admin")
+
+        super(CompanyAdmin, self).save_model(request, instance, form, change)
+
 
 class SpecialCommitmentAdmin(admin.ModelAdmin):
     form = SpecialCommitmentForm

--- a/seo/admin.py
+++ b/seo/admin.py
@@ -1168,6 +1168,7 @@ class CompanyAdmin(admin.ModelAdmin):
         ('Basics', {'fields': [('name'), ('company_slug'), ('member'),
                                ('posting_access'), ('enhanced'),
                                ('digital_strategies_customer'),
+                               ('admin_email'),
                                ('app_access')]}),
         ('Company Info',{'fields':[('logo_url'),('linkedin_id'),
                                    ('canonical_microsite'),

--- a/seo/forms/admin_forms.py
+++ b/seo/forms/admin_forms.py
@@ -669,7 +669,8 @@ class CompanyForm(SeoSiteReverseForm):
                                                 my_model=BusinessUnit,
                                                 required=False,
                                                 widget=job_source_ids_widget)
-    admin_email = forms.fields.EmailField(label='Admin Email')
+    admin_email = forms.fields.EmailField(label='Admin Email',
+                                          required=False)
 
     class Meta:
         model = Company
@@ -678,12 +679,16 @@ class CompanyForm(SeoSiteReverseForm):
         super(CompanyForm, self).__init__(*args, **kwargs)
         instance = kwargs.get('instance')
         if instance and instance.first_invitation:
-            label = "Invitation was sent to %s on %s." % (
-                instance.first_invitation.invitee_email,
-                instance.first_invitation.invited)
-            self.fields['admin_email'] = forms.fields.EmailField(
-                initial=label, widget=forms.widgets.EmailInput())
-
+            text = "Invitation sent to %s." % (
+                instance.first_invitation.invitee_email)
+            self.fields['admin_email'].initial = text
+            self.fields['admin_email'].widget = forms.widgets.EmailInput(
+                attrs={"style": "border: 0; "
+                                "background: 'transparent'; "
+                                "width: 300px;",
+                       "readonly": True,
+                       "onfocus": "this.blur()"
+                       })
 
 
 class SpecialCommitmentForm(SeoSiteReverseForm):

--- a/seo/forms/admin_forms.py
+++ b/seo/forms/admin_forms.py
@@ -34,9 +34,9 @@ class MyModelMultipleChoiceField(forms.ModelMultipleChoiceField):
                  widget=None, label=None, initial=None,
                  help_text=None, *args, **kwargs):
         self.my_model = kwargs.pop('my_model', None)
-        super(forms.ModelMultipleChoiceField, self)\
-            .__init__(queryset, None, cache_choices, required, widget, label,
-                      initial, help_text, *args, **kwargs)
+        super(forms.ModelMultipleChoiceField, self).__init__(
+            queryset, None, cache_choices, required, widget, label, initial,
+            help_text, *args, **kwargs)
 
     def clean(self, value):
         if self.required and not value:
@@ -669,8 +669,21 @@ class CompanyForm(SeoSiteReverseForm):
                                                 my_model=BusinessUnit,
                                                 required=False,
                                                 widget=job_source_ids_widget)
+    admin_email = forms.fields.EmailField(label='Admin Email')
+
     class Meta:
         model = Company
+
+    def __init__(self, *args, **kwargs):
+        super(CompanyForm, self).__init__(*args, **kwargs)
+        instance = kwargs.get('instance')
+        if instance and instance.first_invitation:
+            label = "Invitation was sent to %s on %s." % (
+                instance.first_invitation.invitee_email,
+                instance.first_invitation.invited)
+            self.fields['admin_email'] = forms.fields.EmailField(
+                initial=label, widget=forms.widgets.EmailInput())
+
 
 
 class SpecialCommitmentForm(SeoSiteReverseForm):

--- a/seo/models.py
+++ b/seo/models.py
@@ -606,9 +606,6 @@ class Company(models.Model):
         ordering = ['name']
         unique_together = ('name', 'user_created')
 
-    def __init__(self, *args, **kwargs):
-        super(Company, self).__init__(*args, **kwargs)
-        self._first_invitation = self.invites_sent.order_by('-invited').first()
 
     def __unicode__(self):
         return self.name
@@ -773,7 +770,7 @@ class Company(models.Model):
         """
         # to prevent multiple queries, we set this up on instantiation instead
         # of running the query every time the information is asked for
-        return self._first_invitation
+        return self.invites_sent.order_by('-invited').first()
 
 
 class FeaturedCompany(models.Model):

--- a/seo/tests/test_models.py
+++ b/seo/tests/test_models.py
@@ -7,6 +7,7 @@ from seo.models import Company, CustomFacet, SeoSite, SiteTag
 from myjobs.tests.factories import AppAccessFactory
 from myjobs.tests.factories import RoleFactory
 from seo.tests.setup import DirectSEOBase
+from registration.models import Invitation
 
 
 class ModelsTestCase(DirectSEOBase):
@@ -368,4 +369,12 @@ class SeoSitePostAJobFiltersTestCase(DirectSEOBase):
 
         self.assertItemsEqual(self.company.enabled_access, ['Test Access'])
 
+    def test_first_invitation(self):
+        """
+        `Company.first_invitation` should return the first invitation created
+        for a company.
 
+        """
+        self.assertEqual(
+            self.company.first_invitation, Invitation.objects.filter(
+                inviting_company=self.company).order_by('-invited').first())


### PR DESCRIPTION
This PR adds an "Admin Email" widget to the company admin, which should only exist for companies who haven't invited anyone to be an Admin. 

Because of the way that invitations are laid out at the moment, there is no way to actually prove that the invitation being referred to was due to someone being invited as an Admin. However:
- saved searches cant be cdreated without PRM access
- PRM access can't be granted without role permissions
- Role permissions can only be granted by an admin

That's roughly the logic/assumption this is working on. If the above ever turns out not to be consistently the case, we'd need to add another field to a model somewhere to discern how various invitations are being created.

To test, just go to django admin, and click on a company. It should be the case that
- For a company who has never invited someone to be an admin, you should see "Admin User"
- For a company who has sent such an invitation, it should be made obvious to which email address that invitation was sent. 

Screenshots:
![2016-02-02-145717_794x366_scrot](https://cloud.githubusercontent.com/assets/93686/12762463/377aaa08-c9bd-11e5-997c-7de90cde6903.png)
![2016-02-02-145745_540x338_scrot](https://cloud.githubusercontent.com/assets/93686/12762467/3c66c704-c9bd-11e5-9c81-3a2e4984e8a6.png)

The original spec asked that the field be hidden entirely, but in doing so, a user then has no way to confirm to which email an invitation was sent without asking a developer to dig into the console.