### PR TITLE
[PD-2362] Updated the way can works.

### DIFF
--- a/myjobs/decorators.py
+++ b/myjobs/decorators.py
@@ -1,12 +1,11 @@
 from functools import wraps
 
 from django.contrib.auth import logout
-from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect, HttpResponseForbidden, Http404
 from django.shortcuts import get_object_or_404
 
-from myjobs.models import User, AppAccess
+from myjobs.models import User, Activity
 from universal.helpers import (get_company_or_404, get_company, every)
 
 
@@ -118,7 +117,6 @@ class MissingActivity(HttpResponseForbidden):
     """
 
 
-# TODO: See if I can rewrite requires in terms of User.can
 def requires(*activities, **callbacks):
     """
     Protects a view by activity and app access, optionally invoking callbacks.
@@ -245,9 +243,8 @@ def requires(*activities, **callbacks):
             company = get_company_or_404(request)
 
             # the app_access we need, determined by the activities passed in
-            required_access = filter(bool, AppAccess.objects.filter(
-                activity__name__in=activities).values_list(
-                    'name', flat=True).distinct())
+            required_access = Activity.objects.filter(
+                name__in=activities).required_access
 
             # company should have at least the access required by the view
             has_access = set(required_access).issubset(company.enabled_access)

--- a/myjobs/models.py
+++ b/myjobs/models.py
@@ -5,10 +5,11 @@ import urllib
 import uuid
 
 from django.core.urlresolvers import reverse
-from django.db.models import Q, F
+from django.db.models import Q
 from django.db.models.loading import get_model
 from django.db.models.signals import pre_delete, post_save
 from django.dispatch import receiver
+from django.http import Http404
 from django.utils.crypto import get_random_string
 
 from impersonate.signals import session_begin, session_end
@@ -654,6 +655,9 @@ class User(AbstractBaseUser, PermissionsMixin):
         Output:
             A boolean signifying whether the provided actions may be performed.
 
+            If the company doesn't have sufficient app-level access, an
+            ``Http404`` exception is raised.
+
         Example:
 
             # given
@@ -686,15 +690,16 @@ class User(AbstractBaseUser, PermissionsMixin):
 
         compare = kwargs.get('compare', every)
 
-        required_access = filter(bool, AppAccess.objects.filter(
-            activity__name__in=activity_names).values_list(
-                'name', flat=True).distinct())
+        required_access = Activity.objects.filter(
+            name__in=activity_names).required_access
+
+        if not set(required_access).issubset(company.enabled_access):
+            raise Http404(
+                "%s doesn't have sufficient app-level access." % company)
 
         # Company must have correct access and user must have correct
         # activities
-        return all([
-            set(required_access).issubset(company.enabled_access),
-            compare(activity_names, self.get_activities(company))])
+        return compare(activity_names, self.get_activities(company))
 
     def send_invite(self, email, company, role_name=None):
         """
@@ -852,6 +857,41 @@ class AppAccess(models.Model):
         return self.name
 
 
+class ActivityQuerySet(models.query.QuerySet):
+    """Defines a ``required_access`` convenience property."""
+
+    @property
+    def required_access(self):
+        """
+        Returns a list of ``AppAccess`` names required by the activities in
+        the queryset.
+
+        """
+        return self.values_list('app_access__name', flat=True).distinct()
+
+
+class ActivityManager(models.Manager):
+    """
+    Proxy for ActivityQuerySet which allows chaining.
+
+    Example:
+
+        Activity.objects.filter(name__icontains='create').required_access
+
+    """
+    def __init__(self):
+        super(ActivityManager, self).__init__()
+        self._query_set = ActivityQuerySet
+
+    def get_query_set(self):
+        qs = self._query_set(self.model, using=self._db)
+        return qs
+
+    @property
+    def required_access(self):
+        return self.get_query_set().required_access
+
+
 class Activity(models.Model):
     """
     An activity represents an individual task that can be performed by a
