### PR TITLE
[PD-2314] Feature Enable Forms

### DIFF
--- a/default_settings.py
+++ b/default_settings.py
@@ -669,3 +669,7 @@ ENV_URL_PREFIXES = ['qc', 'staging']
 
 # See template tag js_bundle for details.
 WEBPACK_DEV_SERVER_BASE_URL = None
+
+AJAX_LOOKUP_CHANNELS = {
+    'companies': ('seo.lookups', 'CompaniesLookup')
+}

--- a/dseo_urls.py
+++ b/dseo_urls.py
@@ -9,8 +9,6 @@ from seo.views.settings_views import secure_redirect
 from registration import views as registration_views
 from ajax_select import urls as ajax_select_urls
 
-import seo.lookups
-
 # This is a bit of code pulled from a Django TRAC ticket describing a problem
 # I was seeing when working with the inline model forms:
 # https://code.djangoproject.com/ticket/10405#comment:11

--- a/myjobs_urls.py
+++ b/myjobs_urls.py
@@ -10,8 +10,6 @@ from myjobs.api import UserResource, SavedSearchResource
 from seo.views.search_views import BusinessUnitAdminFilter, SeoSiteAdminFilter
 from ajax_select import urls as ajax_select_urls
 
-import seo.lookups
-
 admin.autodiscover()
 
 # API Resources

--- a/postajob/forms.py
+++ b/postajob/forms.py
@@ -1,3 +1,4 @@
+from ajax_select.fields import AutoCompleteSelectField
 from authorize import AuthorizeInvalidError, AuthorizeResponseError
 from datetime import date, datetime, timedelta
 from fsm.widget import FSM
@@ -996,3 +997,31 @@ def clean_company_name(company_name, current_company):
     if company_query.exists():
         return "A company with that name already exists."
     return None
+
+
+class PostingEnableForm(forms.Form):
+    company = AutoCompleteSelectField(
+        'companies', required=True, help_text=None)
+    site = AutoCompleteSelectField(
+        'sites', required=True, help_text=None)
+
+    def __init__(self, *args, **kwargs):
+        super(MarketPlaceEnableForm, self).__init__(*args, **kwargs)
+        self.fields['company'].help_text = (
+            'The company to add MarketPlace access to.')
+        self.fields['site'].help_text = (
+            'The microsite that purchased jobs will appear on.')
+
+
+class MarketPlaceEnableForm(forms.Form):
+    company = AutoCompleteSelectField(
+        'companies', required=True, help_text=None)
+    site = AutoCompleteSelectField(
+        'sites', required=True, help_text=None)
+
+    def __init__(self, *args, **kwargs):
+        super(MarketPlaceEnableForm, self).__init__(*args, **kwargs)
+        self.fields['company'].help_text = (
+            'The company to add MarketPlace access to.')
+        self.fields['site'].help_text = (
+            'The microsite that purchased jobs will appear on.')

