### PR TITLE
Assign a template when creating a login block.

### DIFF
--- a/postajob/helpers.py
+++ b/postajob/helpers.py
@@ -33,6 +33,22 @@ def can_modify(user, company, kwargs, update_activity, create_activity):
     else:
         return user.can(company, create_activity)
 
+
+def create_login_block(company, site):
+    page = Page.objects.create(
+        name="%s Login Page" % company.name, page_type=Page.LOGIN)
+    page.sites.add(site)
+    row = Row.objects.create()
+    row_order = RowOrder.objects.create(row=row, page=page, order=0)
+    template = open("templates/" + LoginBlock.base_template, "r").read()
+    login_block = LoginBlock.objects.create(
+        name="%s Login Block" % company.name, offset=0, span=12,
+        template=template)
+    BlockOrder.objects.create(block=login_block, row=row, order=0)
+
+    return login_block
+
+
 def enable_posting(company, site):
     """
     Convenience function which enables posting for a company by:
@@ -56,14 +72,7 @@ def enable_posting(company, site):
     company.app_access.add(AppAccess.objects.get(name='Posting'))
 
     # create a login block so that users can log in
-    page = Page.objects.create(
-        name="%s Login Page" % company.name, page_type=Page.LOGIN)
-    page.sites.add(site)
-    row = Row.objects.create()
-    row_order = RowOrder.objects.create(row=row, page=page, order=0)
-    login_block = LoginBlock.objects.create(
-        name="%s Login Block" % company.name, offset=0, span=12)
-    BlockOrder.objects.create(block=login_block, row=row, order=0)
+    create_login_block(company, site)
 
     # create a site package for the posted jobs to live on
     package, _ = SitePackage.objects.get_or_create(
@@ -97,14 +106,7 @@ def enable_marketplace(company, site):
     company.app_access.add(AppAccess.objects.get(name='MarketPlace'))
 
     # create a login block so that users can log in
-    page = Page.objects.create(
-        name="%s Login Page" % company.name, page_type=Page.LOGIN)
-    page.sites.add(site)
-    row = Row.objects.create()
-    row_order = RowOrder.objects.create(row=row, page=page, order=0)
-    login_block = LoginBlock.objects.create(
-        name="%s Login Block" % company.name, offset=0, span=12)
-    BlockOrder.objects.create(block=login_block, row=row, order=0)
+    create_login_block(company, site)
 
     # create a site package for the posted jobs to live on
     package, _ = SitePackage.objects.get_or_create(

--- a/postajob/helpers.py
+++ b/postajob/helpers.py
@@ -1,6 +1,7 @@
 from myjobs.models import AppAccess
 from postajob.models import SitePackage
-from myblocks.models import Page, Row, RowOrder, LoginBlock, BlockOrder
+from myblocks.models import (raw_base_template, Page, Row, RowOrder,
+                             LoginBlock, BlockOrder)
 
 def can_modify(user, company, kwargs, update_activity, create_activity):
     """
@@ -35,12 +36,24 @@ def can_modify(user, company, kwargs, update_activity, create_activity):
 
 
 def create_login_block(company, site):
+    """
+    Given a ``Company`` and a ``SeoSite`, creates a login block for that
+    company on that site.
+
+    Inputs:
+        :company: Who should own the login block
+        :site: The SeoSite the login block should appear on
+
+    Output:
+        The resulting ``LoginBlock`` instance.
+
+    """
     page = Page.objects.create(
         name="%s Login Page" % company.name, page_type=Page.LOGIN)
     page.sites.add(site)
     row = Row.objects.create()
     row_order = RowOrder.objects.create(row=row, page=page, order=0)
-    template = open("templates/" + LoginBlock.base_template, "r").read()
+    template = raw_base_template(LoginBlock)
     login_block = LoginBlock.objects.create(
         name="%s Login Block" % company.name, offset=0, span=12,
         template=template)

--- a/postajob/tests/test_models.py
+++ b/postajob/tests/test_models.py
@@ -7,8 +7,9 @@ from django.core import mail
 from mydashboard.tests.factories import (BusinessUnitFactory, CompanyFactory,
                                          SeoSiteFactory)
 from myjobs.models import User
-from myblocks.models import LoginBlock
-from postajob.helpers import enable_posting, enable_marketplace
+from myblocks.models import LoginBlock, raw_base_template
+from postajob.helpers import (enable_posting, enable_marketplace,
+                              create_login_block)
 from postajob.models import (CompanyProfile, Invoice, Job, JobLocation,
                              OfflineProduct, OfflinePurchase, Package,
                              Product, ProductGrouping, ProductOrder,
@@ -1055,3 +1056,19 @@ class ModelTests(MyJobsBase):
         self.assertIn(site, package.sites.all())
         self.assertTrue(LoginBlock.objects.filter(
             name="Marketplace Company Login Block").exists())
+
+    def test_create_login_block(self):
+        """
+        Ensures that a login block is createed with the correct associations
+        and a valid template.
+
+        """
+        company = CompanyFactory(name='Marketplace Company')
+        site = SeoSite.objects.create(domain='somewhereelse.jobs')
+
+        template = raw_base_template(LoginBlock)
+        response = self.client.get("/login", follow=True)
+        login_block = create_login_block(company, site)
+
+        # validate that the correct template was assigned to the login block
+        self.assertEqual(login_block.template, template)


### PR DESCRIPTION
When creating the login block, i wasn't assigning a default template. Admin seems to do some funkiness to accomplish this. I didn't look at how it was done there, but did go ahead and make sure the default template was assigned when generating login blocks as a result of ruining `enable_marketplace`. 

~~Tomorrow morning I'll write a regression test to ensure that the command creates a login block with  a proper template.~~ (Done)