### PR TITLE
ST-2279 Expire Jobs Successfully.

### DIFF
--- a/default_settings.py
+++ b/default_settings.py
@@ -182,7 +182,10 @@ CELERY_ROUTES = {
         'queue': 'myjobs',
         'routing_key': 'myjobs.process_batch_events'
     },
-    'tasks.expire_jobs': {},
+    'tasks.expire_jobs': {
+        'queue': 'solr',
+        'routing_key': 'solr.expire_jobs'
+    },
     'tasks.update_solr_from_model': {
         'queue': 'myjobs',
         'routing_key': 'myjobs.expire_jobs'


### PR DESCRIPTION
We should actually route this task.  Otherwise, it goes into the ether, and is never run.