### PR TITLE
[PD-2147] Re-enabled content block for request company access request page.

### DIFF
--- a/templates/base-react.html
+++ b/templates/base-react.html
@@ -72,6 +72,7 @@
                                 {% endfor %}
                             {% endif %}
                         {% endblock%}
+                        {% block content %}
                         <div>
                             <div class="row">
                                 <div class="col-sm-12">
@@ -81,6 +82,7 @@
                         </div>
                         <div id="content"></div>
                         <div id="ajax-busy"></div>
+                        {% endblock %}
                     </div>
                     {% endblock %}
                 {% endblock %}

--- a/templates/myjobs/request_company_access.html
+++ b/templates/myjobs/request_company_access.html
@@ -6,8 +6,15 @@
 
 {% block content %}
   <div class="row">
-    <div class="col-md-12">
-      <h1>Request Company Access</h1>
+    <div class="col-sm-12">
+        <h1><strong>My Account<strong></h1>
+    </div>
+    <div class="col-sm-12">
+        <div class="breadcrumbs">
+            <span>
+                Request Company Access
+            </span>
+        </div>
     </div>
   </div>
   <div class="row">


### PR DESCRIPTION
# Description
I forgot that I was using the react-base template for the company access request page (so that I could have access to bootstrap 3). Thus, attempting to visit qc.secure.my.jobs/request-company-access results in a blank page. This fixes that.

# Testing
On this branch, you should see that visiting /request-company-access actually shows up now. I also added a proper header and breadcrumb div. Furthermore, the real react apps should still function (/reports/view/dynamicreporting, /manage-users, /prm/view/nonuseroutreach). No tests written  as it's all template work.