### PR TITLE
Fixed validation error. Custom Django admin things are fun...

### DIFF
--- a/seo/admin.py
+++ b/seo/admin.py
@@ -7,7 +7,7 @@ from django.contrib.admin.views.main import ChangeList
 from django.contrib.auth.models import Group
 from django.contrib.sites.models import Site
 from django.contrib import messages
-from django.core.exceptions import PermissionDenied
+from django.core.exceptions import PermissionDenied, ValidationError
 from django.core.cache import cache
 from django.db import models, transaction
 from django.forms.formsets import all_valid
@@ -1153,8 +1153,14 @@ class CompanyAdmin(admin.ModelAdmin):
 
     def save_model(self, request, instance, form, change):
         invitee_email = form.cleaned_data.get('admin_email')
-        if not invitee_email.startswith("Invitation sent to"):
+
+        try:
             request.user.send_invite(invitee_email, instance, "Admin")
+        except ValidationError:
+            """
+            We already sent an invitation. Actual email validation fails
+            sooner.
+            """
 
         super(CompanyAdmin, self).save_model(request, instance, form, change)
 


### PR DESCRIPTION
Basically:
- when you don't assign an admin (in django admin's company admin) the save_model method will get a blank string, which wouldn't normally be valid. In this particular case it is.
- when you do assign an admin, it's a valid email address, so things work as usual
- when you edit a company after having edited it the first time, you shouldn't be able to change it, and instead are greeted with a message explaining that you sent an invitation already-- such a message isn't a valid email address, so would normally fail validation -- not so here

And for the curious, it was deemed by powers above my pay grade that simply disabling the field wouldn't work. Hiding the field isn't possible because it resides in a row which would display regardless unless we did some client-side magic. In any case, not displaying anything would inform staff that an invitation has already been sent, but not to who. Eg, did I send that to foo@bar.com or fooo@bar.com?