### PR TITLE
Add timeout to loggedout cookie [PD-2283]

### DIFF
--- a/registration/tests/test_views.py
+++ b/registration/tests/test_views.py
@@ -75,9 +75,6 @@ class RegistrationViewTests(MyJobsBase):
             response.cookies.get("loggedout"),
             "Expected the loggedout cookie to not be set, but it was")
 
-
-
-
     def test_valid_activation(self):
         """
         Test that the ``activate`` view properly handles a valid

--- a/registration/tests/test_views.py
+++ b/registration/tests/test_views.py
@@ -55,13 +55,22 @@ class RegistrationViewTests(MyJobsBase):
         password = "password"
         self.user.set_password(password)
 
-        response = self.client.get(reverse("auth_logout"))
-        self.assertTrue(
-            response.cookies.get("loggedout"),
-            "Expected the loggedout cookie to be set, but it's not")
+        def set_logout_cookie():
+            response = self.client.get(reverse("auth_logout"))
+            self.assertTrue(
+                response.cookies.get("loggedout"),
+                "Expected the loggedout cookie to be set, but it's not")
+
+        set_logout_cookie()
 
         response = self.client.post(
             reverse("home"), {"email": self.user.email, "password": password})
+        self.assertFalse(
+            response.cookies.get("loggedout"),
+            "Expected the loggedout cookie to not be set, but it was")
+
+        set_logout_cookie()
+        response = self.client.get("password_reset")
         self.assertFalse(
             response.cookies.get("loggedout"),
             "Expected the loggedout cookie to not be set, but it was")

--- a/registration/views.py
+++ b/registration/views.py
@@ -162,7 +162,7 @@ def logout(request):
     log_out(request)
     response = redirect('home')
     # this cookie forces other tabs to logout immediately
-    response.set_cookie('loggedout', True)
+    response.set_cookie('loggedout', True, 3)
     if 'myguid' in request.COOKIES:
         response.delete_cookie(key='myguid', domain='.my.jobs')
     return response
@@ -207,5 +207,8 @@ def custom_password_reset(request):
     from_email = settings.EMAIL_FORMATS[settings.FORGOTTEN_PASSWORD]['address']
     from_email = from_email.format(domain=email_domain.lower())
 
-    return password_reset(request,  password_reset_form=CustomPasswordResetForm,
-                          from_email=from_email, template_name=template)
+    response = password_reset(
+        request, password_reset_form=CustomPasswordResetForm,
+        from_email=from_email, template_name=template)
+    response.delete_cookie('loggedout')
+    return response


### PR DESCRIPTION
# TESTING

## Before switching to this branch

Log out of your account

Go to /accounts/password/reset/

Note the redirect :sob: 

## After switching to this branch

Do the same thing

Note the lack of a redirect :boom: 

## But there's more code here

Log out of your account

Walk away for some amount of time greater than three seconds

Come back

Go to /accounts/password/reset/

Note the lack of a redirect :boom: