### PR TITLE
[PD-1952]  Restore Report Naming

### DIFF
--- a/gulp/npm-shrinkwrap.json
+++ b/gulp/npm-shrinkwrap.json
@@ -37,6 +37,11 @@
       "from": "lodash-compat@~3.10.1",
       "resolved": "https://registry.npmjs.org/lodash-compat/-/lodash-compat-3.10.1.tgz"
     },
+    "moment": {
+      "version": "2.11.2",
+      "from": "moment@",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.11.2.tgz"
+    },
     "react-dom": {
       "version": "0.14.3",
       "from": "react-dom@^0.14.0",

--- a/gulp/package.json
+++ b/gulp/package.json
@@ -37,6 +37,7 @@
     "tinycolor2": "~1.3.0",
     "warning": "^2.1.0",
     "webpack": "^1.12.9",
-    "lodash-compat": "~3.10.1"
+    "lodash-compat": "~3.10.1",
+    "moment": "~2.11.2"
   }
 }

--- a/gulp/src/common/ui/ValidatedInput.jsx
+++ b/gulp/src/common/ui/ValidatedInput.jsx
@@ -51,8 +51,25 @@ export class ValidatedInput extends Component {
 }
 
 ValidatedInput.propTypes = {
+  /**
+   * This contains a controlled input. Value in the box goes here.
+   */
   value: PropTypes.string.isRequired,
+
+  /**
+   * Function to call with input change values.
+   */
   onValueChange: PropTypes.func.isRequired,
-  helpText: PropTypes.string.isRequired,
+
+  /**
+   * Help text to show alongside the input control.
+   */
+  helpText: PropTypes.string,
+
+  /**
+   * Array of strings to show as errors alongside the input control.
+   *
+   * If this prop is missing or empty the control will display as valid.
+   */
   errorTexts: PropTypes.array,
 };

--- a/gulp/src/common/ui/ValidatedInput.jsx
+++ b/gulp/src/common/ui/ValidatedInput.jsx
@@ -1,0 +1,58 @@
+import React, {PropTypes, Component} from 'react';
+import classnames from 'classnames';
+import {map} from 'lodash-compat/collection';
+
+
+/**
+ * Input field which shows help text and errors.
+ */
+export class ValidatedInput extends Component {
+  renderError(errorText, key) {
+    return <span key={key} className="error-text">{errorText}</span>;
+  }
+
+  renderErrors() {
+    const {errorTexts} = this.props;
+    if (!errorTexts) {
+      return '';
+    }
+
+    if (errorTexts.length === 1) {
+      return <div>{this.renderError(errorTexts[0])}</div>;
+    }
+
+    const errors = map(errorTexts, (errorText, i) =>
+        <li>{this.renderError(errorText, i)}</li>);
+
+    return <div><ul>{errors}</ul></div>;
+  }
+
+  render() {
+    const {value, helpText, errorTexts, onValueChange} = this.props;
+
+    const hasHelp = Boolean(helpText);
+    const hasErrors = Boolean(errorTexts);
+
+    const inputClasses = classnames({'errorInput': hasErrors});
+
+    return (
+      <div>
+        <input
+          type="text"
+          value={value}
+          className={inputClasses}
+          onChange={e => onValueChange(e.target.value)}/>
+        {hasHelp && !hasErrors ?
+          <div><span className="formHelp">{helpText}</span></div> : ''}
+        {this.renderErrors()}
+      </div>
+    );
+  }
+}
+
+ValidatedInput.propTypes = {
+  value: PropTypes.string.isRequired,
+  onValueChange: PropTypes.func.isRequired,
+  helpText: PropTypes.string.isRequired,
+  errorTexts: PropTypes.array,
+};

