### PR TITLE
[PD-2224] Undid unicode representation of seo sites.

### DIFF
--- a/seo/admin.py
+++ b/seo/admin.py
@@ -887,6 +887,10 @@ class SeoSiteAdmin(ForeignKeyAutocompleteAdmin):
         'parent_site': ('domain', 'name'),
     }
 
+    related_string_functions = {
+        'seosite': lambda site: "%s (%s)" % (site.name, site.domain)
+    }
+
     form = SeoSiteForm
     save_on_top = True
     filter_horizontal = ('configurations', 'google_analytics',

--- a/seo/models.py
+++ b/seo/models.py
@@ -552,8 +552,6 @@ class SeoSite(Site):
         site_buids = self.business_units.all()
         return Company.objects.filter(job_source_ids__in=site_buids).distinct()
 
-    def __unicode__(self):
-        return u"{0} ({1})".format(self.name, self.domain)
 
 class SeoSiteFacet(models.Model):
     """This model defines the default Custom Facet(s) for a given site."""


### PR DESCRIPTION
Not much to say really. Removed the unicode representation of site packages since we apparently only want that formatting for the seosite admin itself, not every time we are showing seosites.