### PR TITLE
[PD-2167] Remove django_extensions 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,7 +74,6 @@ doc/build
 
 # Deployment
 static/admin/
-static/django_extensions
 static/endless_pagination
 static/fsm
 collected_static/

--- a/default_settings.py
+++ b/default_settings.py
@@ -298,7 +298,6 @@ INSTALLED_APPS = (
     'captcha',
     'endless_pagination',
     'storages',
-    'django_extensions',
     'haystack',
     'saved_search',
     'taggit',

--- a/myjobs/admin.py
+++ b/myjobs/admin.py
@@ -5,8 +5,6 @@ import pytz
 from django.contrib import admin
 from django.contrib.sites.models import Site
 
-from django_extensions.admin import ForeignKeyAutocompleteAdmin
-
 from myjobs.models import (User, CustomHomepage, EmailLog, FAQ,
                            Activity, CompanyAccessRequest)
 from myjobs.forms import (UserAdminForm,
@@ -78,7 +76,7 @@ class FAQAdmin(admin.ModelAdmin):
     search_fields = ['question', ]
 
 
-class CompanyAccessRequestApprovalAdmin(ForeignKeyAutocompleteAdmin):
+class CompanyAccessRequestApprovalAdmin(admin.ModelAdmin):
     """
     This admin page is used by staff to authorize access to a company.
 

--- a/mypartners/admin.py
+++ b/mypartners/admin.py
@@ -1,33 +1,13 @@
 from django.contrib import admin
 
-from django_extensions.admin import ForeignKeyAutocompleteAdmin
+from ajax_select.helpers import make_ajax_form
 
 from mypartners.models import (Partner, Contact, CommonEmailDomain,
                                OutreachEmailDomain, OutreachEmailAddress)
 
 
-def format_company_name(company):
-    """
-    Returns a string ot be used next to each company that displays how many
-    admins belong to that company, or a warning if there aren't any.
-
-    """
-    template = "{name} ({count} users){warning}"
-    count = company.company_user_count
-    warning = "" if count else " **Might be a duplicate**"
-
-    return template.format(name=company.name, count=count, warning=warning)
-
-
-class OutreachEmailDomainAdmin(ForeignKeyAutocompleteAdmin):
-    related_search_fields = {
-        'company': ('name',)
-    }
-
-    related_string_functions = {
-        'company': format_company_name
-    }
-
+class OutreachEmailDomainAdmin(admin.ModelAdmin):
+    form = make_ajax_form(OutreachEmailDomain, {'company': 'companies'})
     search_fields = ['company__name', 'domain']
 
     class Meta:

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,6 @@ coverage==3.5.3
 defusedxml==0.4.1
 django-celery==3.1.16
 django-debug-toolbar==1.2.1
-django-extensions==1.3.3
 django-haystack==2.1.0
 django-jenkins==0.15.0
 django-passwords==0.2.0

--- a/seo/admin.py
+++ b/seo/admin.py
@@ -19,8 +19,7 @@ from django.utils.html import escape
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext as _
 
-from django_extensions.admin import ForeignKeyAutocompleteAdmin
-from django_extensions.admin.widgets import ForeignKeySearchInput
+from ajax_select.helpers import make_ajax_form
 
 import djcelery.admin
 from celery import current_app
@@ -882,16 +881,7 @@ class SeoSiteFacetAdmin(admin.ModelAdmin):
         """
         return UnorderedChangeList
 
-def parent_site_string(parent_site):
-    return "%s (%s)" % (parent_site.name, parent_site.domain)
-
-class SeoSiteAdmin(ForeignKeyAutocompleteAdmin):
-    related_search_fields = {
-        'parent_site': ('domain','name' ),
-    }
-    related_string_functions = {
-        'seosite': parent_site_string,
-    }
+class SeoSiteAdmin(admin.ModelAdmin):
     form = SeoSiteForm
     save_on_top = True
     filter_horizontal = ('configurations', 'google_analytics',
@@ -911,9 +901,6 @@ class SeoSiteAdmin(ForeignKeyAutocompleteAdmin):
         ('Settings', {'fields': [('site_tags', 'special_commitments',
                                   'view_sources', )]}),
     ]
-
-    class Media:
-        js = ('django_extensions/js/jquery-1.7.2.min.js', )
 
     # Disable bulk delete on this model to prevent accidental catastrophe
     def get_actions(self, request):
@@ -986,13 +973,6 @@ class SeoSiteAdmin(ForeignKeyAutocompleteAdmin):
                 formset = FormSet(instance=self.model(), prefix=prefix,
                                   queryset=inline.queryset(request))
                 formsets.append(formset)
-        # overwrite for the "parent_site" form information...
-        # django-extensions does not allow for addition of the widget
-        # in the form declaration
-        form.fields['parent_site'].widget = ForeignKeySearchInput(
-            opts.get_field('parent_site').rel,['name','domain'])
-        form.fields['parent_site'].help_text=('Use the left field to do'
-            ' parent site lookups via domains or names')
         adminForm = helpers.AdminForm(form, list(self.get_fieldsets(request)),
             self.prepopulated_fields, self.get_readonly_fields(request),
             model_admin=self)
@@ -1093,13 +1073,6 @@ class SeoSiteAdmin(ForeignKeyAutocompleteAdmin):
                 formset = FormSet(instance=obj, prefix=prefix,
                                   queryset=inline.queryset(request))
                 formsets.append(formset)
-        # overwrite for the "parent_site" form information...
-        # django-extensions does not allow for addition of the widget
-        # in the form declaration
-        form.fields['parent_site'].widget = ForeignKeySearchInput(
-            opts.get_field('parent_site').rel,['name','domain'])
-        form.fields['parent_site'].help_text=('Use the left field to do'
-            ' parent site lookups via domains or names')
         adminForm = helpers.AdminForm(form, self.get_fieldsets(request, obj),
             self.prepopulated_fields, self.get_readonly_fields(request, obj),
             model_admin=self)
@@ -1225,7 +1198,7 @@ class ATSSourceCodeAdmin(admin.ModelAdmin):
     list_display = ('name', 'sites')
     search_fields = ['name', 'seosite__name', 'seosite__domain']
     fieldsets = [
-        ('Basics', {'fields': ['name','value','group','ats_name']}),
+        ('Basics', {'fields': ['name', 'value', 'group', 'ats_name']}),
         ('Sites', {'fields': ['sites']}),
     ]
 
@@ -1233,7 +1206,7 @@ class ATSSourceCodeAdmin(admin.ModelAdmin):
 class ViewSourceAdmin(admin.ModelAdmin):
     form = ViewSourceForm
     save_on_top = True
-    list_display = ('name', 'view_source' , 'sites')
+    list_display = ('name', 'view_source', 'sites')
     search_fields = ['name', 'view_source', 'seosite__name', 'seosite__domain']
     fieldsets = [
         ('Basics', {'fields': [('name', 'view_source')]}),
@@ -1253,17 +1226,12 @@ class MocParameterAdmin(admin.TabularInline):
     model = MocParameter
 
 
-class QueryRedirectAdmin(ForeignKeyAutocompleteAdmin):
+class QueryRedirectAdmin(admin.ModelAdmin):
+    form = make_ajax_form(QueryRedirect, {'site': 'sites'})
     inlines = [QParameterAdmin, LocationParameterAdmin, MocParameterAdmin]
     list_display = ('old_path', 'new_path')
     list_filter = ('site__domain',)
-    related_search_fields = {
-        'site': ('domain', )
-    }
     search_fields = ('old_path', 'new_path')
-
-    class Media:
-        js = ('django_extensions/js/jquery-1.7.2.min.js', )
 
 
 admin.site.register(CustomFacet, CustomFacetAdmin)

--- a/seo/forms/admin_forms.py
+++ b/seo/forms/admin_forms.py
@@ -1,6 +1,7 @@
 import os
 from fsm.widget import FSM
 from taggit.forms import TagField, TagWidget
+from ajax_select import helpers
 
 from django.conf import settings
 from django import forms
@@ -236,6 +237,9 @@ class SeoSiteForm(RowPermissionsForm):
                                required=False)
     domain = forms.CharField(max_length=255, label='Domain name',
                              validators=[])
+    parent_site = helpers.make_ajax_field(
+        SeoSite, 'parent_site', 'sites',
+        help_text='Find a parent site by domain or name.')
 
     def __init__(self, data=None, user=None, *args, **kwargs):
         # The 'user' kwarg is passed in from the 'change_view' and 'add_view'

--- a/seo/lookups.py
+++ b/seo/lookups.py
@@ -1,7 +1,5 @@
 from ajax_select import register, LookupChannel
-from seo.models import Company
-
-from mypartners.admin import format_company_name
+from seo import models
 
 @register('companies')
 class CompaniesLookup(LookupChannel):
@@ -12,6 +10,31 @@ class CompaniesLookup(LookupChannel):
         return self.model.objects.filter(name__icontains=q).order_by('name')
 
     def format_match(self, company):
-        """Determines how autocomplete options look in the drop-down."""
-        return format_company_name(company)
+        """
+        Returns a string ot be used next to each company that displays how many
+        admins belong to that company, or a warning if there aren't any.
+
+        """
+        template = "{name} ({count} users){warning}"
+        count = company.company_user_count
+        warning = "" if count else " **Might be a duplicate**"
+
+        return template.format(name=company.name, count=count, warning=warning)
+
+@register('sites')
+class SitesLookup(LookupChannel):
+    model = models.SeoSite
+    min_length = 3
+
+    def get_query(self, q, request):
+        """Match on name or domain."""
+
+        return self.model.objects.filter(
+            Q(domain__startswith=q) | Q(name__startswith=q))[:10]
+
+    # See https://github.com/crucialfelix/django-ajax-selects/issues/153 for
+    # why this is necessary. Inherited models don't act correctly, so we help
+    # the framework out by manually returning results.
+    def get_objects(self, ids):
+        return list(self.model.objects.filter(pk__in=ids))
 

--- a/seo/lookups.py
+++ b/seo/lookups.py
@@ -1,13 +1,15 @@
+from django.db.models import Q
 from ajax_select import register, LookupChannel
 from seo import models
 
 @register('companies')
 class CompaniesLookup(LookupChannel):
-    model = Company
+    model = models.Company
     min_length = 3
 
     def get_query(self, q, request):
-        return self.model.objects.filter(name__icontains=q).order_by('name')
+        return self.model.objects.filter(
+            name__startswith=q).order_by('name')[:10]
 
     def format_match(self, company):
         """
@@ -20,6 +22,7 @@ class CompaniesLookup(LookupChannel):
         warning = "" if count else " **Might be a duplicate**"
 
         return template.format(name=company.name, count=count, warning=warning)
+
 
 @register('sites')
 class SitesLookup(LookupChannel):

--- a/seo/lookups.py
+++ b/seo/lookups.py
@@ -9,7 +9,7 @@ class CompaniesLookup(LookupChannel):
 
     def get_query(self, q, request):
         return self.model.objects.filter(
-            name__startswith=q).order_by('name')[:10]
+            name__istartswith=q).order_by('name')[:10]
 
     def format_match(self, company):
         """
@@ -33,7 +33,7 @@ class SitesLookup(LookupChannel):
         """Match on name or domain."""
 
         return self.model.objects.filter(
-            Q(domain__startswith=q) | Q(name__startswith=q))[:10]
+            Q(domain__istartswith=q) | Q(name__istartswith=q))[:10]
 
     # See https://github.com/crucialfelix/django-ajax-selects/issues/153 for
     # why this is necessary. Inherited models don't act correctly, so we help

--- a/seo/models.py
+++ b/seo/models.py
@@ -561,6 +561,9 @@ class SeoSite(Site):
         site_buids = self.business_units.all()
         return Company.objects.filter(job_source_ids__in=site_buids).distinct()
 
+    def __unicode__(self):
+        return "{0} ({1})".format(self.name, self.domain)
+
 class SeoSiteFacet(models.Model):
     """This model defines the default Custom Facet(s) for a given site."""
     STANDARD = 'STD'


### PR DESCRIPTION
Same as the Last time I posted this a week ago, except that I've limited results to 10 and use istartswith instead of icontains.

See #2107 for more details.

Test by seeing that the forms which had `ForeignKeyAutoCompleteField`s do in fact still autocomplete.