### PR TITLE
Make requires and User.can higher-order

### DIFF
--- a/doc/source/developers/postajob/setup.rst
+++ b/doc/source/developers/postajob/setup.rst
@@ -235,8 +235,21 @@ Use Cases
 Here, we describe the purpose of and setup requirements of each of the eight
 postajob use cases.
 
-Use Case 2: External party buying a job
----------------------------------------
+Use Case 1: External party buying a job
+----------------------------------------
+A small business owner (SBO) finds Paul's website. They decide to post a job,
+so they create an account. This account is with paul's site, powered by
+My.jobs. After creating an account, the SBO goes to the product listing and
+purchases a product, 5 posting for 30 days, for $100. Paul receives an invoice
+email that he can forward to the SBO. After purchasing the product, the SBO
+goes to the purchased products page and posts a job. The job appears on the
+site after approval.
+
+Requirements:
+
+
+Use Case 2: Site owner posting to their own site
+-------------------------------------------------
 
 Rebecca has a job that can't be indexed, as it is on an internal ATS that can't
 be reached by DE's agents. She logs into post-a-job and posts the site to her

--- a/myjobs/decorators.py
+++ b/myjobs/decorators.py
@@ -7,7 +7,7 @@ from django.http import HttpResponseRedirect, HttpResponseForbidden
 from django.shortcuts import get_object_or_404
 
 from myjobs.models import User, AppAccess
-from universal.helpers import get_company_or_404
+from universal.helpers import get_company_or_404, every
 
 
 def user_is_allowed(model=None, pk_name=None, pass_user=False):
@@ -136,7 +136,7 @@ def at_least_one(x, y):
     :y: An iterable with the same type of elements as y
 
     Output: A boolean
-    
+
     """
     return not set(x).isdisjoint(y)
 
@@ -173,11 +173,13 @@ def requires(*activities, **callbacks):
                 do further processing before returning an alternate result.
 
                 callbacks['compare'] is the callable used to compare the
-                requested activities with those a user has access to. By
-                default, we check if a user can perform all activities.
+                requested activities with those a user has access to. Uses
+                `universal.helpers.every` by default, which returns True if the
+                two iterables are identical.
 
                 This callback takes two iterables and returns a boolean
-                signifying whether or not the comparison was successful.
+                signifying whether or not the comparison was successful. See
+                universal.decorators for more built-in compare functions.
 
     Examples:
     Let's assume that the activities "create user", "read user", "update user",
@@ -237,7 +239,7 @@ def requires(*activities, **callbacks):
     access_callback = callbacks.get(
         'access_callback', lambda request: MissingAppAccess())
 
-    compare = callbacks.get('compare', lambda x, y: set(x).issubset(y))
+    compare = callbacks.get('compare', every)
 
     def decorator(view_func):
         @wraps(view_func)

--- a/myjobs/decorators.py
+++ b/myjobs/decorators.py
@@ -127,6 +127,20 @@ class MissingActivity(HttpResponseForbidden):
     """
 
 
+def at_least_one(x, y):
+    """
+    Returns ``True`` if any items in x are in y.
+
+    Inputs:
+    :x: An iterable of hashable elements
+    :y: An iterable with the same type of elements as y
+
+    Output: A boolean
+    
+    """
+    return bool(set(x).intersection(y))
+
+
 def requires(*activities, **callbacks):
     """
     Protects a view by activity and app access, optionally invoking callbacks.

--- a/myjobs/decorators.py
+++ b/myjobs/decorators.py
@@ -138,7 +138,7 @@ def at_least_one(x, y):
     Output: A boolean
     
     """
-    return bool(set(x).intersection(y))
+    return not set(x).isdisjoint(y)
 
 
 def requires(*activities, **callbacks):
@@ -220,8 +220,7 @@ def requires(*activities, **callbacks):
     case on an admin overview page. Thus, we might decorate our view as
     follows::
 
