### PR TITLE
[PD-2297] Reporting Export Screen

### DIFF
--- a/gulp/npm-shrinkwrap.json
+++ b/gulp/npm-shrinkwrap.json
@@ -1458,6 +1458,9 @@
     "react-prop-types": {
       "version": "0.3.0"
     },
+    "react-reorder": {
+      "version": "2.0.0"
+    },
     "react-router": {
       "version": "1.0.3"
     },

--- a/gulp/package.json
+++ b/gulp/package.json
@@ -38,6 +38,7 @@
     "react-bootstrap": "^0.28.0",
     "react-dom": "^0.14.3",
     "react-filtered-multiselect": "^0.4.2",
+    "react-reorder": "^2.0.0",
     "react-router": "^1.0.0",
     "tinycolor2": "~1.3.0",
     "warning": "^2.1.0",

--- a/gulp/src/reporting/ExportReport.jsx
+++ b/gulp/src/reporting/ExportReport.jsx
@@ -194,7 +194,6 @@ export default class ExportReport extends Component {
         </div>
         <div className="row actions text-center">
           <div className="col-md-offset-4 col-md-8 col-xs-12">
-            <button className="button">Cancel</button>
             <a
               className="button primary"
               href={this.buildExportHref()}>Export</a>

--- a/gulp/src/reporting/SortableField.jsx
+++ b/gulp/src/reporting/SortableField.jsx
@@ -1,0 +1,60 @@
+import React, {Component, PropTypes} from 'react';
+
+class SortableField extends Component {
+  constructor(props) {
+    super(props);
+  }
+
+  render() {
+    const {sharedProps, item} = this.props;
+    // Using a raw input since we need special event handling.
+    // The stop in onMouseDown prevents the event from reaching the reorder
+    // widget and being a candidate for the beginning of a drag operation.
+    return (
+      <div className="sortable-report-field">
+        <label htmlFor={item.value}>
+        <input
+          type="checkbox"
+          name={item.value}
+          id={item.value}
+          className=""
+          onChange={sharedProps.onChange}
+          onMouseDown={e => {e.stopPropagation();}}
+          checked={item.checked}/>
+        {item.display}</label>
+      </div>
+    );
+  }
+}
+
+SortableField.propTypes = {
+  /**
+   * Value and display text combined. React Reorder only gives us a single
+   * property so we bundle what we want under it.
+   */
+  item: PropTypes.shape({
+    /**
+     * Display text for this item.
+     */
+    display: PropTypes.string.isRequired,
+    /**
+     * Value this item represents.
+     */
+    value: PropTypes.string.isRequired,
+    /**
+     * Is this box checked?
+     */
+    checked: PropTypes.bool.isRequired,
+  }),
+  /**
+   * Properties shared by all children of React Reorder.
+   */
+  sharedProps: PropTypes.shape({
+    /**
+     * Used to signal a check/uncheck event.
+     */
+    onChange: PropTypes.func.isRequired,
+  }),
+};
+
+export default SortableField;

--- a/gulp/src/reporting/api.js
+++ b/gulp/src/reporting/api.js
@@ -35,9 +35,8 @@ class Api {
   }
 
   async getExportOptions(reportId) {
-    const response = await this.getFromReportingApi(
+    return await this.getFromReportingApi(
       '/reports/api/export_options_api?report_id=' + reportId);
-    return response.report_options;
   }
 
   async getDefaultReportName(reportDataId) {

--- a/myreports/helpers.py
+++ b/myreports/helpers.py
@@ -138,3 +138,24 @@ def determine_user_type(user):
 
     if user.is_staff:
         return 'STAFF'
+
+
+def compare_records(order_by):
+    """Compare two dynamic reporting records by the given field."""
+    def do_compare(a, b):
+        field_a = a.get(order_by)
+        field_b = b.get(order_by)
+        return cmp(field_a, field_b)
+    return do_compare
+
+
+def sort_records(records, order_by, reverse):
+    """Sort dynamic reporting records by the given field.
+
+    records: records to sort
+    order_by: name of field
+    reverse: True for ascending, False for desending
+
+    returns: a new set of records, sorted.
+    """
+    return sorted(records, compare_records(order_by), reverse=reverse)

--- a/myreports/report_configuration.py
+++ b/myreports/report_configuration.py
@@ -19,11 +19,33 @@ class ReportConfiguration(object):
         """Return a list of column names which will appear in the report."""
         return [c.column for c in self.columns]
 
-    def format_record(self, raw_data):
+    def format_record(self, raw_data, values):
         """Return a flat fully formatted dictionary of report data."""
+        if len(values) == 0:
+            columns = self.columns
+        else:
+            columns = [
+                c
+                for c in [
+                    self.find_column(v)
+                    for v in values
+                ]
+                if c is not None
+            ]
+
         return dict(
             (c.column, c.extract_formatted(raw_data))
-            for c in self.columns)
+            for c in columns)
+
+    def find_column(self, column_name):
+        """Find a particular column by name.
+
+        returns None if the column is not found.
+        """
+        for column in self.columns:
+            if column.column == column_name:
+                return column
+        return None
 
 
 @dict_identity

--- a/myreports/tests/test_helpers.py
+++ b/myreports/tests/test_helpers.py
@@ -3,13 +3,15 @@
 import csv
 import json
 from cStringIO import StringIO
+from unittest import TestCase
 
 from myjobs.tests.factories import UserFactory
 from mypartners.tests.factories import ContactRecordFactory, TagFactory
 from mypartners.models import ContactRecord
 from myreports.tests.test_views import MyReportsTestCase
 from myreports import helpers
-from myreports.helpers import determine_user_type
+from myreports.helpers import (
+    determine_user_type, compare_records, sort_records)
 
 
 class TestHelpers(MyReportsTestCase):
@@ -156,3 +158,29 @@ class TestUserType(MyReportsTestCase):
         """Handle details of determining and checking user_type."""
         self.assertEqual(expected,
                          determine_user_type(user))
+
+
+class TestSorting(TestCase):
+    """Test dynamic reports sorting utilities."""
+    def test_compare(self):
+        """Compare dynamic report records by different fields."""
+        a = {'d': 1, 'e': 2}
+        b = {'d': 2, 'e': 1}
+
+        self.assertEqual(-1, compare_records('d')(a, b))
+        self.assertEqual(0, compare_records('d')(a, a))
+        self.assertEqual(1, compare_records('d')(b, a))
+
+        self.assertEqual(1, compare_records('e')(a, b))
+        self.assertEqual(0, compare_records('e')(a, a))
+        self.assertEqual(-1, compare_records('e')(b, a))
+
+    def test_sort(self):
+        """Sort dynamic records by different fields."""
+        a = {'d': 1, 'e': 2}
+        b = {'d': 2, 'e': 1}
+
+        self.assertEqual([a, a, b], sort_records([a, a, b], 'd', False))
+        self.assertEqual([b, a, a], sort_records([a, a, b], 'd', True))
+        self.assertEqual([b, a, a], sort_records([a, a, b], 'e', False))
+        self.assertEqual([a, a, b], sort_records([a, a, b], 'e', True))

--- a/myreports/tests/test_report_configuration.py
+++ b/myreports/tests/test_report_configuration.py
@@ -86,7 +86,7 @@ class TestReportConfig(TestCase):
     def test_records(self):
         """Test that records are formatted properly."""
         self.maxDiff = 10000
-        rec = self.contacts_config.format_record(self.test_data[0])
+        rec = self.contacts_config.format_record(self.test_data[0], [])
         self.assertEqual({
             'name': 'john adams',
             'partner': 'aaa',
@@ -97,7 +97,7 @@ class TestReportConfig(TestCase):
             'locations': "Indianapolis, IN, Chicago, IL",
             'tags': 'east',
             }, rec)
-        rec = self.contacts_config.format_record(self.test_data[1])
+        rec = self.contacts_config.format_record(self.test_data[1], [])
         self.assertEqual({
             'name': 'Sue Baxter',
             'partner': 'bbb',
@@ -107,6 +107,28 @@ class TestReportConfig(TestCase):
             'notes': '',
             'locations': 'Los Angeles, CA',
             'tags': 'west',
+            }, rec)
+
+    def test_formatting_limit_columns(self):
+        """Test that records contain only desired columns."""
+        self.maxDiff = 10000
+        rec = self.contacts_config.format_record(
+            self.test_data[0],
+            ['partner', 'name'])
+        self.assertEqual({
+            'name': 'john adams',
+            'partner': 'aaa',
+            }, rec)
+
+    def test_formatting_ignores_invalid_columns(self):
+        """Test that records contain only desired and valid columns."""
+        self.maxDiff = 10000
+        rec = self.contacts_config.format_record(
+            self.test_data[0],
+            ['partner', 'name', 'ZZZZZ'])
+        self.assertEqual({
+            'name': 'john adams',
+            'partner': 'aaa',
             }, rec)
 
 

--- a/myreports/views.py
+++ b/myreports/views.py
@@ -11,10 +11,11 @@ from django.utils.decorators import method_decorator
 from django.views.generic import View
 from django.views.decorators.http import require_http_methods
 
-from myreports.helpers import humanize, serialize
+from myreports.helpers import humanize, serialize, sort_records
 from myjobs.decorators import requires
 from myreports.models import (
-    Report, ReportPresentation, DynamicReport, ReportTypeDataTypes)
+    Report, ReportPresentation, DynamicReport, ReportTypeDataTypes,
+    ConfigurationColumn)
 from myreports.presentation import presentation_drivers
 from myreports.presentation.disposition import get_content_disposition
 from postajob import location_data
@@ -456,6 +457,31 @@ def select_data_type_api(request):
 @requires('read partner', 'read contact', 'read communication record')
 @require_http_methods(['GET'])
 def export_options_api(request):
+    """Get options and defaults, etc. needed to drive a UI for downloads.
+
+    Parameters:
+        :report_id: Id of the report to download
+
+    Outputs an object shaped like this:
+        {
+            'count': number of records in the report,
+            'report_options': {
+                'id': the report id,
+                'formats': [
+                    {
+                        'value': format key,
+                        'display': user visible title for format,
+                    },
+                ],
+                'values': [
+                    {
+                        'value': key describing an available column,
+                        'display': user visible title of column,
+                    },
+                ],
+            },
+        }
+    """
     validator = ApiValidator()
 
     report_id = request.GET.get('report_id')
@@ -473,16 +499,27 @@ def export_options_api(request):
         return validator.build_error_response()
 
     report = report_list[0]
+    count = len(report.python)
     rps = (ReportPresentation.objects
            .active_for_report_type_data_type(report.report_data))
 
+    cols = (
+        ConfigurationColumn.objects
+        .active_for_report_data(report.report_data))
+    values = [
+        {'value': c.column_name, 'display': c.column_name}
+        for c in cols
+    ]
+
     data = {
+        'count': count,
         'report_options': {
             'id': report.id,
             'formats': [
                 {'value': rp.id, 'display': rp.display_name}
                 for rp in rps
             ],
+            'values': values,
         },
     }
     return HttpResponse(content_type='application/json',
@@ -606,24 +643,26 @@ def list_dynamic_reports(request):
 @require_http_methods(['GET'])
 def download_dynamic_report(request):
     """
-    Download dynamic report as CSV.
+    Download dynamic report in some format.
 
     Query String Parameters:
-        :id: ID of the report to download
-        :values: Fields to include in the resulting CSV, as well as the order
+        :id: ID of the report to export
+        :values: Fields to include in the data, as well as the order
                  in which to include them.
-        :order_by: The sort order for the resulting CSV.
+        :order_by: The the field to sort the records by
+        :direction: 'ascending' or 'decescending', for sort order
         :report_presentation_id: id of report presentation to use for file
                                  format.
 
     Outputs:
-        The report with the specified options rendered as a CSV file.
+        The report with the specified options rendered in the desired format.
     """
 
     # SECURITY: check report_id vs company owner!!!
     report_id = request.GET.get('id', 0)
-    values = request.GET.getlist('values', None)
+    values = request.GET.getlist('values')
     order_by = request.GET.get('order_by')
+    order_direction = request.GET.get('direction', 'ascending')
     report_presentation_id = request.GET.get('report_presentation_id')
 
     report = get_object_or_404(DynamicReport, pk=report_id)
@@ -636,8 +675,20 @@ def download_dynamic_report(request):
         report.order_by = order_by
         report.save()
 
-    values = report_configuration.get_header()
-    records = [report_configuration.format_record(r) for r in report.python]
+    if len(values) == 0:
+        values = report_configuration.get_header()
+
+    records = [
+        report_configuration.format_record(r, values)
+        for r in report.python
+    ]
+
+    sorted_records = records
+    if order_by:
+        reverse = False
+        if order_direction == 'descending':
+            reverse = True
+        sorted_records = sort_records(records, order_by, reverse)
 
     presentation_driver = (
         report_presentation.presentation_type.presentation_type)
@@ -649,7 +700,7 @@ def download_dynamic_report(request):
     response['Content-Disposition'] = disposition
 
     output = StringIO()
-    presentation.write_presentation(values, records, output)
+    presentation.write_presentation(values, sorted_records, output)
     response.write(output.getvalue())
 
     return response

--- a/static/custom.css
+++ b/static/custom.css
@@ -3216,18 +3216,25 @@ fieldset:nth-child(n+2) {
     margin-top: 20px;
 }
 
+.row .col-md-8 label {
+    margin-top: 5px;
+    font-weight: normal;
+}
+
 .row .col-md-4 label {
     color: #676767;
     font-size: 10pt;
     text-align: left;
     display: block;
     line-height: normal;
+    margin-top: 0;
 }
 
 @media screen and (min-width: 768px){
     .row .col-md-4 label {
         line-height: 33px;
         text-align: right;
+        font-weight: normal;
     }
 }
 
@@ -3277,6 +3284,11 @@ fieldset:nth-child(n+2) {
 
 .row .col-md-8 ul li label {
     font-weight: normal;
+}
+
+.row .col-md-8 label input[type='checkbox'] {
+    height: inherit;
+    margin-right: 10px;
 }
 
 .row .col-md-8 select {
@@ -3339,8 +3351,11 @@ height: 33px;
     margin-right: 10px;
 }
 
-.actions.row .col-md-8 .button:hover {
+.actions.row .col-md-8 .button:hover,
+.actions.row .col-md-8 .button:active,
+.actions.row .col-md-8 .button:focus {
     color: #444545;
+    text-decoration: none;
 }
 
 .actions.row .col-md-8 .button.primary {
@@ -3469,6 +3484,47 @@ legend.fieldset-border {
 }
 
 /* End Select Element React Component Styles */
+
+/* Export Page Styles */
+#export-page #record-count {
+  text-align: center;
+}
+
+.list-item {
+  border-radius: 3px;
+  margin-bottom: 5px;
+  padding: 0 5px;
+  cursor: pointer;
+  -webkit-touch-callout: none; /* iOS Safari */
+  -webkit-user-select: none;   /* Chrome/Safari/Opera */
+  -khtml-user-select: none;    /* Konqueror */
+  -moz-user-select: none;      /* Firefox */
+  -ms-user-select: none;       /* IE/Edge */
+  user-select: none;           /* non-prefixed version, currently */
+}
+
+.list-item label {
+  cursor: pointer;
+  width: 100%;
+}
+
+.list-item:hover {
+  background-color: #C6D6EA;
+}
+
+.list-item.dragged {
+  background-color: #EEE;
+  opacity: 0.7;
+}
+
+.list-item.placeholder {
+  background-color: #CCC;
+}
+
+.list-item.placeholder .sortable-report-field {
+  visibility: hidden;
+}
+/* End Export Page Styles */
 
 input[type='checkbox'] + .help-block {
     display:inline;


### PR DESCRIPTION
**Guidance Requested:** I'm putting this out early in hopes of streamlining the merge later. Please review it as if it were presented for merge.

**Note:** I don't recall every talking about where in the data models we put user visible names for columns *as they appear in the report*. Do we need a new ticket for that?

## Test:

1. Run a report.
2. Export it. Behold the new export options screen.
3. Play with the options to look for problems. Everything should work. It should look and behave as designed by @misterjonscott.