@@ -860,6 +900,8 @@ class Activity(models.Model):
     """
     class Meta:
         verbose_name_plural = "Activities"
+
+    objects = ActivityManager()
 
     name = models.CharField(max_length=50, unique=True)
     display_name = models.CharField(max_length=50, blank=True)

--- a/myjobs/models.py
+++ b/myjobs/models.py
@@ -651,6 +651,8 @@ class User(AbstractBaseUser, PermissionsMixin):
                       False. By default, `universal.helpers.every` is used,
                       which only returns two if the two iterables contain the
                       same elements.
+            :check_access: A boolean that signifies whether app-level access
+                           should be checked. Defaults to True.
 
         Output:
             A boolean signifying whether the provided actions may be performed.
@@ -689,11 +691,13 @@ class User(AbstractBaseUser, PermissionsMixin):
             return False
 
         compare = kwargs.get('compare', every)
+        check_access = kwargs.get('check_access', True)
 
         required_access = Activity.objects.filter(
             name__in=activity_names).required_access
 
-        if not set(required_access).issubset(company.enabled_access):
+        if check_access and not set(required_access).issubset(
+                company.enabled_access):
             raise Http404(
                 "%s doesn't have sufficient app-level access." % company)
 

--- a/myjobs/templatetags/common_tags.py
+++ b/myjobs/templatetags/common_tags.py
@@ -296,7 +296,7 @@ def get_menus(context):
         ]
     } if user.roles.exists() else {}
 
-    if employer_menu and user.can(company, "read partner"):
+    if employer_menu and user.can(company, "read partner", check_access=False):
         employer_menu["submenus"] += [
             {
                 "id": "partner-tab",
@@ -310,7 +310,7 @@ def get_menus(context):
             }
         ]
 
-    if employer_menu and user.can(company, "read role"):
+    if employer_menu and user.can(company, "read role", check_access=False):
         employer_menu["submenus"].append(
             {
                 "id": "manage-users-tab",

--- a/postajob/helpers.py
+++ b/postajob/helpers.py
@@ -1,4 +1,4 @@
-from myjobs.models import AppAccess
+from myjobs.models import AppAccess, Activity
 from postajob.models import SitePackage
 from myblocks.models import (raw_base_template, Page, Row, RowOrder,
                              LoginBlock, BlockOrder)
@@ -21,14 +21,18 @@ def can_modify(user, company, kwargs, update_activity, create_activity):
         A boolean representing whether or not they had permission to perform
         the particular set of actions.
 
+        If the company doesn't have appropriate access, raises an ``Http404``
+        exception.
+
     Example::
 
         if not can_modify(user, company, kwargs, "update job", "create job"):
             return MissingActivity()
 
-        retunr HttpResponse("Success")
+        return HttpResponse("Success")
 
     """
+
     if 'pk' in kwargs:
         return user.can(company, update_activity)
     else:

--- a/postajob/views.py
+++ b/postajob/views.py
@@ -173,9 +173,6 @@ def purchasedjobs_overview(request, purchased_product, admin):
 @user_is_allowed()
 def purchasedmicrosite_admin_overview(request):
     company = settings.SITE.canonical_company
-    if 'MarketPlace' not in company.enabled_access:
-        raise Http404('%s does not have MarketPlace access.' % company)
-
     has_access = request.user.can(company, 'read product', 'read request',
                                   'read offline purchase',
                                   'read purchased product', 'read grouping',


### PR DESCRIPTION
Up until now, the `User.can` method had been checking for app access, but not responding differently based on it. The reason for this was that we had, up until postajob, been using can in conjunction with requires, which checked for app level access automatically. Furthermore, until recently, the return types in either case (insufficient app access or missing activities) was the same. This PR, does a number of things to correct this:

- I added a custom manager/queryset so that you can check for required access on an activity queryset directly (not essential, but convenient).
- attempting to call `User.can` with a company with insufficient app-level access now raises an exception (Http404)
- due to the above, the explicit 404 introduced by an earlier commit is no longer necessary
- can now accepts another optional keyword argument, `check_access` - the alternative was to riddle code with try/excepts or `if company and 'Foo' in company.enabled_access`

# Testing
Hit these URLs for a microsite which doesn't have marketplace enabled (in app access):
- http://trustmarkcompanies.jobs/posting/all/
- http://trustmarkcompanies.jobs/posting/job/add/

If you don't want to add the domain to hosts, then `?domain=trustmarkcompanies.jobs` should work as well.

In either case, you should see a 404. Once you enable "MarketPlace" (see [documentation](https://github.com/DirectEmployers/MyJobs/blob/quality-control/doc/source/developers/postajob/setup.rst#enabling-the-marketplace) if you're unfamiliar with this), you should see 403s until you enable the correct activities for your user.