### PR TITLE
[PD-2264] Adapt Old Report Preview to New Reporting

### DIFF
--- a/gulp/src/reporting/DynamicReportApp.jsx
+++ b/gulp/src/reporting/DynamicReportApp.jsx
@@ -32,6 +32,7 @@ export class DynamicReportApp extends Component {
 
   render() {
     const {reportList} = this.state;
+    const {reportId} = this.props.params;
 
     return (
       <div>
@@ -49,7 +50,9 @@ export class DynamicReportApp extends Component {
             {this.props.children}
           </div>
           <div className="col-xs-6 col-md-4">
-            <ReportList reports={reportList}/>
+            <ReportList
+              reports={reportList}
+              highlightId={Number.parseInt(reportId, 10)}/>
           </div>
         </div>
       </div>
@@ -60,4 +63,7 @@ export class DynamicReportApp extends Component {
 DynamicReportApp.propTypes = {
   reportFinder: PropTypes.object.isRequired,
   children: PropTypes.node,
+  params: PropTypes.shape({
+    reportId: PropTypes.any,
+  }).isRequired,
 };

--- a/gulp/src/reporting/OldPreviewEmbed.jsx
+++ b/gulp/src/reporting/OldPreviewEmbed.jsx
@@ -1,0 +1,26 @@
+/* global renderGraphs */
+import React, {PropTypes, Component} from 'react';
+import warning from 'warning';
+
+
+export default class OldPreviewEmbed extends Component {
+  componentDidMount() {
+    const {reportId, reportName} = this.props.params;
+    renderGraphs(reportId, reportName);
+  }
+
+  render() {
+    return <div id="main-container"/>;
+  }
+}
+
+OldPreviewEmbed.propTypes = {
+  params: PropTypes.shape({
+    reportId: PropTypes.string.isRequired,
+    reportName: PropTypes.string.isRequired,
+  }).isRequired,
+};
+
+warning(typeof(renderGraphs) !== 'undefined',
+  'Imported OldPreviewEmbed but can\'t find global renderGraphs. ' +
+  'Did we forget to include reporting.js?');

--- a/gulp/src/reporting/OldPreviewEmbed.jsx
+++ b/gulp/src/reporting/OldPreviewEmbed.jsx
@@ -1,26 +1,85 @@
-/* global renderGraphs */
+/* global renderGraphs, renderViewContact, renderViewPartner */
 import React, {PropTypes, Component} from 'react';
 import warning from 'warning';
+import {isEqual} from 'lodash-compat/lang';
 
 
 export default class OldPreviewEmbed extends Component {
   componentDidMount() {
-    const {reportId, reportName} = this.props.params;
-    renderGraphs(reportId, reportName);
+    this.runJQueryRender();
+  }
+
+  shouldComponentUpdate(newProps) {
+    const shouldUpdate =
+      !isEqual(this.getPropComparison(this.props),
+        this.getPropComparison(newProps));
+    return shouldUpdate;
+  }
+
+  componentDidUpdate() {
+    this.runJQueryRender();
+  }
+
+  getPropComparison(props) {
+    return {
+      reportId: props.reportId,
+      reportName: props.reportName,
+      reportType: props.reportType,
+    };
+  }
+
+  runJQueryRender() {
+    const {reportId, reportName, reportType, onLoading} = this.props;
+    const oldPreviewUrl = '/reports/api/old_report_preview';
+
+    if (reportType === 'communication-records') {
+      onLoading(true);
+      renderGraphs(
+        reportId,
+        reportName,
+        () => {onLoading(false);},
+        oldPreviewUrl);
+    } else if (reportType === 'contacts') {
+      renderViewContact(reportId, reportName, oldPreviewUrl);
+      onLoading(false);
+    } else if (reportType === 'partners') {
+      renderViewPartner(reportId, reportName, oldPreviewUrl);
+      onLoading(false);
+    }
   }
 
   render() {
-    return <div id="main-container"/>;
+    return (
+      <div>
+        <div id="main-container"/>
+      </div>
+    );
   }
 }
 
 OldPreviewEmbed.propTypes = {
-  params: PropTypes.shape({
-    reportId: PropTypes.string.isRequired,
-    reportName: PropTypes.string.isRequired,
-  }).isRequired,
+  /**
+   * Name of the report being previewed
+   */
+  reportName: PropTypes.string.isRequired,
+  /**
+   * Report type being previewed.
+   */
+  reportType: PropTypes.string.isRequired,
+  /**
+   * Id of report being previewed.
+   */
+  reportId: PropTypes.string.isRequired,
+  /**
+   * Called when the loading state of the previewed report changes.
+   * This is only used for communication record reports.
+   */
+  onLoading: PropTypes.func.isRequired,
 };
 
 warning(typeof(renderGraphs) !== 'undefined',
   'Imported OldPreviewEmbed but can\'t find global renderGraphs. ' +
   'Did we forget to include reporting.js?');
+
+// Disable the old reporting history mechanism.
+window.onpopstate = () => {};

--- a/gulp/src/reporting/OldPreviewEmbed.jsx
+++ b/gulp/src/reporting/OldPreviewEmbed.jsx
@@ -4,7 +4,13 @@ import warning from 'warning';
 import {isEqual} from 'lodash-compat/lang';
 
 
+/**
+ * Actually embed the jQuery report preview.
+ */
 export default class OldPreviewEmbed extends Component {
+  // It is important not to keep any state in this component.
+  // Making ajax calls from componentDidUpdate and updating state leads
+  // to loading loops.
   componentDidMount() {
     this.runJQueryRender();
   }
@@ -50,9 +56,7 @@ export default class OldPreviewEmbed extends Component {
 
   render() {
     return (
-      <div>
-        <div id="main-container"/>
-      </div>
+      <div id="main-container"/>
     );
   }
 }

--- a/gulp/src/reporting/OldPreviewEmbedPage.jsx
+++ b/gulp/src/reporting/OldPreviewEmbedPage.jsx
@@ -1,0 +1,60 @@
+import React, {PropTypes, Component} from 'react';
+import OldPreviewEmbed from './OldPreviewEmbed';
+import {Loading} from 'common/ui/Loading';
+
+
+/**
+ * Page handling React components pertaining to the old report preview.
+ *
+ * Handle simple React components and loading state here.
+ */
+export default class OldPreviewEmbedPage extends Component {
+  constructor() {
+    super();
+    this.state = {
+      loading: true,
+    };
+  }
+
+  onLoading(loading) {
+    this.setState({loading});
+  }
+
+  render() {
+    const {reportId} = this.props.params;
+    const {reportName, reportType} = this.props.location.query;
+    const {loading} = this.state;
+    return (
+      <div>
+        {loading ? <Loading/> : ''}
+        <OldPreviewEmbed
+          reportId={reportId}
+          reportName={reportName}
+          reportType={reportType}
+          onLoading={(l) => this.onLoading(l)}
+          />
+      </div>
+    );
+  }
+}
+
+OldPreviewEmbedPage.propTypes = {
+  location: PropTypes.shape({
+    query: PropTypes.shape({
+      /**
+       * Name of the report being previewed
+       */
+      reportName: PropTypes.string.isRequired,
+      /**
+       * Report type being previewed.
+       */
+      reportType: PropTypes.string.isRequired,
+    }),
+  }),
+  params: PropTypes.shape({
+    /**
+     * Id of report being previewed.
+     */
+    reportId: PropTypes.string.isRequired,
+  }).isRequired,
+};

--- a/gulp/src/reporting/ReportList.jsx
+++ b/gulp/src/reporting/ReportList.jsx
@@ -3,16 +3,21 @@ import {Link} from 'react-router';
 import {map} from 'lodash-compat';
 
 export function ReportList(props) {
-  const {reports} = props;
+  const {reports, highlightId} = props;
   const reportLinks = map(reports, r =>
-    <li key={r.id}>
+    <li
+      className={highlightId === r.id ? 'active' : ''}
+      key={r.id}>
       <Link to={'/export/' + r.id}>{r.name}</Link>
+      {" "}
       <Link
         to={'/preview/' + r.id}
         query={{
           reportName: r.name,
           reportType: r.report_type,
         }}>[preview]</Link>
+      {" "}
+      <Link to={'/export/' + r.id}>[export]</Link>
     </li>
   );
 
@@ -20,7 +25,12 @@ export function ReportList(props) {
     <div>
       <div className="sidebar">
         <h2 className="top">Reports</h2>
-        {reportLinks}
+        <ul>
+          <li>
+            <Link to="/set-up-report">Create new report...</Link>
+          </li>
+          {reportLinks}
+        </ul>
       </div>
     </div>
   );
@@ -34,4 +44,5 @@ ReportList.propTypes = {
       report_type: PropTypes.string.isRequired,
     }),
   ).isRequired,
+  highlightId: PropTypes.number,
 };

--- a/gulp/src/reporting/ReportList.jsx
+++ b/gulp/src/reporting/ReportList.jsx
@@ -1,14 +1,18 @@
 import React, {PropTypes} from 'react';
 import {Link} from 'react-router';
+import {map} from 'lodash-compat';
 
 export function ReportList(props) {
-  const reportData = props.reports.map(report => ({
-    id: report.id,
-    name: report.name,
-  }));
-  const reportLinks = reportData.map(r =>
+  const {reports} = props;
+  const reportLinks = map(reports, r =>
     <li key={r.id}>
       <Link to={'/export/' + r.id}>{r.name}</Link>
+      <Link
+        to={'/preview/' + r.id}
+        query={{
+          reportName: r.name,
+          reportType: r.report_type,
+        }}>[preview]</Link>
     </li>
   );
 
@@ -23,5 +27,11 @@ export function ReportList(props) {
 }
 
 ReportList.propTypes = {
-  reports: PropTypes.arrayOf(PropTypes.object).isRequired,
+  reports: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.number.isRequired,
+      name: PropTypes.string.isRequired,
+      report_type: PropTypes.string.isRequired,
+    }),
+  ).isRequired,
 };

--- a/gulp/src/reporting/WizardRouter.jsx
+++ b/gulp/src/reporting/WizardRouter.jsx
@@ -3,6 +3,7 @@ import {Router, Route, IndexRedirect} from 'react-router';
 import {DynamicReportApp} from 'reporting/DynamicReportApp';
 import SetUpReport from 'reporting/SetUpReport';
 import ExportReport from 'reporting/ExportReport';
+import OldPreviewEmbed from 'reporting/OldPreviewEmbed';
 
 export class WizardRouter extends Component {
   createElement(TheComponent, componentProps) {
@@ -23,6 +24,9 @@ export class WizardRouter extends Component {
           <Route
             path="export/:reportId"
             component={ExportReport}/>
+          <Route
+            path="preview/:reportId/:reportName"
+            component={OldPreviewEmbed}/>
         </Route>
       </Router>
     );

--- a/gulp/src/reporting/WizardRouter.jsx
+++ b/gulp/src/reporting/WizardRouter.jsx
@@ -3,7 +3,7 @@ import {Router, Route, IndexRedirect} from 'react-router';
 import {DynamicReportApp} from 'reporting/DynamicReportApp';
 import SetUpReport from 'reporting/SetUpReport';
 import ExportReport from 'reporting/ExportReport';
-import OldPreviewEmbed from 'reporting/OldPreviewEmbed';
+import OldPreviewEmbedPage from 'reporting/OldPreviewEmbedPage';
 
 export class WizardRouter extends Component {
   createElement(TheComponent, componentProps) {
@@ -25,8 +25,8 @@ export class WizardRouter extends Component {
             path="export/:reportId"
             component={ExportReport}/>
           <Route
-            path="preview/:reportId/:reportName"
-            component={OldPreviewEmbed}/>
+            path="preview/:reportId"
+            component={OldPreviewEmbedPage}/>
         </Route>
       </Router>
     );

--- a/myreports/tests/test_views.py
+++ b/myreports/tests/test_views.py
@@ -617,7 +617,11 @@ class TestDynamicReports(MyReportsTestCase):
         self.assertEqual(200, resp.status_code)
         self.assertEqual(
             {'reports': [
-                {'id': report_id, 'name': 'The Report'},
+                {
+                    'id': report_id,
+                    'name': 'The Report',
+                    'report_type': 'contacts'
+                },
             ]},
             json.loads(resp.content))
 
@@ -664,7 +668,11 @@ class TestDynamicReports(MyReportsTestCase):
         self.assertEqual(200, resp.status_code)
         self.assertEqual(
             {'reports': [
-                {'id': report_id, 'name': 'The Report'},
+                {
+                    'id': report_id,
+                    'name': 'The Report',
+                    'report_type': 'partners'
+                },
             ]},
             json.loads(resp.content))
 
@@ -714,7 +722,11 @@ class TestDynamicReports(MyReportsTestCase):
         self.assertEqual(200, resp.status_code)
         self.assertEqual(
             {'reports': [
-                {'id': report_id, 'name': 'The Report'},
+                {
+                    'id': report_id,
+                    'name': 'The Report',
+                    'report_type': 'communication-records'
+                },
             ]},
             json.loads(resp.content))
 
@@ -809,7 +821,11 @@ class TestDynamicReports(MyReportsTestCase):
         self.assertEqual(200, resp.status_code)
         self.assertEqual(
             {'reports': [
-                {'id': report_id, 'name': 'The Report'},
+                {
+                    'id': report_id,
+                    'name': 'The Report',
+                    'report_type': 'contacts'
+                },
             ]},
             json.loads(resp.content))
 
@@ -854,7 +870,11 @@ class TestDynamicReports(MyReportsTestCase):
         self.assertEqual(200, resp.status_code)
         self.assertEqual(
             {'reports': [
-                {'id': report_id, 'name': 'The Report'},
+                {
+                    'id': report_id,
+                    'name': 'The Report',
+                    'report_type': 'contacts'
+                },
             ]},
             json.loads(resp.content))
 
@@ -921,7 +941,11 @@ class TestDynamicReports(MyReportsTestCase):
         self.assertEqual(200, resp.status_code)
         self.assertEqual(
             {'reports': [
-                {'id': report_id, 'name': 'The Report'},
+                {
+                    'id': report_id,
+                    'name': 'The Report',
+                    'report_type': 'partners'
+                },
             ]},
             json.loads(resp.content))
 

--- a/myreports/urls.py
+++ b/myreports/urls.py
@@ -27,4 +27,6 @@ urlpatterns = patterns(
     url(r'^api/help$', 'help_api', name='help_api'),
     url(r'^api/default_report_name$', 'get_default_report_name',
         name='get_default_report_name'),
+    url(r'^api/old_report_preview$', 'old_report_preview',
+        name='old_report_preview')
 )

--- a/static/reporting.js
+++ b/static/reporting.js
@@ -1712,7 +1712,7 @@ function renderDownload(report_id) {
 }
 
 
-function renderGraphs(report_id, reportName, callback) {
+function renderGraphs(report_id, reportName, callback, overrideUrl) {
   var data = {'id': report_id},
       url = location.protocol + "//" + location.host; // https://secure.my.jobs
 
@@ -1720,7 +1720,7 @@ function renderGraphs(report_id, reportName, callback) {
 
   $.ajax({
     type: "GET",
-    url: url + "/reports/view/mypartners/contactrecord",
+    url: url + (overrideUrl ? overrideUrl : "/reports/view/mypartners/contactrecord"),
     data: data,
     success: function(data) {
       var contacts = data.contacts,
@@ -1921,13 +1921,13 @@ function renderGraphs(report_id, reportName, callback) {
 }
 
 
-function renderViewPartner(id, name) {
+function renderViewPartner(id, name, overrideUrl) {
   var data = {id: id},
       url = location.protocol + "//" + location.host; // https://secure.my.jobs
 
   $.ajax({
     type: "GET",
-    url: url + "/reports/view/mypartners/partner",
+    url: url + (overrideUrl ? overrideUrl : "/reports/view/mypartners/partner"),
     data: data,
     success: function(data) {
       var $span = $('<div class="span12"><h2>' + name + '</h2></div>'),
@@ -1948,13 +1948,13 @@ function renderViewPartner(id, name) {
 }
 
 
-function renderViewContact(id, name) {
+function renderViewContact(id, name, overrideUrl) {
    var data = {id: id},
       url = location.protocol + "//" + location.host; // https://secure.my.jobs
 
   $.ajax({
     type: "GET",
-    url: url + "/reports/view/mypartners/contact",
+    url: url + (overrideUrl ? overrideUrl : "/reports/view/mypartners/contact"),
     data: data,
     success: function(data) {
       var $span = $('<div class="span12"><h2>' + name + '</h2></div>'),
@@ -1967,10 +1967,15 @@ function renderViewContact(id, name) {
       // Append content to Table's tbody.
       $tbody.append('<tr class="record">' + data.map(function(record) {
         // Create a list of States based off of locations
-        // in a format of City, State
+        // in a format of City, State, or objects shaped like
+        // {city: '', state: ''}
         location = record.locations.map(function(location) {
             // for each location get state and trim whitespace
-            return (location.split(',')[1] || '').trim();
+            if (typeof(location) === 'string') {
+                return (location.split(',')[1] || '').trim();
+            } else if (typeof(location) === 'object') {
+                return location.state.trim();
+            }
             // Determine uniqueness
           }).sort().filter(function(e, i, a) {
             // Due to sort, duplicates will be together.

--- a/templates/myreports/dynamicreports.html
+++ b/templates/myreports/dynamicreports.html
@@ -18,6 +18,7 @@
     <script>
     spinnerImg = "{% static "images/ajax-loader.gif" %}";
     </script>
+    <script type="text/javascript" src="{% static "reporting.js" %}"></script>
 
 {% if wp_base_url %}
   <script src="{{wp_base_url}}/reporting.js"/></script>


### PR DESCRIPTION
With help from @aspidites and @JLMcLaugh this has come together more quickly than expected. Thank you.

## Test

1. Run a report
2. Click the preview link in the report list bar.
3. The current report should be highlighted in the preview and export screens.

The navigation works differently between the old and new systems. i.e. The report list bar has all the nav now.

## Review

**Guidance requested:** If `pd-2192--implement-tags-control` were merged this would be ready to review for merge. I'd like to get some early feedback to streamline merging this.

Most of the ugly hackery is in the new component `OldPreviewEmbed.jsx`. I've made minimal changes to `reporting.js` to support using the new api and rendering slightly differently shaped data.

As far as I can tell the preview numbers exactly match the numbers coming from the old system provided you are running the same query. The default query in the new system may not always match the default query in the old system. We may need a ticket for that?

