### PR TITLE
[PD-2360] Removed duplicate config column for comm record reports.

### DIFF
--- a/myreports/tests/setup.py
+++ b/myreports/tests/setup.py
@@ -369,12 +369,6 @@ def create_full_fixture():
         multi_value_expansion=False)
     ConfigurationColumnFactory.create(
         column_name="job_applications",
-        order=110,
-        output_format="text",
-        configuration=con_comm,
-        multi_value_expansion=False)
-    ConfigurationColumnFactory.create(
-        column_name="job_applications",
         order=111,
         output_format="text",
         configuration=con_comm,


### PR DESCRIPTION
What the title says. No regression tests because it was never determined to be a regression. That is, I asked if duplicate column configurations should be allowed, but never received a concrete response, so left that functionality as is. Thus, if duplicates are allowed, then it's not a bug and is simply human error.