### PR TITLE
[PD-2167] Re-introduce Django-Extensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,7 @@ doc/build
 
 # Deployment
 static/admin/
+static/django_extensions
 static/endless_pagination
 static/fsm
 collected_static/

--- a/default_settings.py
+++ b/default_settings.py
@@ -298,6 +298,7 @@ INSTALLED_APPS = (
     'captcha',
     'endless_pagination',
     'storages',
+    'django_extensions',
     'haystack',
     'saved_search',
     'taggit',

--- a/dseo_urls.py
+++ b/dseo_urls.py
@@ -9,6 +9,8 @@ from seo.views.settings_views import secure_redirect
 from registration import views as registration_views
 from ajax_select import urls as ajax_select_urls
 
+import seo.lookups
+
 # This is a bit of code pulled from a Django TRAC ticket describing a problem
 # I was seeing when working with the inline model forms:
 # https://code.djangoproject.com/ticket/10405#comment:11

--- a/myjobs/admin.py
+++ b/myjobs/admin.py
@@ -5,6 +5,8 @@ import pytz
 from django.contrib import admin
 from django.contrib.sites.models import Site
 
+from django_extensions.admin import ForeignKeyAutocompleteAdmin
+
 from myjobs.models import (User, CustomHomepage, EmailLog, FAQ,
                            Activity, CompanyAccessRequest)
 from myjobs.forms import (UserAdminForm,
@@ -76,7 +78,7 @@ class FAQAdmin(admin.ModelAdmin):
     search_fields = ['question', ]
 
 
-class CompanyAccessRequestApprovalAdmin(admin.ModelAdmin):
+class CompanyAccessRequestApprovalAdmin(ForeignKeyAutocompleteAdmin):
     """
     This admin page is used by staff to authorize access to a company.
 

--- a/myjobs/forms.py
+++ b/myjobs/forms.py
@@ -9,7 +9,6 @@ from ajax_select.fields import AutoCompleteSelectField
 
 from myjobs.models import User, CompanyAccessRequest, Role
 from myprofile.models import SecondaryEmail
-import seo.lookups
 from seo.models import Company
 
 

--- a/myjobs_urls.py
+++ b/myjobs_urls.py
@@ -10,6 +10,8 @@ from myjobs.api import UserResource, SavedSearchResource
 from seo.views.search_views import BusinessUnitAdminFilter, SeoSiteAdminFilter
 from ajax_select import urls as ajax_select_urls
 
+import seo.lookups
+
 admin.autodiscover()
 
 # API Resources

--- a/mypartners/admin.py
+++ b/mypartners/admin.py
@@ -1,13 +1,33 @@
 from django.contrib import admin
 
-from ajax_select.helpers import make_ajax_form
+from django_extensions.admin import ForeignKeyAutocompleteAdmin
 
 from mypartners.models import (Partner, Contact, CommonEmailDomain,
                                OutreachEmailDomain, OutreachEmailAddress)
 
 
-class OutreachEmailDomainAdmin(admin.ModelAdmin):
-    form = make_ajax_form(OutreachEmailDomain, {'company': 'companies'})
+def format_company_name(company):
+    """
+    Returns a string ot be used next to each company that displays how many
+    admins belong to that company, or a warning if there aren't any.
+
+    """
+    template = "{name} ({count} users){warning}"
+    count = company.company_user_count
+    warning = "" if count else " **Might be a duplicate**"
+
+    return template.format(name=company.name, count=count, warning=warning)
+
+
+class OutreachEmailDomainAdmin(ForeignKeyAutocompleteAdmin):
+    related_search_fields = {
+        'company': ('name',)
+    }
+
+    related_string_functions = {
+        'company': format_company_name
+    }
+
     search_fields = ['company__name', 'domain']
 
     class Meta:

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ coverage==3.5.3
 defusedxml==0.4.1
 django-celery==3.1.16
 django-debug-toolbar==1.2.1
+django-extensions==1.3.3
 django-haystack==2.1.0
 django-jenkins==0.15.0
 django-passwords==0.2.0

--- a/seo/admin.py
+++ b/seo/admin.py
@@ -19,7 +19,8 @@ from django.utils.html import escape
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext as _
 
-from ajax_select.helpers import make_ajax_form
+from django_extensions.admin import ForeignKeyAutocompleteAdmin
+from django_extensions.admin.widgets import ForeignKeySearchInput
 
 import djcelery.admin
 from celery import current_app
@@ -881,7 +882,11 @@ class SeoSiteFacetAdmin(admin.ModelAdmin):
         """
         return UnorderedChangeList
 
-class SeoSiteAdmin(admin.ModelAdmin):
+class SeoSiteAdmin(ForeignKeyAutocompleteAdmin):
+    related_search_fields = {
+        'parent_site': ('domain', 'name'),
+    }
+
     form = SeoSiteForm
     save_on_top = True
     filter_horizontal = ('configurations', 'google_analytics',
@@ -901,6 +906,9 @@ class SeoSiteAdmin(admin.ModelAdmin):
         ('Settings', {'fields': [('site_tags', 'special_commitments',
                                   'view_sources', )]}),
     ]
+
+    class Media:
+        js = ('django_extensions/js/jquery-1.7.2.min.js',)
 
     # Disable bulk delete on this model to prevent accidental catastrophe
     def get_actions(self, request):
@@ -973,6 +981,13 @@ class SeoSiteAdmin(admin.ModelAdmin):
                 formset = FormSet(instance=self.model(), prefix=prefix,
                                   queryset=inline.queryset(request))
                 formsets.append(formset)
+        # overwrite for the "parent_site" form information...
+        # django-extensions does not allow for addition of the widget
+        # in the form declaration
+        form.fields['parent_site'].widget = ForeignKeySearchInput(
+            opts.get_field('parent_site').rel,['name','domain'])
+        form.fields['parent_site'].help_text=('Use the left field to do'
+            ' parent site lookups via domains or names')
         adminForm = helpers.AdminForm(form, list(self.get_fieldsets(request)),
             self.prepopulated_fields, self.get_readonly_fields(request),
             model_admin=self)
@@ -1073,6 +1088,13 @@ class SeoSiteAdmin(admin.ModelAdmin):
                 formset = FormSet(instance=obj, prefix=prefix,
                                   queryset=inline.queryset(request))
                 formsets.append(formset)
+        # overwrite for the "parent_site" form information...
+        # django-extensions does not allow for addition of the widget
+        # in the form declaration
+        form.fields['parent_site'].widget = ForeignKeySearchInput(
+            opts.get_field('parent_site').rel,['name','domain'])
+        form.fields['parent_site'].help_text=('Use the left field to do'
+            ' parent site lookups via domains or names')
         adminForm = helpers.AdminForm(form, self.get_fieldsets(request, obj),
             self.prepopulated_fields, self.get_readonly_fields(request, obj),
             model_admin=self)
@@ -1226,12 +1248,17 @@ class MocParameterAdmin(admin.TabularInline):
     model = MocParameter
 
 
-class QueryRedirectAdmin(admin.ModelAdmin):
-    form = make_ajax_form(QueryRedirect, {'site': 'sites'})
+class QueryRedirectAdmin(ForeignKeyAutocompleteAdmin):
     inlines = [QParameterAdmin, LocationParameterAdmin, MocParameterAdmin]
     list_display = ('old_path', 'new_path')
     list_filter = ('site__domain',)
     search_fields = ('old_path', 'new_path')
+    related_search_fields = {
+        'site': ('domain', )
+    }
+
+    class Media:
+        js = ('django_extensions/js/jquery-1.7.2.min.js',)
 
 
 admin.site.register(CustomFacet, CustomFacetAdmin)

--- a/seo/forms/admin_forms.py
+++ b/seo/forms/admin_forms.py
@@ -1,7 +1,6 @@
 import os
 from fsm.widget import FSM
 from taggit.forms import TagField, TagWidget
-from ajax_select import helpers
 
 from django.conf import settings
 from django import forms
@@ -237,9 +236,6 @@ class SeoSiteForm(RowPermissionsForm):
                                required=False)
     domain = forms.CharField(max_length=255, label='Domain name',
                              validators=[])
-    parent_site = helpers.make_ajax_field(
-        SeoSite, 'parent_site', 'sites',
-        help_text='Find a parent site by domain or name.')
 
     def __init__(self, data=None, user=None, *args, **kwargs):
         # The 'user' kwarg is passed in from the 'change_view' and 'add_view'

--- a/seo/lookups.py
+++ b/seo/lookups.py
@@ -22,26 +22,3 @@ class CompaniesLookup(LookupChannel):
         warning = "" if count else " **Might be a duplicate**"
 
         return template.format(name=company.name, count=count, warning=warning)
-
-
-@register('sites')
-class SitesLookup(LookupChannel):
-    model = models.SeoSite
-    min_length = 3
-    plugin_options = {
-        'autoFocus': True,
-        'delay': 0
-    }
-
-    def get_query(self, q, request):
-        """Match on name or domain."""
-
-        return self.model.objects.filter(
-            Q(domain__istartswith=q) | Q(name__istartswith=q))[:10]
-
-    # See https://github.com/crucialfelix/django-ajax-selects/issues/153 for
-    # why this is necessary. Inherited models don't act correctly, so we help
-    # the framework out by manually returning results.
-    def get_objects(self, ids):
-        return list(self.model.objects.filter(pk__in=ids))
-

--- a/seo/lookups.py
+++ b/seo/lookups.py
@@ -28,6 +28,10 @@ class CompaniesLookup(LookupChannel):
 class SitesLookup(LookupChannel):
     model = models.SeoSite
     min_length = 3
+    plugin_options = {
+        'autoFocus': True,
+        'delay': 0
+    }
 
     def get_query(self, q, request):
         """Match on name or domain."""


### PR DESCRIPTION
The widgets in django_extensions and django-ajax-selects are different enough that replacing one with the other was disruptive to staff's work flow. Once this is reverted, I'm closing the ticket as wontfix.