### PR TITLE
Remove roles enabled

### DIFF
--- a/default_settings.py
+++ b/default_settings.py
@@ -9,8 +9,6 @@ from os.path import abspath, dirname, basename, join
 
 from secrets import *
 
-ROLES_ENABLED = True
-
 djcelery.setup_loader()
 
 _PATH = PROJECT_PATH = os.path.abspath(os.path.dirname(__file__))

--- a/deploy/settings.jenkins-single-test.py
+++ b/deploy/settings.jenkins-single-test.py
@@ -2,7 +2,6 @@ from default_settings import *
 from secrets import REDIRECT_QC
 
 DEBUG = True
-ROLES_ENABLED = False
 
 ABSOLUTE_URL = "/"
 

--- a/deploy/settings.jenkins.py
+++ b/deploy/settings.jenkins.py
@@ -1,7 +1,6 @@
 from default_settings import *
 
 DEBUG = True
-ROLES_ENABLED = False
 
 ABSOLUTE_URL = "/"
 

--- a/deploy/settings.myjobs_qc.py
+++ b/deploy/settings.myjobs_qc.py
@@ -6,7 +6,6 @@ import os
 from secrets import REDIRECT_QC, REDIRECT_STAGING, ARCHIVE_STAGING
 
 DEBUG = True
-ROLES_ENABLED = True
 
 COMPRESS_ENABLED = True
 COMPRESS_OFFLINE_MANIFEST = 'manifest.json'

--- a/doc/source/faq.rst
+++ b/doc/source/faq.rst
@@ -34,11 +34,9 @@ User Management
     ``User Management`` option found under ``Employer`` in the topbar.
 
   Why don't I see "User Management" in the topbar?
-    First, roles should be enabled by adding ``ROLES_ENABLED = True`` in your
-    Django settings file. Second, the company for which you'd like to manage
-    users should have "User Management" app-level access. Finally, the user
-    attempting to manage users should be assigned a role which has the "read
-    role" activity.
+    First, the company for which you'd like to manage users should have "User
+    Management" app-level access. Then, the user attempting to manage users
+    should be assigned a role which has the "read role" activity.
 
   How do I add app-level access?
     If you navigate to "Companies" in the Django admin (under "Common Tasks")

