### PR TITLE
Call correct _trackPageview method on secureMyJobs tracker [PD-2184]

### DIFF
--- a/templates/base-react.html
+++ b/templates/base-react.html
@@ -201,7 +201,7 @@
                   _gaq._createAsyncTracker('UA-16316580-6', 'secureMyJobs');
               });
               _gaq.push(['secureMyJobs._setDomainName','secure.my.jobs']);
-              _gaq.push(['secureMyJobs.trackPageView']);
+              _gaq.push(['secureMyJobs._trackPageview']);
 
               (function() {
                   var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;

--- a/templates/base.html
+++ b/templates/base.html
@@ -140,7 +140,7 @@
                 _gaq._createAsyncTracker('UA-16316580-6', 'secureMyJobs');
             });
             _gaq.push(['secureMyJobs._setDomainName','secure.my.jobs']);
-            _gaq.push(['secureMyJobs.trackPageView']);
+            _gaq.push(['secureMyJobs._trackPageview']);
 
             (function() {
                 var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;


### PR DESCRIPTION
This was never exactly right, but this line was probably failing harmlessly or after the secure.my.jobs-specific beacon was sent. Now, it looks like there are exceptions that keep that from happening, and GA is not tracking the secure.my.jobs beacon.

The next step should be moving from ga.js to analytics.js.