### PR TITLE
[PD_2252] Moved restrict_to_staff to universal and hid a few mockup views.

### DIFF
--- a/myblocks/views.py
+++ b/myblocks/views.py
@@ -11,7 +11,7 @@ from django.views.decorators.csrf import (
 
 from myjobs.autoserialize import autoserialize
 from myjobs.cross_site_verify import cross_site_verify
-from myreports.decorators import restrict_to_staff
+from universal.decorators import restrict_to_staff
 from myblocks.models import Page, Block
 
 logger = logging.getLogger(__name__)

--- a/myjobs/views.py
+++ b/myjobs/views.py
@@ -7,7 +7,6 @@ import urllib2
 from urlparse import urlparse, urljoin
 import uuid
 
-from myreports.decorators import restrict_to_staff
 from django.conf import settings
 from django.contrib.auth import logout, authenticate
 from django.contrib.auth.decorators import user_passes_test
@@ -24,6 +23,7 @@ from django.views.generic import TemplateView
 from captcha.fields import ReCaptchaField
 
 from universal.helpers import get_domain
+from universal.decorators import restrict_to_staff
 from myjobs.decorators import user_is_allowed, requires
 from myjobs.forms import (ChangePasswordForm, EditCommunicationForm,
                           CompanyAccessRequestForm)

--- a/mypartners/views.py
+++ b/mypartners/views.py
@@ -30,11 +30,10 @@ from urllib2 import HTTPError
 from email_parser import build_email_dicts, get_datetime_from_str
 from universal.helpers import (get_company_or_404, get_int_or_none,
                                add_pagination, get_object_or_none)
-from universal.decorators import warn_when_inactive
+from universal.decorators import warn_when_inactive, restrict_to_staff
 from myjobs.models import User
 
 from myjobs.decorators import requires
-from myreports.decorators import restrict_to_staff
 from mysearches.models import PartnerSavedSearch
 from mysearches.helpers import get_interval_from_frequency
 from mysearches.forms import PartnerSavedSearchForm

--- a/myreports/decorators.py
+++ b/myreports/decorators.py
@@ -1,8 +1,0 @@
-from functools import partial
-from universal.decorators import not_found_when
-
-restrict_to_staff = partial(
-    not_found_when,
-    condition=lambda req: not req.user.is_staff,
-    feature="MyReports",
-    message="Feature currently restricted to DirectEmployers staff.")

--- a/myreports/views.py
+++ b/myreports/views.py
@@ -11,7 +11,6 @@ from django.utils.decorators import method_decorator
 from django.views.generic import View
 from django.views.decorators.http import require_http_methods
 
-from myreports.decorators import restrict_to_staff
 from myreports.helpers import humanize, serialize
 from myjobs.decorators import requires
 from myreports.models import (
@@ -21,6 +20,7 @@ from myreports.presentation import presentation_drivers
 from myreports.presentation.disposition import get_content_disposition
 from postajob import location_data
 from universal.helpers import get_company_or_404
+from universal.decorators import restrict_to_staff
 
 from myreports.datasources import ds_json_drivers
 

--- a/mysearches/views.py
+++ b/mysearches/views.py
@@ -18,14 +18,13 @@ from myjobs.decorators import user_is_allowed
 from myjobs.models import User
 from myjobs.autoserialize import autoserialize
 from myjobs.cross_site_verify import cross_site_verify
-from myreports.decorators import restrict_to_staff
 from mysearches.models import (SavedSearch, SavedSearchDigest,
                                PartnerSavedSearch)
 from mysearches.forms import (SavedSearchForm, DigestForm,
                               PartnerSubSavedSearchForm)
 from mysearches.helpers import (get_interval_from_frequency, parse_feed,
                                 url_sort_options, validate_dotjobs_url)
-from universal.decorators import warn_when_inactive
+from universal.decorators import warn_when_inactive, restrict_to_staff
 
 
 @user_is_allowed(SavedSearch, 'id', pass_user=True)

--- a/seo/views/search_views.py
+++ b/seo/views/search_views.py
@@ -59,6 +59,7 @@ from seo.templatetags.seo_extras import filter_carousel
 from transform import hr_xml_to_json
 from universal.states import states_with_sites
 from universal.helpers import get_company_or_404
+from universal.decorators import restrict_to_staff
 from myjobs.decorators import user_is_allowed
 from myemails.models import EmailSection
 from myblocks.models import Page
@@ -1929,6 +1930,7 @@ def test_markdown(request):
                                   context_instance=RequestContext(request))
 
 
+@restrict_to_staff()
 @user_is_allowed()
 def admin_dashboard(request):
     data_dict = {}
@@ -1936,6 +1938,7 @@ def admin_dashboard(request):
                               context_instance=RequestContext(request))
 
 
+@restrict_to_staff()
 @user_is_allowed()
 def event_overview(request):
     data_dict = {'active_events': [],
@@ -1945,6 +1948,7 @@ def event_overview(request):
                               context_instance=RequestContext(request))
 
 
+@restrict_to_staff()
 @user_is_allowed()
 def manage_header_footer(request):
     headers = EmailSection.objects.filter(section_type=1)
@@ -1959,6 +1963,7 @@ def manage_header_footer(request):
                               context_instance=RequestContext(request))
 
 
+@restrict_to_staff()
 @user_is_allowed()
 def manage_templates(request):
     data_dict = {'events': []}
@@ -1967,6 +1972,7 @@ def manage_templates(request):
                               context_instance=RequestContext(request))
 
 
+@restrict_to_staff()
 @user_is_allowed()
 def blocks_overview(request):
     company = get_company_or_404(request)

--- a/universal/decorators.py
+++ b/universal/decorators.py
@@ -122,3 +122,10 @@ warn_when_inactive = partial(
     message='You have yet to activate your account.',
     link='/accounts/register/resend',
     link_text='Resend Activation')
+
+
+restrict_to_staff = partial(
+    not_found_when,
+    condition=lambda req: not req.user.is_staff,
+    feature="MyReports",
+    message="Feature currently restricted to DirectEmployers staff.")


### PR DESCRIPTION
While messing with postajob I noticed we had some mockups that David did some time before he left that were exposed. This PR restricts them to staff.

To test, visit `/dashboard` while logged into  a local running microsite. If you demote yourself from staff to normal user, you should get 404s. As staff, you should see the mockups. An example of this in production is at http://www.my.jobs/dashboard

What you should *not* see, unless you are staff:
![2016-03-28-092035_1197x253_scrot](https://cloud.githubusercontent.com/assets/93686/14078769/67603772-f4c6-11e5-9823-75e2cf90fb5a.png)
