### PR TITLE
[PD-2330] Updated the City State Component

### DIFF
--- a/gulp/src/common/states.js
+++ b/gulp/src/common/states.js
@@ -1,0 +1,243 @@
+// Just a convenient array of states adapted from jsondata/usa_regions.json.
+export const states = [
+  {
+    'value': 'AL',
+    'display': 'Alabama',
+  },
+  {
+    'value': 'AK',
+    'display': 'Alaska',
+  },
+  {
+    'value': 'AS',
+    'display': 'American Samoa',
+  },
+  {
+    'value': 'AZ',
+    'display': 'Arizona',
+  },
+  {
+    'value': 'AR',
+    'display': 'Arkansas',
+  },
+  {
+    'value': 'CA',
+    'display': 'California',
+  },
+  {
+    'value': 'CO',
+    'display': 'Colorado',
+  },
+  {
+    'value': 'CT',
+    'display': 'Connecticut',
+  },
+  {
+    'value': 'DE',
+    'display': 'Delaware',
+  },
+  {
+    'value': 'DC',
+    'display': 'District of Columbia',
+  },
+  {
+    'value': 'FL',
+    'display': 'Florida',
+  },
+  {
+    'value': 'GA',
+    'display': 'Georgia',
+  },
+  {
+    'value': 'GU',
+    'display': 'Guam',
+  },
+  {
+    'value': 'HI',
+    'display': 'Hawaii',
+  },
+  {
+    'value': 'ID',
+    'display': 'Idaho',
+  },
+  {
+    'value': 'IL',
+    'display': 'Illinois',
+  },
+  {
+    'value': 'IN',
+    'display': 'Indiana',
+  },
+  {
+    'value': 'IA',
+    'display': 'Iowa',
+  },
+  {
+    'value': 'KS',
+    'display': 'Kansas',
+  },
+  {
+    'value': 'KY',
+    'display': 'Kentucky',
+  },
+  {
+    'value': 'LA',
+    'display': 'Louisiana',
+  },
+  {
+    'value': 'ME',
+    'display': 'Maine',
+  },
+  {
+    'value': 'MD',
+    'display': 'Maryland',
+  },
+  {
+    'value': 'MA',
+    'display': 'Massachusetts',
+  },
+  {
+    'value': 'MI',
+    'display': 'Michigan',
+  },
+  {
+    'value': 'MS',
+    'display': 'Mississippi',
+  },
+  {
+    'value': 'MN',
+    'display': 'Minnesota',
+  },
+  {
+    'value': 'MO',
+    'display': 'Missouri',
+  },
+  {
+    'value': 'MT',
+    'display': 'Montana',
+  },
+  {
+    'value': 'NE',
+    'display': 'Nebraska',
+  },
+  {
+    'value': 'NV',
+    'display': 'Nevada',
+  },
+  {
+    'value': 'NH',
+    'display': 'New Hampshire',
+  },
+  {
+    'value': 'NJ',
+    'display': 'New Jersey',
+  },
+  {
+    'value': 'NM',
+    'display': 'New Mexico',
+  },
+  {
+    'value': 'NY',
+    'display': 'New York',
+  },
+  {
+    'value': 'NC',
+    'display': 'North Carolina',
+  },
+  {
+    'value': 'ND',
+    'display': 'North Dakota',
+  },
+  {
+    'value': 'MP',
+    'display': 'Northern Mariana Islands',
+  },
+  {
+    'value': 'OH',
+    'display': 'Ohio',
+  },
+  {
+    'value': 'OK',
+    'display': 'Oklahoma',
+  },
+  {
+    'value': 'OR',
+    'display': 'Oregon',
+  },
+  {
+    'value': 'PA',
+    'display': 'Pennsylvania',
+  },
+  {
+    'value': 'PR',
+    'display': 'Puerto Rico',
+  },
+  {
+    'value': 'RI',
+    'display': 'Rhode Island',
+  },
+  {
+    'value': 'SC',
+    'display': 'South Carolina',
+  },
+  {
+    'value': 'SD',
+    'display': 'South Dakota',
+  },
+  {
+    'value': 'TN',
+    'display': 'Tennessee',
+  },
+  {
+    'value': 'TX',
+    'display': 'Texas',
+  },
+  {
+    'value': 'UM',
+    'display': 'United States Minor Outlying Islands',
+  },
+  {
+    'value': 'UT',
+    'display': 'Utah',
+  },
+  {
+    'value': 'VT',
+    'display': 'Vermont',
+  },
+  {
+    'value': 'VA',
+    'display': 'Virginia',
+  },
+  {
+    'value': 'VI',
+    'display': 'Virgin Islands',
+  },
+  {
+    'value': 'WA',
+    'display': 'Washington',
+  },
+  {
+    'value': 'WV',
+    'display': 'West Virginia',
+  },
+  {
+    'value': 'WI',
+    'display': 'Wisconsin',
+  },
+  {
+    'value': 'WY',
+    'display': 'Wyoming',
+  },
+  {
+    'value': 'AA',
+    'display': 'Armed Forces Americas',
+  },
+  {
+    'value': 'AP',
+    'display': 'Armed Forces Pacific',
+  },
+  {
+    'value': 'AE',
+    'display': 'Armed Forces Others',
+  },
+];

--- a/gulp/src/reporting/SetUpReport.jsx
+++ b/gulp/src/reporting/SetUpReport.jsx
@@ -39,7 +39,6 @@ export default class SetUpReport extends Component {
     const {reportFinder} = this.props;
     reportFinder.unsubscribeToMenuChoices(this.menuCallbackRef);
   }