--- a/postajob/urls.py
+++ b/postajob/urls.py
@@ -8,6 +8,7 @@ urlpatterns = patterns(
     '',
 
     # Views for job and admin
+    url(r'^enable/$', views.enable_posting, name='enable_posting'),
     url(r'^order/',
         views.order_postajob,
         name="order_postajob"),
@@ -30,6 +31,8 @@ urlpatterns = patterns(
     # Purchased microsite management
     url(r'^admin/$', views.purchasedmicrosite_admin_overview,
         name='purchasedmicrosite_admin_overview'),
+    url(r'^admin/enable/$', views.enable_marketplace,
+        name='enable_marketplace'),
 
     # Invoices
     url(r'^admin/invoice/(?P<pk>\d+)/$', views.resend_invoice,

--- a/postajob/urls.py
+++ b/postajob/urls.py
@@ -8,7 +8,8 @@ urlpatterns = patterns(
     '',
 
     # Views for job and admin
-    url(r'^enable/$', views.enable_posting, name='enable_posting'),
+    url(r'^enable/$', views.enable_feature,
+        {'feature': 'Posting'}, name='enable_posting'),
     url(r'^order/',
         views.order_postajob,
         name="order_postajob"),
@@ -31,8 +32,8 @@ urlpatterns = patterns(
     # Purchased microsite management
     url(r'^admin/$', views.purchasedmicrosite_admin_overview,
         name='purchasedmicrosite_admin_overview'),
-    url(r'^admin/enable/$', views.enable_marketplace,
-        name='enable_marketplace'),
+    url(r'^admin/enable/$', views.enable_feature,
+        {'feature': 'MarketPlace'}, name='enable_marketplace'),
 
     # Invoices
     url(r'^admin/invoice/(?P<pk>\d+)/$', views.resend_invoice,

--- a/postajob/views.py
+++ b/postajob/views.py
@@ -27,7 +27,18 @@ from postajob.helpers import can_modify
 from universal.helpers import (get_company, get_object_or_none,
                                get_company_or_404, at_least_one)
 from universal.views import RequestFormViewBase
+from universal.decorators import restrict_to_staff
 from myjobs.decorators import requires
+
+
+@restrict_to_staff()
+def enable_posting(request):
+    pass
+
+
+@restrict_to_staff()
+def enable_marketplace(request):
+    pass
 
 
 @user_is_allowed()

--- a/postajob/views.py
+++ b/postajob/views.py
@@ -19,11 +19,12 @@ from postajob.forms import (CompanyProfileForm, JobForm, OfflinePurchaseForm,
                             OfflinePurchaseRedemptionForm, ProductForm,
                             ProductGroupingForm, PurchasedJobForm,
                             PurchasedProductForm,
-                            PurchasedProductNoPurchaseForm, JobLocationFormSet)
+                            PurchasedProductNoPurchaseForm,
+                            JobLocationFormSet, MarketPlaceEnableForm)
 from postajob.models import (CompanyProfile, Invoice, Job, OfflinePurchase,
                              Product, ProductGrouping, PurchasedJob,
                              PurchasedProduct, Request, JobLocation)
-from postajob.helpers import can_modify
+from postajob.helpers import can_modify, enable_posting, enable_marketplace
 from universal.helpers import (get_company, get_object_or_none,
                                get_company_or_404, at_least_one)
 from universal.views import RequestFormViewBase
@@ -32,13 +33,25 @@ from myjobs.decorators import requires
 
 
 @restrict_to_staff()
-def enable_posting(request):
-    pass
+def enable_feature(request, feature):
+    ctx = {'feature': feature}
+    if request.method == "POST":
+        form = MarketPlaceEnableForm(request.POST)
 
+        if form.is_valid():
+            company = form.cleaned_data['company']
+            site = form.cleaned_data['site']
+            if feature == 'Posting':
+                enable_posting(company, site)
+            elif feature == 'MarketPlace':
+                enable_marketplace(company, site)
+            ctx['message'] = 'Success'
+    else:
+        form = MarketPlaceEnableForm()
+    ctx['form'] = form
 
-@restrict_to_staff()
-def enable_marketplace(request):
-    pass
+    return render_to_response(
+        'postajob/enable_feature.html', ctx, RequestContext(request))
 
 
 @user_is_allowed()

--- a/seo/lookups.py
+++ b/seo/lookups.py
@@ -22,3 +22,16 @@ class CompaniesLookup(LookupChannel):
         warning = "" if count else " **Might be a duplicate**"
 
         return template.format(name=company.name, count=count, warning=warning)
+
+
+@register('sites')
+class SitesLookup(LookupChannel):
+    model = models.SeoSite
+    min_length = 3
+
+    def get_query(self, q, request):
+        return self.model.objects.filter(
+            domain__istartswith=q).order_by('domain')[:10]
+
+    def get_objects(self, ids):
+        return list(self.model.objects.filter(pk__in=ids))

--- a/templates/base-react.html
+++ b/templates/base-react.html
@@ -72,6 +72,7 @@
                                 {% endfor %}
                             {% endif %}
                         {% endblock%}
+                        {% block content %}
                         <div>
                             <div class="row">
                                 <div class="col-sm-12">
@@ -81,6 +82,7 @@
                         </div>
                         <div id="content"></div>
                         <div id="ajax-busy"></div>
+                        {% endblock %}
                     </div>
                     {% endblock %}
                 {% endblock %}

--- a/templates/myjobs/request_company_access.html
+++ b/templates/myjobs/request_company_access.html
@@ -6,8 +6,15 @@
 
 {% block content %}
   <div class="row">
-    <div class="col-md-12">
-      <h1>Request Company Access</h1>
+    <div class="col-sm-12">
+        <h1><strong>My Account<strong></h1>
+    </div>
+    <div class="col-sm-12">
+        <div class="breadcrumbs">
+            <span>
+                Request Company Access
+            </span>
+        </div>
     </div>
   </div>
   <div class="row">

--- a/templates/postajob/enable_feature.html
+++ b/templates/postajob/enable_feature.html
@@ -1,18 +1,22 @@
 {% extends "base-react.html" %}
 {% load i18n %}
+{% load static %}
 
 {% block meta-extra %}
+<script src="{% static 'ajax_select/js/bootstrap.js' %}"></script>
+<script src="{% static 'ajax_select/js/ajax_select.js' %}"></script>
+<link rel="stylesheet" type="text/css" href="{% static 'ajax_select/css/ajax_select.css' %}">
 {% endblock meta-extra %}
 
 {% block content %}
   <div class="row">
     <div class="col-sm-12">
-        <h1><strong>My Account<strong></h1>
+        <h1><strong>Company Management<strong></h1>
     </div>
     <div class="col-sm-12">
         <div class="breadcrumbs">
             <span>
-                Request Company Access
+              Enable {{ feature }}
             </span>
         </div>
     </div>
@@ -24,7 +28,7 @@
         {% include 'includes/form-error-highlight-bs3.html' %}
         <div class="actions row">
           <div class="col-md-offset-4 col-md-8 col-xs-12 text-center">
-            <input type="submit" class="button primary" value="Request Access">
+            <input type="submit" class="button primary" value="Enable">
           </div>
         </div>
       </form>
@@ -32,26 +36,17 @@
     <div class="col-md-4 col-xs-12">
       <div class="sidebar">
         <h2 class="top">Tips</h2>
-        Don't forget to write down your access code once it's generated.
+        The MarketPlace feature requires users to have correct permissions
+        enabled. Be sure to educate the member.
       </div>
     </div>
   </div>
-  {% if access_code %}
+  {% if message %}
     <div class="row">
       <div class="col-md-8 col-xs-12">
         <p class="text-left">
-          Your request has been submitted. A representative will be in contact 
-          with your company shortly.
+          {{ feature }} access has been successfully enabled!
         </p>
-        <p>
-          Please write down the following code. You will need it to verify your
-          request. <strong>This is the only time this code is displayed.</strong>
-        </p>
-      </div>
-      <div class="row">
-        <div class="col-md-offset-3 col-md-3 col-xs-12">
-          <p class="text-center" id="auth-code">{{ access_code }}</p>
-        </div>
       </div>
     </div>
   {% endif %}


### PR DESCRIPTION
For most applications, it's easy enough to simply make sure the application is added to the list of enabled app-level access in the company admin. For postajob, things are a bit more involved. In the past, I've written a pair of functions meant to automate the simplest case for enabling posting or marketplace. This work takes it another level by exposing the functionality of those functions as forms. They can be found at /posting/enable and /posting/admin/enable, respectively. They aren't centrally located or in the admin as to make them less tempting to abuse. Once there is a staff-facing SPA, they'll probably be incorporated (in function, not form...no pun intended).

