### PR TITLE
[PD-2346] Made sure app access was being checked first.

### DIFF
--- a/postajob/views.py
+++ b/postajob/views.py
@@ -173,6 +173,9 @@ def purchasedjobs_overview(request, purchased_product, admin):
 @user_is_allowed()
 def purchasedmicrosite_admin_overview(request):
     company = settings.SITE.canonical_company
+    if 'MarketPlace' not in company.enabled_access:
+        raise Http404('%s does not have MarketPlace access.' % company)
+
     has_access = request.user.can(company, 'read product', 'read request',
                                   'read offline purchase',
                                   'read purchased product', 'read grouping',


### PR DESCRIPTION
While QCing this issue, @fezick  noticed that a page that should have been 404ing was 403ing instead. That corrects that.

# Testing (microsite, not secure.my.jobs)
- head to /posting/admin : you should see a 404 if the company doesn't have marketplace access
- head to /posting/admin/enable : fill out the form with whatever you want
- head to /posting/admin again : you should see a 403, unless you're an admin for the company, in which case you should see an unrestricted page