--- a/mydashboard/views.py
+++ b/mydashboard/views.py
@@ -75,13 +75,9 @@ def dashboard(request, template="mydashboard/mydashboard.html",
 
     authorized_microsites, buids = get_company_microsites(company)
 
-    # roles are only enabled during development
-    if settings.ROLES_ENABLED:
-        admins = User.objects.filter(roles__company=company)
-    else:
-        admins = User.objects.filter(company=company)
+    admins = User.objects.filter(roles__company=company).exclude(
+        pk=request.user.pk)
 
-    admins = admins.exclude(pk=request.user.pk)
     requested_microsite = request.REQUEST.get('microsite', '')
     requested_date_button = request.REQUEST.get('date_button', False)
     candidates_page = request.REQUEST.get('page', 1)

--- a/myemails/models.py
+++ b/myemails/models.py
@@ -143,13 +143,8 @@ class Event(models.Model):
         if not subject:
             subject = 'An update on your %s' % self.model.name
 
-        if settings.ROLES_ENABLED:
-            recipients = Role.objects.filter(
-                company=recipient_company).values_list(
-                    'user__email', flat=True)
-        else:
-            recipients = User.objects.filter(
-                company=recipient_company).values_list('email', flat=True)
+        recipients = Role.objects.filter(
+            company=recipient_company).values_list( 'user__email', flat=True)
 
         if hasattr(sending_company, 'companyprofile'):
             email_domain = sending_company.companyprofile.outgoing_email_domain

--- a/myjobs/decorators.py
+++ b/myjobs/decorators.py
@@ -209,12 +209,6 @@ def requires(*activities, **callbacks):
     def decorator(view_func):
         @wraps(view_func)
         def wrap(request, *args, **kwargs):
-            # TODO: Remove this logic once feature is rolled out. for the
-            #      moment, we only want this decorator factory to work in QC
-            #      and Staging.
-            if not settings.ROLES_ENABLED:
-                return view_func(request, *args, **kwargs)
-
             company = get_company_or_404(request)
 
             # the app_access we need, determined by the activities passed in

--- a/myjobs/models.py
+++ b/myjobs/models.py
@@ -224,7 +224,7 @@ class CustomUserManager(BaseUserManager):
         Outputs:
         :is_member: Boolean representing the user's membership status
         """
-        return user.roles.exists()
+        return not user.is_anonymous() and user.roles.exists()
 
 
 # New in Django 1.5. This is now the default auth user table.

--- a/myjobs/templatetags/common_tags.py
+++ b/myjobs/templatetags/common_tags.py
@@ -76,14 +76,7 @@ def is_a_group_member(company, user, group):
     requested group
     """
 
-    if settings.ROLES_ENABLED:
-        # deleted users don't have a PK
-        return user.pk and user.roles.exists()
-    else:
-        try:
-            return User.objects.is_group_member(user, group)
-        except ValueError:
-            return False
+    return user.pk and user.roles.exists()
 
 
 @register.assignment_tag
@@ -99,13 +92,7 @@ def get_company_name(user):
     """
 
     # Only return companies for which the user is a company user
-    if settings.ROLES_ENABLED:
-        return Company.objects.filter(role__user=user).distinct()
-    else:
-        try:
-            return user.company_set.all()
-        except ValueError:
-            return Company.objects.none()
+    return Company.objects.filter(role__user=user).distinct()
 
 
 @register.simple_tag(takes_context=True)

--- a/myjobs/tests/setup.py
+++ b/myjobs/tests/setup.py
@@ -99,7 +99,6 @@ class TestClient(Client):
 class MyJobsBase(TestCase):
     def setUp(self):
         settings.ROOT_URLCONF = "myjobs_urls"
-        settings.ROLES_ENABLED = True
         settings.PROJECT = "myjobs"
 
         self.app_access = AppAccessFactory()

--- a/myjobs/tests/test_models.py
+++ b/myjobs/tests/test_models.py
@@ -241,15 +241,13 @@ class TestActivities(MyJobsBase):
         # check for a single activity
         self.assertTrue(user.can(self.company, activities[0]))
 
-        with self.settings(ROLES_ENABLED=True):
-            self.assertFalse(user.can(self.company, "eat a burrito"))
+        self.assertFalse(user.can(self.company, "eat a burrito"))
 
         # check for multiple activities
         self.assertTrue(user.can(self.company, *activities))
 
-        with self.settings(ROLES_ENABLED=True):
-            self.assertFalse(user.can(
-                self.company, activities[0], "eat a burrito"))
+        self.assertFalse(user.can(
+            self.company, activities[0], "eat a burrito"))
 
     def test_send_invite_method(self):
         """

--- a/mypartners/tests/test_api.py
+++ b/mypartners/tests/test_api.py
@@ -48,8 +48,8 @@ class NonUserOutreachTestCase(MyPartnersTestCase):
 
     def test_user_requires_prm_access(self):
         """
-            Verify that the has_access("prm") decorator works properly with this module when
-            ROLES_ENABLED is set to false
+        Verify that the has_access("prm") decorator works properly.
+
         """
         response = self.client.get(reverse('api_get_nuo_inbox_list'))
         self.assertEqual(response.status_code, 200, msg="assert view loaded properly for prm access user")

--- a/mypartners/views.py
+++ b/mypartners/views.py
@@ -1231,12 +1231,8 @@ def process_email(request):
         return HttpResponse(status=200)
 
     # determine if the user is associated with more thanone company
-    multiple_companies = False
-    if settings.ROLES_ENABLED:
-        multiple_companies = admin_user.roles.values(
-            "company").distinct().count() > 1
-    else:
-        multiple_companies = admin_user.company_set.count() > 1
+    multiple_companies = admin_user.roles.values(
+        "company").distinct().count() > 1
 
     if multiple_companies:
         error = "Your account is setup as the admin for multiple companies. " \
@@ -1248,10 +1244,8 @@ def process_email(request):
                                            error, admin_email)
         return HttpResponse(status=200)
 
-    if settings.ROLES_ENABLED and admin_user.roles.exists():
+    if admin_user.roles.exists():
         partners = admin_user.roles.first().company.partner_set.all()