-        @requires("read product", "read grouping",
-                  compare=lambda x, y: bool(set(x).intersection(y))
+        @requires("read product", "read grouping", compare=at_least_one)
         def admin_overview(request):
             ...
 

--- a/myjobs/models.py
+++ b/myjobs/models.py
@@ -654,12 +654,12 @@ class User(AbstractBaseUser, PermissionsMixin):
             :company: The company who's role activities to check.
             :activity_names: Positional arguments are the names of the
                              activities the user wants to perform.
-            :function: A binary function which takes two iterables and returns
-                       a boolean. It is used to determine whether, based on the
-                       provided activities, this method should return True or
-                       False. By default, this is a set's issubset method,
-                       which means that this method returns true only if a user
-                       can perform *all* activities for the provided company.
+            :compare: A binary function which takes two iterables and returns a
+                      boolean. It is used to determine whether, based on the
+                      provided activities, this method should return True or
+                      False. By default, this is a set's issubset method, which
+                      means that this method returns true only if a user can
+                      perform *all* activities for the provided company.
 
         Output:
             A boolean signifying whether the provided actions may be performed.
@@ -694,7 +694,7 @@ class User(AbstractBaseUser, PermissionsMixin):
         if not company:
             return False
 
-        function = kwargs.get('function', lambda x, y: set(x).issubset(y))
+        compare = kwargs.get('function', lambda x, y: set(x).issubset(y))
 
         required_access = filter(bool, AppAccess.objects.filter(
             activity__name__in=activity_names).values_list(
@@ -706,7 +706,7 @@ class User(AbstractBaseUser, PermissionsMixin):
             bool(company.enabled_access),
             set(required_access).issubset(company.enabled_access),
             bool(self.get_activities(company)),
-            function(activity_names, self.get_activities(company))])
+            compare(activity_names, self.get_activities(company))])
 
     def send_invite(self, email, company, role_name=None):
         """

--- a/myjobs/models.py
+++ b/myjobs/models.py
@@ -28,7 +28,8 @@ from django.utils.translation import ugettext_lazy as _
 from default_settings import GRAVATAR_URL_PREFIX, GRAVATAR_URL_DEFAULT
 from registration import signals as custom_signals
 from mymessages.models import Message, MessageInfo
-from universal.helpers import get_domain, send_email, invitation_context
+from universal.helpers import (get_domain, send_email, invitation_context,
+                               every)
 
 BAD_EMAIL = ['dropped', 'bounce']
 STOP_SENDING = ['unsubscribe', 'spamreport']
@@ -657,9 +658,9 @@ class User(AbstractBaseUser, PermissionsMixin):
             :compare: A binary function which takes two iterables and returns a
                       boolean. It is used to determine whether, based on the
                       provided activities, this method should return True or
-                      False. By default, this is a set's issubset method, which
-                      means that this method returns true only if a user can
-                      perform *all* activities for the provided company.
+                      False. By default, `universal.helpers.every` is used,
+                      which only returns two if the two iterables contain the
+                      same elements.
 
         Output:
             A boolean signifying whether the provided actions may be performed.
@@ -694,7 +695,7 @@ class User(AbstractBaseUser, PermissionsMixin):
         if not company:
             return False
 
-        compare = kwargs.get('function', lambda x, y: set(x).issubset(y))
+        compare = kwargs.get('function', every)
 
         required_access = filter(bool, AppAccess.objects.filter(
             activity__name__in=activity_names).values_list(

--- a/postajob/views.py
+++ b/postajob/views.py
@@ -27,9 +27,9 @@ from postajob.models import (CompanyProfile, Invoice, Job, OfflinePurchase,
 from postajob.decorators import (error_when_site_misconfigured,
                                  error_when_company_missing_from_sitepackages)
 from universal.helpers import (get_company, get_object_or_none,
-                               get_company_or_404)
+                               get_company_or_404, at_least_one)
 from universal.views import RequestFormViewBase
-from myjobs.decorators import requires, at_least_one
+from myjobs.decorators import requires
 
 
 @user_is_allowed()

--- a/postajob/views.py
+++ b/postajob/views.py
@@ -162,6 +162,14 @@ def purchasedjobs_overview(request, purchased_product, admin):
 @error_when_site_misconfigured(feature='Microsite Admin is')
 def purchasedmicrosite_admin_overview(request):
     company = get_company(request)
+    can = lambda *activities: request.user.can(company, *activities)
+
+    if not any([can('read product'),
+                can('read request'),
+                can('read offline purchase'),
+                can('read purchased product'), can('read grouping')]):
+        return MissingActivity()
+
     if settings.SITE:
         sites = settings.SITE.postajob_site_list()
         products = Product.objects.filter_by_sites(sites)

--- a/postajob/views.py
+++ b/postajob/views.py
@@ -162,12 +162,10 @@ def purchasedjobs_overview(request, purchased_product, admin):
 @error_when_site_misconfigured(feature='Microsite Admin is')
 def purchasedmicrosite_admin_overview(request):
     company = get_company(request)
-    can = lambda *activities: request.user.can(company, *activities)
-
-    if not any([can('read product'),
-                can('read request'),
-                can('read offline purchase'),
-                can('read purchased product'), can('read grouping')]):
+    if not request.user.can(company,
+               'read product', 'read request', 'read offline purchase',
+               'read purchased product', 'read grouping',
+               function=lambda x, y: bool(set(x).intersection(y))):
         return MissingActivity()
 
     if settings.SITE:

--- a/postajob/views.py
+++ b/postajob/views.py
@@ -160,14 +160,11 @@ def purchasedjobs_overview(request, purchased_product, admin):
 @user_is_allowed()
 @error_when_company_missing_from_sitepackages(feature='Microsite Admin is')
 @error_when_site_misconfigured(feature='Microsite Admin is')
+@requires('read product', 'read request', 'read offline purchase',
+          'read purchased product', 'read grouping',
+          compare=lambda x, y: bool(set(x).intersection(y)))
 def purchasedmicrosite_admin_overview(request):
     company = get_company(request)
-    if not request.user.can(company,
-               'read product', 'read request', 'read offline purchase',
-               'read purchased product', 'read grouping',
-               function=lambda x, y: bool(set(x).intersection(y))):
-        return MissingActivity()
-
     if settings.SITE:
         sites = settings.SITE.postajob_site_list()
         products = Product.objects.filter_by_sites(sites)

--- a/postajob/views.py
+++ b/postajob/views.py
@@ -29,7 +29,7 @@ from postajob.decorators import (error_when_site_misconfigured,
 from universal.helpers import (get_company, get_object_or_none,
                                get_company_or_404)
 from universal.views import RequestFormViewBase
-from myjobs.decorators import requires
+from myjobs.decorators import requires, at_least_one
 
 
 @user_is_allowed()
@@ -148,9 +148,9 @@ def purchasedjobs_overview(request, purchased_product, admin):
         'expired_jobs': jobs.filter(is_expired=True)
     }
     if admin:
-        return render_to_response('postajob/%s/purchasedjobs_admin_overview.html'
-                                  % settings.PROJECT,
-                                  data, RequestContext(request))
+        return render_to_response(
+            'postajob/%s/purchasedjobs_admin_overview.html' % settings.PROJECT,
+            data, RequestContext(request))
     else:
         return render_to_response('postajob/%s/purchasedjobs_overview.html'
                                   % settings.PROJECT,
@@ -161,8 +161,7 @@ def purchasedjobs_overview(request, purchased_product, admin):
 @error_when_company_missing_from_sitepackages(feature='Microsite Admin is')
 @error_when_site_misconfigured(feature='Microsite Admin is')
 @requires('read product', 'read request', 'read offline purchase',
-          'read purchased product', 'read grouping',
-          compare=lambda x, y: bool(set(x).intersection(y)))
+          'read purchased product', 'read grouping', compare=at_least_one)
 def purchasedmicrosite_admin_overview(request):
     company = get_company(request)
     if settings.SITE:

--- a/templates/postajob/dseo/dseo_navigation.html
+++ b/templates/postajob/dseo/dseo_navigation.html
@@ -5,13 +5,15 @@
         {% if can_read_product %}
         <li id="product-listing" class="{% if request.resolver_match.url_name == 'product_listing' %}active{% endif %}"><a href="{% url 'product_listing' %}">Product Listing</a></li>
         {% endif %}
-        {% if company.posting_access %}
+        {% can user company "create job" as can_create_job %}
+        {% if can_create_job %}
         <li id="our-postings" class="{% if request.resolver_match.url_name == 'jobs_overview' %}active{% endif %}"><a href="{% url 'jobs_overview' %}">Posted Jobs</a></li>
         {% endif %}
         {% if company.purchasedproduct_set.exists %}
         <li id="purchased-products" class="{% if request.resolver_match.url_name == 'purchasedproducts_overview' %}active{% endif %}"><a href="{% url 'purchasedproducts_overview' %}">Purchased Jobs</a></li>
         {% endif %}
-        {% if company.product_access %}
+        {% can user company "create product" as can_create_product %}
+        {% if can_create_product %}
         <li id="posting-admin" class="{% if request.resolver_match.url_name == 'purchasedmicrosite_admin_overview' %}active{% endif %}"><a href="{% url 'purchasedmicrosite_admin_overview' %}">Partner Microsite</a></li>
         {% endif %}
     </ul>

--- a/templates/postajob/dseo/dseo_navigation.html
+++ b/templates/postajob/dseo/dseo_navigation.html
@@ -12,8 +12,7 @@
         {% if company.purchasedproduct_set.exists %}
         <li id="purchased-products" class="{% if request.resolver_match.url_name == 'purchasedproducts_overview' %}active{% endif %}"><a href="{% url 'purchasedproducts_overview' %}">Purchased Jobs</a></li>
         {% endif %}
-        {% can user company "create product" as can_create_product %}
-        {% if can_create_product %}
+        {% if can_read_product %}
         <li id="posting-admin" class="{% if request.resolver_match.url_name == 'purchasedmicrosite_admin_overview' %}active{% endif %}"><a href="{% url 'purchasedmicrosite_admin_overview' %}">Partner Microsite</a></li>
         {% endif %}
     </ul>

--- a/universal/helpers.py
+++ b/universal/helpers.py
@@ -16,6 +16,46 @@ from django.core.mail import EmailMessage
 from django.http import QueryDict
 
 
+def every(x, y):
+    """
+    Returns True if every element of x is also an element of y.
+
+    :Inputs
+    :x: An iterable of hashable values.
+    :y: An iterable of elements of the same time as x's elements.
+
+    :Output
+    A boolean.
+
+    Example::
+
+        every([1, 2, 3], [1, 2, 3]) => True
+        every([1, 2, 3], [2, 3, 4]) => False
+
+    """
+    return set(x).issubset(y)
+
+
+def at_least_one(x, y):
+    """
+    Returns True if at least one element of x is also an element of y.
+
+    :Inputs
+    :x: An iterable of hashable values.
+    :y: An iterable of elements of the same time as x's elements.
+
+    :Output
+    A boolean.
+
+    Example::
+
+        at_least_one([1, 2, 3], [3, 4, 5]) => True
+        at_least_one([1, 2, 3], [4, 5, 6]) => False
+
+    """
+    return not set(x).isdisjoint(y)
+
+
 def update_url_param(url, param, new_val):
     """
     Changes the value for a parameter in a query string. If the parameter


### PR DESCRIPTION
I'm doing this as an untagged, small PR because I'd like feedback. I started working on Use Case 1 for postajob (hence the unfinished documentation) when I ran into this. Basically, for admin views, we'd like to say that any number of activities is required to see a view since from that view, any number of pages may be navigated to. Whereas the original requires decorator enforced that all specified activities were required to see the decorated view, this version allows that comparison to be changed. Here, we specify that at least one of the specified activities should be available before the  view is accessible.