### PR TITLE
Autofocus on keyword field of partner search forms [PD-1487]

### DIFF
--- a/templates/mypartners/includes/partner_sidebar.html
+++ b/templates/mypartners/includes/partner_sidebar.html
@@ -3,7 +3,7 @@
     <div class="partner-filters">
         <h2 class="top">Filter Partners</h2>
         <label>Keywords:</label>
-        <input id="lib-keywords" type="text" placeholder="Keywords" {% if request.GET.keywords %}value="{{request.GET.keywords}}"{% endif %} />
+        <input id="lib-keywords" type="text" placeholder="Keywords" autofocus="autofocus" {% if request.GET.keywords %}value="{{request.GET.keywords}}"{% endif %} />
         <label>State:</label>
         {% include "includes/state_dropdown.html" %}
         <label>City:</label>


### PR DESCRIPTION
This form is used on both the initial PRM view that allows you to search your current partners as well as the view that allows searching for new OFCCP partners.