### PR TITLE
Made it so that we weren't rendering empty menu items

### DIFF
--- a/myjobs/templatetags/common_tags.py
+++ b/myjobs/templatetags/common_tags.py
@@ -347,4 +347,5 @@ def get_menus(context):
         ]
     }
 
-    return [message_menu, employer_menu, profile_menu]
+    # only return menus we've populated
+    return [menu for menu in message_menu, employer_menu, profile_menu if menu]


### PR DESCRIPTION
If you remove yourself from all companies and refresh (secure.my.jobs), you'll see an empty menu item. This caused by an empty <li> element being rendered for the Employers menu (since you won't have one, it's not populated with submenus). Nothing is 'broken' because of it, but it's still annoying to look at. This PR removes that annoyance.