### PR TITLE
Removal of test prefix trim

### DIFF
--- a/myjobs/cross_site_verify.py
+++ b/myjobs/cross_site_verify.py
@@ -19,19 +19,7 @@ def extract_hostname(url):
     if url is None:
         return None
     else:
-        return remove_test_prefix(urlparse(url).hostname)
-
-
-def remove_test_prefix(url):
-    """
-    Removes test prefix (qc, staging) from incoming requests, if it exists.
-    :param url:
-    :return: url without qc, staging prefixes
-    """
-    if not url:
-        return url
-    url_split = url.split('.', 1)
-    return url_split[1] if url_split[0] in settings.ENV_URL_PREFIXES else url
+        return urlparse(url).hostname
 
 
 def parse_request_meta(meta):


### PR DESCRIPTION
In my most recent PR, I attempted to remove specific handling for QC/Staging from the secure blocks logic.

Well.. I missed a spot.

This is the removal of the -REST- of the logic.