### PR TITLE
Remove caching from views using myblocks [PD-2268]

### DIFF
--- a/myblocks/tests/test_models.py
+++ b/myblocks/tests/test_models.py
@@ -501,34 +501,6 @@ class ModelsTests(BlocksTestBase):
         pattern = '.*%s.*%s.*%s.*%s.*' % (two, one, four, three)
         self.assertRegexpMatches(template, pattern)
 
-    def test_page_render_cache_prefix(self):
-        """
-        Changes to any part of a page should change the cache prefix.
-
-        """
-        row = factories.RowFactory()
-        search_filter_block = factories.SearchFilterBlockFactory()
-        breadbox_block = factories.BreadboxBlockFactory()
-
-        models.BlockOrder.objects.create(block=search_filter_block, row=row,
-                                         order=1)
-        models.BlockOrder.objects.create(block=breadbox_block, row=row,
-                                         order=2)
-
-        page = factories.PageFactory()
-        models.RowOrder.objects.create(page=page, row=row, order=1)
-
-        start_prefix = page.render_cache_prefix(self.search_results_request)
-
-        breadbox_block.save()
-
-        # Get the most recent version of the page, without the old
-        # cached blocks.
-        page = models.Page.objects.get(pk=page.pk)
-        end_prefix = page.render_cache_prefix(self.search_results_request)
-
-        self.assertNotEqual(start_prefix, end_prefix)
-
     def test_page_handle_job_detail_redirect(self):
         page = factories.PageFactory(page_type=models.Page.JOB_DETAIL)
 


### PR DESCRIPTION
We were caching rendered login pages, including the csrf tokens on them. This is why everyone who was checking the page at the same time had the same token.

Per a conversation with @fezick, we're removing caching until we determine what we actually want to do.

If you wish to manually verify:

Using a microsite with a login block (this can be done in production):
Log in.
Log out.
Try logging back in -> error.

Using this branch:
Create a login page.
Mess with settings as necessary to mimic a microsite.
You're now able to log in and out to your heart's content.