### PR TITLE
[PD-2323] Only add roles, no kill-and-fill.

### DIFF
--- a/myjobs/tests/test_manage_users.py
+++ b/myjobs/tests/test_manage_users.py
@@ -482,6 +482,23 @@ class ManageUsersTests(MyJobsBase):
         self.assertEqual(output["message"],
                          "User created. Invitation email sent.")
 
+    def test_create_user_keeps_roles(self):
+        """
+        Regression test. When attempting to add a user who already exists, that
+        users existing roles would be overwritten. Instead, they should be
+        added to.
+
+        """
+        self.user.roles = [self.role]
+        self.assertItemsEqual(self.user.roles.all(), [self.role])
+        role = RoleFactory(name='Test Role', company=self.company)
+        data = {
+            'user_email': self.user.email,
+            'assigned_roles[]': [role.name]
+        }
+        self.client.post(reverse('api_create_user'), data)
+        self.assertItemsEqual(self.user.roles.all(), [self.role, role])
+
     def test_add_role_to_existing_user(self):
         """
         Tests adding a role to an existing user

--- a/myjobs/views.py
+++ b/myjobs/views.py
@@ -1133,6 +1133,7 @@ def api_create_user(request):
 
     Returns:
     :success:                   boolean
+
     """
     ctx = {'success': 'true'}
 
@@ -1160,9 +1161,7 @@ def api_create_user(request):
         # Does user already exist?
         if user:
             existing_roles = set(user.roles.filter(company=company))
-
-            # Update the user's roles, overwriting those for "company"
-            user.roles = user.roles.exclude(company=company) | new_roles
+            user.roles.add(*new_roles)
 
             ctx["message"] = "User already exists. Role invitation email sent."
         else:


### PR DESCRIPTION
Without this, creating a user with an email address that already exists would override preexisting roles (which we want for edit, but not create). 

Long term, we'll probably want to disallow creating an existing user, but for now, this avoids the UI changes a proper solution would have required.

To test, add yourself as a user to a company you are already a member of with a role that you don't already have. You should see that you have that role in addition to the admin role you already had. On QC, you'll notice that you've then locked yourself out of a company instead.