--- a/gulp/src/reporting/ReportList.js
+++ b/gulp/src/reporting/ReportList.js
@@ -3,11 +3,12 @@ import React, {PropTypes} from 'react';
 export function ReportList(props) {
   const reportData = props.reports.map(report => ({
     id: report.id,
+    name: report.name,
     href: '/reports/view/dynamicdownload?id=' + report.id,
   }));
   const reportLinks = reportData.map(r =>
     <li key={r.id}>
-      <a href={r.href}>Report id: {r.id}</a>
+      <a href={r.href}>{r.name}</a>
     </li>
   );
 

--- a/gulp/src/reporting/reportEngine.js
+++ b/gulp/src/reporting/reportEngine.js
@@ -1,5 +1,11 @@
+import moment from 'moment';
+
 // This is the business logic of the myreports client.
 
+
+export function defaultReportName(date) {
+  return moment(date).format('YYYY-MM-DD hh:mm:ss.SSS');
+}
 
 // Root of the client.
 //
@@ -75,7 +81,8 @@ export class ReportFinder {
 // Future: consider restructuring this class so that it's methods which mutate
 // state operate on and return a new react state object.
 export class ReportConfiguration {
-  constructor(rpId, filters, api, newReportNote) {
+  constructor(name, rpId, filters, api, newReportNote) {
+    this.name = name;
     this.rpId = rpId;
     this.filters = filters;
     this.simpleFilter = {};
@@ -161,8 +168,19 @@ export class ReportConfiguration {
     return this.andOrFilter[key];
   }
 
-  async run(name) {
-    const reportId = await this.api.runReport(this.rpId, name, this.getFilter());
+  changeReportName(name) {
+    this.name = name;
+  }
+
+  getReportName() {
+    return this.name;
+  }
+
+  async run() {
+    const reportId = await this.api.runReport(
+        this.rpId,
+        this.name,
+        this.getFilter());
     this.newReportNote(reportId);
     return reportId;
   }
@@ -177,6 +195,7 @@ export class ReportConfigurationBuilder {
   }
 
   async build(rpId, filters, cb) {
-    return new ReportConfiguration(rpId, filters, this.api, cb);
+    const name = defaultReportName(new Date());
+    return new ReportConfiguration(name, rpId, filters, this.api, cb);
   }
 }

--- a/gulp/src/reporting/reportEngine.js
+++ b/gulp/src/reporting/reportEngine.js
@@ -176,6 +176,13 @@ export class ReportConfiguration {
     return this.name;
   }
 
+  getReportNameError() {
+    if (!this.name) {
+      return 'Report name cannot be empty.';
+    }
+    return null;
+  }
+
   async run() {
     const reportId = await this.api.runReport(
         this.rpId,

--- a/gulp/src/reporting/spec/reportEngineSpec.js
+++ b/gulp/src/reporting/spec/reportEngineSpec.js
@@ -1,4 +1,8 @@
-import {ReportFinder, ReportConfiguration} from '../reportEngine';
+import {
+  ReportFinder,
+  ReportConfiguration,
+  defaultReportName,
+} from '../reportEngine';
 
 import {promiseTest} from '../../util/spec';
 
@@ -62,7 +66,7 @@ describe('ReportConfiguration', () => {
   beforeEach(() => {
     fakeComponent = new FakeComponent();
     config = new ReportConfiguration(
-      2, {}, fakeApi,
+      'defaultName', 2, {}, fakeApi,
       id => fakeComponent.newReportNote(id));
   });
 
@@ -158,8 +162,26 @@ describe('ReportConfiguration', () => {
 
     const result = await config.run();
 
-    expect(fakeApi.runReport).toHaveBeenCalled();
+    expect(fakeApi.runReport).toHaveBeenCalledWith(2, 'defaultName', {});
     expect(result).toEqual(7);
     expect(fakeComponent.newReportNote).toHaveBeenCalled();
   }));
+
+  it('can change the name of the report', promiseTest(async() => {
+    spyOn(fakeApi, 'runReport').and.callThrough();
+    spyOn(fakeComponent, 'newReportNote').and.callThrough();
+
+    config.changeReportName('bbb');
+    const result = await config.run();
+
+    expect(fakeApi.runReport).toHaveBeenCalledWith(2, 'bbb', {});
+    expect(result).toEqual(7);
+  }));
+});
+
+describe('defaultReportName', () => {
+  it('can come up with a name from a date', () => {
+    const name = defaultReportName(new Date(2015, 0, 2, 10, 9, 8, 7));
+    expect(name).toEqual('2015-01-02 10:09:08.007');
+  });
 });

--- a/gulp/src/reporting/spec/reportEngineSpec.js
+++ b/gulp/src/reporting/spec/reportEngineSpec.js
@@ -177,6 +177,11 @@ describe('ReportConfiguration', () => {
     expect(fakeApi.runReport).toHaveBeenCalledWith(2, 'bbb', {});
     expect(result).toEqual(7);
   }));
+
+  it('warns about invalid report names', promiseTest(async() => {
+    config.changeReportName('');
+    expect(config.getReportNameError()).toContain('empty');
+  }));
 });
 
 describe('defaultReportName', () => {

--- a/gulp/src/reporting/wizard/WizardPageFilter.js
+++ b/gulp/src/reporting/wizard/WizardPageFilter.js
@@ -14,7 +14,7 @@ export class WizardPageFilter extends Component {
   constructor() {
     super();
     this.state = {
-      reportName: 'Report Name',
+      reportName: '',
       loading: true,
     };
   }
@@ -72,10 +72,17 @@ export class WizardPageFilter extends Component {
     this.updateState();
   }
 
+  changeReportName(name) {
+    const {reportConfig} = this.state;
+    reportConfig.changeReportName(name);
+    this.updateState();
+  }
+
   updateState() {
     const {reportConfig} = this.state;
     this.setState({
       filter: reportConfig.getFilter(),
+      reportName: reportConfig.getReportName(),
     });
   }
 
@@ -100,6 +107,12 @@ export class WizardPageFilter extends Component {
     }
 
     const rows = [];
+    rows.push(this.renderRow('Report Name', 'reportName',
+      <input
+        type="text"
+        value={reportName}
+        onChange={(e) => this.changeReportName(e.target.value)}/>
+    ));
     reportConfig.filters.forEach(col => {
       switch (col.interface_type) {
       case 'date_range':

--- a/gulp/src/reporting/wizard/WizardPageFilter.js
+++ b/gulp/src/reporting/wizard/WizardPageFilter.js
@@ -9,6 +9,7 @@ import {WizardFilterTags} from './WizardFilterTags';
 import {WizardFilterCollectedItems} from './WizardFilterCollectedItems';
 import {WizardFilterCityState} from './WizardFilterCityState';
 import {SearchInput} from 'common/ui/SearchInput';
+import {ValidatedInput} from 'common/ui/ValidatedInput';
 
 export class WizardPageFilter extends Component {
   constructor() {
@@ -83,6 +84,7 @@ export class WizardPageFilter extends Component {
     this.setState({
       filter: reportConfig.getFilter(),
       reportName: reportConfig.getReportName(),
+      reportNameError: reportConfig.getReportNameError(),
     });
   }
 
@@ -100,18 +102,20 @@ export class WizardPageFilter extends Component {
   }
 
   render() {
-    const {loading, reportConfig, reportName} = this.state;
+    const {loading, reportConfig, reportName, reportNameError} = this.state;
 
     if (loading) {
       return <Loading/>;
     }
 
     const rows = [];
+    const errorTexts = reportNameError ? [reportNameError] : null;
     rows.push(this.renderRow('Report Name', 'reportName',
-      <input
-        type="text"
+      <ValidatedInput
         value={reportName}
-        onChange={(e) => this.changeReportName(e.target.value)}/>
+        helpText="Name will appear in downloaded filenames."
+        errorTexts={errorTexts}
+        onValueChange={v => this.changeReportName(v)}/>
     ));
     reportConfig.filters.forEach(col => {
       switch (col.interface_type) {


### PR DESCRIPTION
## Test

* Go to `/reports/views/dynamicoverview`
* Create a report. On the filter screen you can name the report.
* The default should be a timestamp in the same format as the production reporting system.
* If you leave the field blank you get an error.

## Note
* There is _no_ server side validation. This will be addressed in [PR-2193](https://directemployersfoundation.atlassian.net/browse/PD-2193).