-
   onIntentionChange(reportingType) {
     const {reportType, dataType} = this.state;
     this.buildReportConfig(reportingType, reportType, dataType);

--- a/gulp/src/reporting/wizard/WizardFilterCityState.jsx
+++ b/gulp/src/reporting/wizard/WizardFilterCityState.jsx
@@ -9,6 +9,7 @@ export class WizardFilterCityState extends Component {
     constructor() {
       super();
       this.state = {
+        // list of states to choose from
         states: [
           {
             display: 'Select a State',
@@ -16,6 +17,7 @@ export class WizardFilterCityState extends Component {
           },
           ...states,
         ],
+        // currently selected city and state, used to filter results
         currentLocation: {
           city: '',
           state: '',
@@ -28,7 +30,7 @@ export class WizardFilterCityState extends Component {
 
       // Update parent
       const {currentLocation} = this.state;
-      currentLocation[field] = value.key;
+      currentLocation[field] = value;
       updateFilter(currentLocation);
 
       // Set internal state
@@ -37,14 +39,12 @@ export class WizardFilterCityState extends Component {
 
     render() {
       const {id, getHints} = this.props;
-      const createValue = value => {
-        return {key: value, value: value};
-      };
+
       return (
         <span>
           <Select
             onChange={e =>
-              this.updateField('state', createValue(e.target.value))}
+              this.updateField('state', e.target.value)}
             name=""
             value={
               getDisplayForValue(
@@ -56,7 +56,7 @@ export class WizardFilterCityState extends Component {
             callSelectWhenEmpty
             placeholder="city"
             onSelect={v =>
-              this.updateField('city', v)}
+              this.updateField('city', v.key)}
             getHints={v =>
               getHints('city', v)}
           />

--- a/gulp/src/reporting/wizard/WizardFilterCityState.jsx
+++ b/gulp/src/reporting/wizard/WizardFilterCityState.jsx
@@ -5,21 +5,24 @@ import {SearchInput} from 'common/ui/SearchInput';
 export class WizardFilterCityState extends Component {
     constructor() {
       super();
-      this.state = {city: '', state: ''};
+      this.state = {
+        currentLocation: {
+          city: '',
+          state: '',
+        },
+      };
     }
 
     updateField(field, value) {
       const {updateFilter} = this.props;
 
       // Update parent
-      const newFilter = {...this.state};
-      newFilter[field] = value.key;
-      updateFilter(newFilter);
+      const {currentLocation} = this.state;
+      currentLocation[field] = value.key;
+      updateFilter(currentLocation);
 
       // Set internal state
-      const newState = {};
-      newState[field] = value.key;
-      this.setState(newState);
+      this.setState(...this.state, currentLocation);
     }
 
     render() {

--- a/gulp/src/reporting/wizard/WizardFilterCityState.jsx
+++ b/gulp/src/reporting/wizard/WizardFilterCityState.jsx
@@ -1,11 +1,21 @@
 import React, {PropTypes, Component} from 'react';
+import Select from 'common/ui/Select';
 import {SearchInput} from 'common/ui/SearchInput';
+import {getDisplayForValue} from 'common/array';
+import {states} from 'common/states';
 
 
 export class WizardFilterCityState extends Component {
     constructor() {
       super();
       this.state = {
+        states: [
+          {
+            display: 'Select a State',
+            value: '',
+          },
+          ...states,
+        ],
         currentLocation: {
           city: '',
           state: '',
@@ -27,8 +37,20 @@ export class WizardFilterCityState extends Component {
 
     render() {
       const {id, getHints} = this.props;
+      const createValue = value => {
+        return {key: value, value: value};
+      };
       return (
         <span>
+          <Select
+            onChange={e =>
+              this.updateField('state', createValue(e.target.value))}
+            name=""
+            value={
+              getDisplayForValue(
+                this.state.states, this.state.currentLocation.state)}
+            choices={this.state.states}
+          />
           <SearchInput
             id={id + '-city'}
             callSelectWhenEmpty
@@ -36,15 +58,8 @@ export class WizardFilterCityState extends Component {
             onSelect={v =>
               this.updateField('city', v)}
             getHints={v =>
-              getHints('city', v)}/>
-          <SearchInput
-            id={id + '-state'}
-            callSelectWhenEmpty
-            placeholder="state"
-            onSelect={v =>
-              this.updateField('state', v)}
-            getHints={v =>
-              getHints('state', v)}/>
+              getHints('city', v)}
+          />
         </span>
       );
     }


### PR DESCRIPTION
# Differences
- state is before city
- state is now a select rather than a search input
- states are now displayed in long form, rather than their abbreviation
- all states are shown, rather than only those that have records associated with them [1]

# Known Issues
- You can't quickly select an option by partially typing it's name as you can with native selects. Not addressed as it affects all select components, not just this one.
- If you switch between reports, the state selection (and perhaps city, not sure) are persistent. That's how it worked before, so I didn't change it.

# Before
![2016-04-22-152904_572x86_scrot](https://cloud.githubusercontent.com/assets/93686/14752726/fb60af88-089e-11e6-86be-eea172173599.png)

# After
![2016-04-22-120119_587x106_scrot](https://cloud.githubusercontent.com/assets/93686/14747395/f006a2cc-0881-11e6-8658-9c5c40b9898c.png)

[1] Filtering by available states would have been much more work, as it would have required a callback for when such a change should occur, the triggering of that callback on load in addition to when city is changed, and a few other things. 