### PR TITLE
[PD-2230] Fix Microsites Name Display for Topbar

### DIFF
--- a/myjobs/views.py
+++ b/myjobs/views.py
@@ -596,6 +596,8 @@ def topbar(request):
                             value=last_name,
                             max_age=max_age,
                             domain='.my.jobs')
+        ctx['current_microsite_name'] = last_name
+        ctx['current_microsite_url'] = caller
 
     html = render_to_response('includes/topbar.html', ctx,
                               RequestContext(request))

--- a/templates/includes/topbar-new.html
+++ b/templates/includes/topbar-new.html
@@ -16,12 +16,13 @@
                 </a>
             </div>
 
-            {% get_ms_name as microsite_name %}
-            {% if microsite_name != None %}
+            {% get_ms_name as last_microsite_name %}
+            {% if current_microsite_name or last_microsite_name %}
             <div id="last-microsite" class="de-topbar-item">
-                <a href="{% get_ms_url %}">
+                <a href="{% if current_microsite_url %}{{current_microsite_url}}
+                        {% else %}{% get_ms_url %}{% endif %}">
                     <span id="last-microsite-name">
-                        {{ microsite_name }}
+                        {% firstof current_microsite_name last_microsite_name %}
                     </span>
                     <span class="arrow pull-left"></span>
                 </a>

--- a/templates/includes/topbar.html
+++ b/templates/includes/topbar.html
@@ -16,12 +16,13 @@
                 </a>
             </div>
 
-            {% get_ms_name as microsite_name %}
-            {% if microsite_name != None %}
+            {% get_ms_name as last_microsite_name %}
+            {% if current_microsite_name or last_microsite_name %}
             <div id="last-microsite" class="de-topbar-item">
-                <a href="{% get_ms_url %}">
+                <a href="{% if current_microsite_url %}{{current_microsite_url}}
+                        {% else %}{% get_ms_url %}{% endif %}">
                     <span id="last-microsite-name">
-                        {{ microsite_name }}
+                        {% firstof current_microsite_name last_microsite_name %}
                     </span>
                     <span class="arrow pull-left"></span>
                 </a>

--- a/templates/myblocks/blocks/secure_blocks/tools.html
+++ b/templates/myblocks/blocks/secure_blocks/tools.html
@@ -16,12 +16,13 @@
                 </a>
             </div>
 
-            {% get_ms_name as microsite_name %}
-            {% if microsite_name != None %}
+            {% get_ms_name as last_microsite_name %}
+            {% if current_microsite_name or last_microsite_name %}
             <div id="last-microsite" class="de-topbar-item">
-                <a href="{% get_ms_url %}">
+                <a href="{% if current_microsite_url %}{{current_microsite_url}}
+                        {% else %}{% get_ms_url %}{% endif %}">
                     <span id="last-microsite-name">
-                        {{ microsite_name }}
+                        {% firstof current_microsite_name last_microsite_name %}
                     </span>
                     <span class="arrow pull-left"></span>
                 </a>


### PR DESCRIPTION
## Overview

The microsite name/url displayed in the topbar was entirely based off of a cookie. The reason for this was to display a link back to the microsite that a user was last microsite visited, even if they are on a different microsite at the time of the display.

The new logic first determines if they are on a valid Microsite. If they are, a context variable will be added for the link/text. If not, the topbar will use the cookie.

## Testing

This PR affects topbar, tools widget (secure blocks topbar) and react topbar. Each should be tested.

### Old Topbar

- Navigate to a microsite  (ex. newhampshire.jobs)
- Navigate to another microsite (ex. vermont.jobs)
- Verify that the topbar displays the name of the microsite you are CURRENTLY on, not the previous
- Navigate to secure.my.jobs
- Verify that the topbar displays the last visited microsite.

### Tools Widget (Secure Blocks Topbar)

- The exact same steps as above, but using secure blocks enabled microsites.
- [Here] (https://github.com/DirectEmployers/MyJobs/blob/quality-control/doc/source/developers/myblocks/secureblocks.rst#testing-a-secure-block-widget) are the steps for testing secure blocks

### React Topbar

- Navigate to a microsite  (ex. newhampshire.jobs)
- Navigate to secure.my.jobs/manage-users
- Verify that the microsite name/link are pointing back to the microsite.