### PR TITLE
[PD-2209] Allow use of confirm, and alert etc.

### DIFF
--- a/gulp/gulpfile.js
+++ b/gulp/gulpfile.js
@@ -186,6 +186,8 @@ function lintOptions() {
     rules: {
       "babel/object-curly-spacing": 1,
       "babel/no-await-in-loop": 2,
+      // this allows use of confirm, which is currently acceptable
+      "no-alert": 0,
     },
   };
 }


### PR DESCRIPTION
We've been looking at a warning about the use of JS confirm for weeks. Since the code is shipping I'm removing the warning.