### PR TITLE
[PD-2259] Tell staff that an admin is assigned rather than that invitations were sent

### DIFF
--- a/seo/forms/admin_forms.py
+++ b/seo/forms/admin_forms.py
@@ -678,11 +678,9 @@ class CompanyForm(SeoSiteReverseForm):
     def __init__(self, *args, **kwargs):
         super(CompanyForm, self).__init__(*args, **kwargs)
         instance = kwargs.get('instance')
-        if instance and instance.first_invitation:
-            text = "Invitation sent to %s." % (
-                instance.first_invitation.invitee_email)
+        if instance and instance.role_set.filter(user__isnull=False).count():
             self.fields['admin_email'] = forms.fields.CharField(
-                initial=text,
+                initial="An admin already exists for this company",
                 widget=forms.widgets.TextInput(
                     attrs={"style": "border: 0; "
                                     "background: 'transparent'; "

--- a/seo/forms/admin_forms.py
+++ b/seo/forms/admin_forms.py
@@ -669,8 +669,7 @@ class CompanyForm(SeoSiteReverseForm):
                                                 my_model=BusinessUnit,
                                                 required=False,
                                                 widget=job_source_ids_widget)
-    admin_email = forms.fields.EmailField(label='Admin Email',
-                                          required=False)
+    admin_email = forms.fields.EmailField(label='Admin Email', required=False)
 
     class Meta:
         model = Company
@@ -679,15 +678,12 @@ class CompanyForm(SeoSiteReverseForm):
         super(CompanyForm, self).__init__(*args, **kwargs)
         instance = kwargs.get('instance')
         if instance and instance.role_set.filter(user__isnull=False).count():
+            attrs = {
+                "style": "border: 0; background: 'transparent'; width: 300px;",
+                "readonly": True, "onfocus": "this.blur()"}
             self.fields['admin_email'] = forms.fields.CharField(
                 initial="An admin already exists for this company",
-                widget=forms.widgets.TextInput(
-                    attrs={"style": "border: 0; "
-                                    "background: 'transparent'; "
-                                    "width: 300px;",
-                           "readonly": True,
-                           "onfocus": "this.blur()"
-                           }))
+                widget=forms.widgets.TextInput(attrs=attrs))
 
 
 class SpecialCommitmentForm(SeoSiteReverseForm):

--- a/seo/models.py
+++ b/seo/models.py
@@ -744,19 +744,6 @@ class Company(models.Model):
 
         return filter(bool, self.app_access.values_list('name', flat=True))
 
-    @property
-    def first_invitation(self):
-        """
-        Returns the first invitation created for this company.
-
-        In most cases (as of 02/02/2016), this should be an invitation for the
-        Admin role of the company.
-
-        """
-        # to prevent multiple queries, we set this up on instantiation instead
-        # of running the query every time the information is asked for
-        return self.invites_sent.order_by('-invited').first()
-
 
 class FeaturedCompany(models.Model):
     """

--- a/seo/tests/test_models.py
+++ b/seo/tests/test_models.py
@@ -342,13 +342,3 @@ class SeoSitePostAJobFiltersTestCase(DirectSEOBase):
         self.company.app_access.add(app_access)
 
         self.assertItemsEqual(self.company.enabled_access, ['Test Access'])
-
-    def test_first_invitation(self):
-        """
-        `Company.first_invitation` should return the first invitation created
-        for a company.
-
-        """
-        self.assertEqual(
-            self.company.first_invitation, Invitation.objects.filter(
-                inviting_company=self.company).order_by('-invited').first())


### PR DESCRIPTION
# Testing
Visit /admin for a company. If that company doesn't have anyone assigned the "Admin" role, you should see an "Admin email" field that you can use to assign that role. If an admin already exists, you should instead see a message saying that the company already has an admin.