-    elif admiN_user.company_set.exists():
-        partners = admin_user.company_set.first().partner_set.all()
     else:
         partners = []
 

--- a/seo/models.py
+++ b/seo/models.py
@@ -724,10 +724,8 @@ class Company(models.Model):
         Read-only property that returns whether or not a company has access
         to PRM features.
         """
-        if settings.ROLES_ENABLED:
-            return "PRM" in self.app_access.values_list("name", flat=True)
-        else:
-            return self.member
+
+        return "PRM" in self.app_access.values_list("name", flat=True)
 
 
     def user_has_access(self, user):
@@ -735,10 +733,7 @@ class Company(models.Model):
         Returns whether or not the given user can be tied back to the company.
         """
 
-        if settings.ROLES_ENABLED:
-            return user.pk in self.role_set.values_list('user', flat=True)
-        else:
-            return user in self.admins.all()
+        return user.pk in self.role_set.values_list('user', flat=True)
 
     @property
     def has_packages(self):

--- a/seo/tests/test_models.py
+++ b/seo/tests/test_models.py
@@ -155,39 +155,24 @@ class TestRoles(DirectSEOBase):
         the companies associated with an seo site's business units.
         """
 
-        with self.settings(ROLES_ENABLED=False):
-            # no company user, so shouldn't have access
-            self.assertFalse(self.site.user_has_access(self.user))
+        # user not assigned a role in company, so shouldn't have access
+        self.assertFalse(self.site.user_has_access(self.user))
 
-            factories.CompanyUserFactory(company=self.company, user=self.user)
-            self.assertTrue(self.site.user_has_access(self.user))
-
-        with self.settings(ROLES_ENABLED=True):
-            # user not assigned a role in company, so shouldn't have access
-            self.assertFalse(self.site.user_has_access(self.user))
-
-            role = RoleFactory(company=self.company)
-            self.user.roles.add(role)
-            self.assertTrue(self.site.user_has_access(self.user))
+        role = RoleFactory(company=self.company)
+        self.user.roles.add(role)
+        self.assertTrue(self.site.user_has_access(self.user))
 
     def test_company_user_has_access(self):
         """
         Test that a user has access if the user can be tied to a company.
         """
 
-        with self.settings(ROLES_ENABLED=False):
-            self.assertFalse(self.company.user_has_access(self.user))
+        # user not assigned a role in company, so shouldn't have access
+        self.assertFalse(self.company.user_has_access(self.user))
 
-            factories.CompanyUserFactory(company=self.company, user=self.user)
-            self.assertTrue(self.company.user_has_access(self.user))
-
-        with self.settings(ROLES_ENABLED=True):
-            # user not assigned a role in company, so shouldn't have access
-            self.assertFalse(self.company.user_has_access(self.user))
-
-            role = RoleFactory(company=self.company)
-            self.user.roles.add(role)
-            self.assertTrue(self.company.user_has_access(self.user))
+        role = RoleFactory(company=self.company)
+        self.user.roles.add(role)
+        self.assertTrue(self.company.user_has_access(self.user))
 
     def test_company_user_count(self):
         """

--- a/universal/decorators.py
+++ b/universal/decorators.py
@@ -103,9 +103,7 @@ def warn_when(condition, feature, message, link=None, link_text=None,
     def decorator(view_func):
         @wraps(view_func)
         def wrap(request, *args, **kwargs):
-            # this decorator factory only works if called with enabled=True or
-            # settings.ROLES_ENABLED is False
-            if not enabled and settings.ROLES_ENABLED:
+            if not enabled:
                 return view_func(request, *args, **kwargs)
 
             if request.user.is_anonymous() and redirect:


### PR DESCRIPTION
This ticket gets rid of the need to constantly check for "ROLES_ENABLED". It only looks this big because I kept it in sync with my other work which removes the need for CompanyUser in postajob.

[Here's the real difference](https://github.com/DirectEmployers/MyJobs/compare/pd-2116...remove-roles-enabled?expand=1)

I also went ahead and fixed a bug caused by my last pr which would cause an error if you hit a mydashboard view while not logged in. We don't actually use the app, but I figured the behavior might happen elsewhere. Thanks @tdphillips 