### PR TITLE
[PD-2212]  Remove jQuery from User Management

### DIFF
--- a/gulp/npm-shrinkwrap.json
+++ b/gulp/npm-shrinkwrap.json
@@ -32,6 +32,11 @@
       "from": "fetch-polyfill@^0.8.1",
       "resolved": "https://registry.npmjs.org/fetch-polyfill/-/fetch-polyfill-0.8.2.tgz"
     },
+    "jquery-param": {
+      "version": "0.2.0",
+      "from": "jquery-param@",
+      "resolved": "https://registry.npmjs.org/jquery-param/-/jquery-param-0.2.0.tgz"
+    },
     "lodash-compat": {
       "version": "3.10.1",
       "from": "lodash-compat@~3.10.1",

--- a/gulp/package.json
+++ b/gulp/package.json
@@ -37,6 +37,7 @@
     "tinycolor2": "~1.3.0",
     "warning": "^2.1.0",
     "webpack": "^1.12.9",
-    "lodash-compat": "~3.10.1"
+    "lodash-compat": "~3.10.1",
+    "jquery-param": "~0.2.0"
   }
 }

--- a/gulp/src/common/myjobs-api.js
+++ b/gulp/src/common/myjobs-api.js
@@ -1,0 +1,81 @@
+// This is needed for IE8. The fetch-polyfill module doesn't quite do enough.
+// based on:
+// http://stackoverflow.com/questions/24710503/how-do-i-post-urlencoded-form-data-with-http-in-angularjs
+function ancientSerialize(obj) {
+  const str = [];
+  for (const p in obj) {
+    if (obj.hasOwnProperty(p)) {
+      const type = typeof obj[p];
+
+      if (type === 'object' || type === 'array' || type === 'function') {
+        throw new Error(
+                  'Tried to serialize non primitive object. key: ' + p);
+      }
+      str.push(encodeURIComponent(p) + '=' + encodeURIComponent(obj[p]));
+    }
+  }
+  return str.join('&');
+}
+
+const hasFormData = !(window.FormData === undefined);
+
+/**
+ * Utility for making XHR calls from all our supported browsers.
+ *
+ * Also handles csrf and known response types.
+ */
+export class MyJobsApi {
+  constructor(csrf) {
+    this.csrf = csrf;
+  }
+
+  withCsrf(formData) {
+    return {...formData, csrfmiddlewaretoken: this.csrf};
+  }
+
+  checkStatus(response) {
+    if (response.status === 200) {
+      return response;
+    }
+
+    const error = new Error(response.statusText);
+    error.response = response;
+    throw error;
+  }
+
+  parseJSON(response) {
+    return response.json();
+  }
+
+  objectToFormData(obj) {
+      // No good way around this:
+    if (hasFormData) {
+      const formData = new FormData();
+      Object.keys(obj).forEach(k => formData.append(k, obj[k]));
+      return formData;
+    }
+    return ancientSerialize(obj);
+  }
+
+  async get(url) {
+    const response = await fetch(url, {
+      method: 'GET',
+      credentials: 'include',
+    });
+    return this.parseJSON(this.checkStatus(response));
+  }
+
+  async post(url, data) {
+    const formData = this.objectToFormData(this.withCsrf(data));
+    const response = await fetch(url, {
+      method: 'POST',
+      body: formData,
+      credentials: 'include',
+          // No good way around this.
+      headers: hasFormData ? undefined : {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+    });
+    return this.parseJSON(this.checkStatus(response));
+  }
+}

--- a/gulp/src/manageusers/Role.jsx
+++ b/gulp/src/manageusers/Role.jsx
@@ -208,7 +208,6 @@ class Role extends React.Component {
   }
   async handleDeleteRoleClick() {
     const {api, history} = this.props;
-    // Temporary until I replace $.ajax jQuery with vanilla JS ES6 arrow function
 
     if (confirm('Are you sure you want to delete this role?') === false) {
       return;

--- a/gulp/src/manageusers/Role.jsx
+++ b/gulp/src/manageusers/Role.jsx
@@ -1,11 +1,8 @@
-/* global $ */
-
 import React from 'react';
 import _ from 'lodash-compat';
 import {Link} from 'react-router';
 import Button from 'react-bootstrap/lib/Button';
 
-import {getCsrf} from 'common/cookie';
 import {buildCurrentActivitiesObject} from './buildCurrentActivitiesObject';
 
 import HelpText from './HelpText';
@@ -30,43 +27,7 @@ class Role extends React.Component {
     this.handleDeleteRoleClick = this.handleDeleteRoleClick.bind(this);
   }
   componentDidMount() {
-    const action = this.props.location.query.action;
-
-    if (action === 'Edit') {
-      $.get('/manage-users/api/roles/' + this.props.params.roleId + '/', function getRole(results) {
-        const activities = results.activities;
-
-        this.setState({
-          apiResponseHelp: '',
-          roleName: results.role_name,
-          availableUsers: results.available_users,
-          assignedUsers: results.assigned_users,
-          activities: activities,
-        });
-      }.bind(this));
-    } else {
-      // action === 'Add'
-      $.get('/manage-users/api/roles/', function addRole(results) {
-        // It doesn't matter which role we get
-        const roleObject = results[0];
-
-        const activities = roleObject.activities;
-
-        // Loop through all app_access's
-        // Make sure there are no assigned_activities
-        _.forOwn(activities, function resetAssignedActivities(activity) {
-          activity.assigned_activities = [];
-        });
-
-        this.setState({
-          apiResponseHelp: '',
-          roleName: '',
-          availableUsers: roleObject.available_users,
-          assignedUsers: [],
-          activities: activities,
-        });
-      }.bind(this));
-    }
+    this.initialApiLoad();
   }
   onTextChange(event) {
     this.state.roleName = event.target.value;
@@ -83,10 +44,49 @@ class Role extends React.Component {
       activites: currentActivitiesObject,
     });
   }
-  handleSaveRoleClick() {
+  async initialApiLoad() {
+    const {api} = this.props;
+    const action = this.props.location.query.action;
+
+    if (action === 'Edit') {
+      const results = await api.get('/manage-users/api/roles/' + this.props.params.roleId + '/');
+      const activities = results.activities;
+
+      this.setState({
+        apiResponseHelp: '',
+        roleName: results.role_name,
+        availableUsers: results.available_users,
+        assignedUsers: results.assigned_users,
+        activities: activities,
+      });
+    } else {
+      // action === 'Add'
+      const results = await api.get('/manage-users/api/roles/');
+      // It doesn't matter which role we get
+      const roleObject = results[0];
+
+      const activities = roleObject.activities;
+
+      // Loop through all app_access's
+      // Make sure there are no assigned_activities
+      _.forOwn(activities, function resetAssignedActivities(activity) {
+        activity.assigned_activities = [];
+      });
+
+      this.setState({
+        apiResponseHelp: '',
+        roleName: '',
+        availableUsers: roleObject.available_users,
+        assignedUsers: [],
+        activities: activities,
+      });
+    }
+  }
+  async handleSaveRoleClick() {
     // Grab form fields and validate
     // TODO: Warn user? If they remove a user from all roles, they will have to reinvite him.
 
+    const {api} = this.props;
     const roleId = this.props.params.roleId;
 
     let assignedUsers = this.refs.users.state.assignedUsers;
@@ -171,13 +171,13 @@ class Role extends React.Component {
 
     // Build data to send
     const dataToSend = {};
-    dataToSend.csrfmiddlewaretoken = getCsrf();
     dataToSend.role_name = roleName;
     dataToSend.assigned_activities = assignedActivities;
     dataToSend.assigned_users = assignedUsers;
 
     // Submit to server
-    $.post(url, dataToSend, function submitToServer(response) {
+    try {
+      const response = await api.post(url, dataToSend);
       const history = this.props.history;
 
       // TODO: Render a nice disappearing alert with the disappear_text prop. Use the React CSSTransitionGroup addon.
@@ -198,19 +198,17 @@ class Role extends React.Component {
           activities: currentActivitiesObject,
         });
       }
-    }.bind(this))
-    .fail( function failGracefully(xhr) {
-      if (xhr.status === 403) {
+    } catch (e) {
+      if (e.response && e.response.status === 403) {
         this.setState({
           apiResponseHelp: 'Unable to save role. Insufficient privileges.',
         });
       }
-    }.bind(this));
+    }
   }
-  handleDeleteRoleClick() {
-    const history = this.props.history;
+  async handleDeleteRoleClick() {
+    const {api, history} = this.props;
     // Temporary until I replace $.ajax jQuery with vanilla JS ES6 arrow function
-    const self = this;
 
     if (confirm('Are you sure you want to delete this role?') === false) {
       return;
@@ -218,27 +216,18 @@ class Role extends React.Component {
 
     const roleId = this.props.params.roleId;
 
-    const csrf = getCsrf();
-
     // Submit to server
-    $.ajax( '/manage-users/api/roles/delete/' + roleId + '/', {
-      type: 'DELETE',
-      beforeSend: function beforeSend(xhr) {
-        xhr.setRequestHeader('X-CSRFToken', csrf);
-      },
-      success: function success() {
-        // Reload API
-        self.props.callRolesAPI();
-        // Redirect the user
-        history.pushState(null, '/roles');
-      }})
-      .fail( function failGracefully(xhr) {
-        if (xhr.status === 403) {
-          this.setState({
-            apiResponseHelp: 'Role not deleted. Insufficient privileges.',
-          });
-        }
-      }.bind(this));
+    try {
+      await api.delete( '/manage-users/api/roles/delete/' + roleId + '/');
+      await this.props.callRolesAPI();
+      history.pushState(null, '/roles');
+    } catch (e) {
+      if (e.response && e.response.status === 403) {
+        this.setState({
+          apiResponseHelp: 'Role not deleted. Insufficient privileges.',
+        });
+      }
+    }
   }
   render() {
     let action = this.props.location.query.action;
@@ -311,6 +300,7 @@ Role.propTypes = {
   params: React.PropTypes.object.isRequired,
   callRolesAPI: React.PropTypes.func,
   history: React.PropTypes.object.isRequired,
+  api: React.PropTypes.object,
 };
 
 export default Role;

--- a/gulp/src/reporting/api.js
+++ b/gulp/src/reporting/api.js
@@ -4,153 +4,87 @@
 // This uses the fetch api. Fetch works somewhat differently from jQuery.ajax.
 // This module encasulates all of that. Errors are translated to JS exceptions.
 
-// Future: Factor out the non-reporting-specific ajax details so they can be
-// used by other apps.
-
-
-// This is needed for IE8. The fetch-polyfill module doesn't quite do enough.
-// based on:
-// http://stackoverflow.com/questions/24710503/how-do-i-post-urlencoded-form-data-with-http-in-angularjs
-function ancientSerialize(obj) {
-  const str = [];
-  for (const p in obj) {
-    if (obj.hasOwnProperty(p)) {
-      const type = typeof obj[p];
-
-      if (type === 'object' || type === 'array' || type === 'function') {
-        throw new Error(
-                  'Tried to serialize non primitive object. key: ' + p);
-      }
-      str.push(encodeURIComponent(p) + '=' + encodeURIComponent(obj[p]));
-    }
-  }
-  return str.join('&');
-}
-
-const hasFormData = !(window.FormData === undefined);
 
 class Api {
-    constructor(csrf) {
-      this.csrf = csrf;
-    }
+  constructor(myJobsApi) {
+    this.myJobsApi = myJobsApi;
+  }
 
-    withCsrf(formData) {
-      return {...formData, csrfmiddlewaretoken: this.csrf};
-    }
+  async getFromReportingApi(url) {
+    return this.myJobsApi.get(url);
+  }
 
-    checkStatus(response) {
-      if (response.status === 200) {
-        return response;
-      }
+  async postToReportingApi(url, data) {
+    return this.myJobsApi.post(url, data);
+  }
 
-      const error = new Error(response.statusText);
-      error.response = response;
-      throw error;
-    }
+  async listReports() {
+    const response = await this.getFromReportingApi(
+      '/reports/api/list_reports');
+    return response.reports;
+  }
 
-    parseJSON(response) {
-      return response.json();
-    }
+  async getReportingTypes() {
+    const promise = this.postToReportingApi('/reports/api/reporting_types', {});
+    return (await promise).reporting_type;
+  }
 
-    objectToFormData(obj) {
-        // No good way around this:
-      if (hasFormData) {
-        const formData = new FormData();
-        Object.keys(obj).forEach(k => formData.append(k, obj[k]));
-        return formData;
-      }
-      return ancientSerialize(obj);
-    }
+  async getReportTypes(reportingTypeId) {
+    const formData = {
+      reporting_type_id: reportingTypeId,
+    };
+    const promise = this.postToReportingApi('/reports/api/report_types', formData);
+    return (await promise).report_type;
+  }
 
-    async getFromReportingApi(url) {
-      const response = await fetch(url, {
-        method: 'GET',
-        credentials: 'include',
-      });
-      return this.parseJSON(this.checkStatus(response));
-    }
+  async getDataTypes(reportTypeId) {
+    const formData = {
+      report_type_id: reportTypeId,
+    };
+    const promise = this.postToReportingApi('/reports/api/data_types', formData);
+    return (await promise).data_type;
+  }
 
-    async postToReportingApi(url, data) {
-      const formData = this.objectToFormData(this.withCsrf(data));
-      const response = await fetch(url, {
-        method: 'POST',
-        body: formData,
-        credentials: 'include',
-            // No good way around this.
-        headers: hasFormData ? undefined : {
-          'Content-Type': 'application/x-www-form-urlencoded',
-        },
-      });
-      return this.parseJSON(this.checkStatus(response));
-    }
+  async getPresentationTypes(reportTypeId, dataTypeId) {
+    const formData = {
+      report_type_id: reportTypeId,
+      data_type_id: dataTypeId,
+    };
+    const promise = this.postToReportingApi('/reports/api/report_presentations', formData);
+    return (await promise).report_presentation;
+  }
 
-    async listReports() {
-      const response = await this.getFromReportingApi(
-        '/reports/api/list_reports');
-      return response.reports;
-    }
+  async getFilters(reportPresentationId) {
+    const formData = {
+      rp_id: reportPresentationId,
+    };
+    const promise = this.postToReportingApi(
+          '/reports/api/filters',
+          formData);
+    return (await promise);
+  }
 
-    async getReportingTypes() {
-      const promise = this.postToReportingApi('/reports/api/reporting_types', {});
-      return (await promise).reporting_type;
-    }
+  async getHelp(reportPresentationId, filter, field, partial) {
+    const formData = {
+      rp_id: reportPresentationId,
+      filter: JSON.stringify(filter),
+      field: field,
+      partial: partial,
+    };
+    const promise = this.postToReportingApi(
+          '/reports/api/help',
+          formData);
+    return (await promise);
+  }
 
-    async getReportTypes(reportingTypeId) {
-      const formData = {
-        reporting_type_id: reportingTypeId,
-      };
-      const promise = this.postToReportingApi('/reports/api/report_types', formData);
-      return (await promise).report_type;
-    }
-
-    async getDataTypes(reportTypeId) {
-      const formData = {
-        report_type_id: reportTypeId,
-      };
-      const promise = this.postToReportingApi('/reports/api/data_types', formData);
-      return (await promise).data_type;
-    }
-
-    async getPresentationTypes(reportTypeId, dataTypeId) {
-      const formData = {
-        report_type_id: reportTypeId,
-        data_type_id: dataTypeId,
-      };
-      const promise = this.postToReportingApi('/reports/api/report_presentations', formData);
-      return (await promise).report_presentation;
-    }
-
-    async getFilters(reportPresentationId) {
-      const formData = {
-        rp_id: reportPresentationId,
-      };
-      const promise = this.postToReportingApi(
-            '/reports/api/filters',
-            formData);
-      return (await promise);
-    }
-
-    async getHelp(reportPresentationId, filter, field, partial) {
-      const formData = {
-        rp_id: reportPresentationId,
-        filter: JSON.stringify(filter),
-        field: field,
-        partial: partial,
-      };
-      const promise = this.postToReportingApi(
-            '/reports/api/help',
-            formData);
-      return (await promise);
-    }
-
-    async runReport(reportPresentationId, name, filter) {
-      const formData = {
-        name: name,
-        filter: JSON.stringify(filter),
-        rp_id: reportPresentationId,
-      };
-      return await this.postToReportingApi('/reports/api/run_report', formData);
-    }
+  async runReport(reportPresentationId, name, filter) {
+    const formData = {
+      name: name,
+      filter: JSON.stringify(filter),
+      rp_id: reportPresentationId,
+    };
+    return await this.postToReportingApi('/reports/api/run_report', formData);
+  }
 }
 
 export {Api as default};

--- a/gulp/src/reporting/main.js
+++ b/gulp/src/reporting/main.js
@@ -1,5 +1,6 @@
 import 'babel/polyfill';
 import {installPolyfills} from '../common/polyfills.js';
+import {MyJobsApi} from '../common/myjobs-api.js';
 import Api from './api';
 import {ReportFinder, ReportConfigurationBuilder} from './reportEngine';
 import {getCsrf} from '../common/cookie';
@@ -10,10 +11,11 @@ import ReactDOM from 'react-dom';
 
 installPolyfills();
 
-const api = new Api(getCsrf());
+const myJobsApi = new MyJobsApi(getCsrf());
+const reportingApi = new Api(myJobsApi);
 
-const configBuilder = new ReportConfigurationBuilder(api);
-const reportFinder = new ReportFinder(api, configBuilder);
+const configBuilder = new ReportConfigurationBuilder(reportingApi);
+const reportFinder = new ReportFinder(reportingApi, configBuilder);
 
 ReactDOM.render(
   <WizardRouter reportFinder={reportFinder}/>,


### PR DESCRIPTION
* Create a common API class useful from any app.
* Use it from Manage Users and Reporting.
* Remove use of `/* global $ */` in Manage Users.

We depend on a common behavior in jQuery implemented by it's param function starting in jQuery 1.4.

http://api.jquery.com/jquery.param/

This affects sending arrays and objects as form data. jQuery renames array keys to `field[]` and object keys to `field[key]`.

Using this I can use the same code for all browsers.

