### PR TITLE
[PD-2344] Reordered Report Filter Columns

### DIFF
--- a/myreports/tests/setup.py
+++ b/myreports/tests/setup.py
@@ -328,8 +328,51 @@ def create_full_fixture():
         multi_value_expansion=False)
 
     ConfigurationColumnFactory.create(
+        column_name="date_time",
+        order=100,
+        configuration=con_comm,
+        output_format="us_date",
+        filter_interface_type='date_range',
+        filter_interface_display='Date',
+        multi_value_expansion=False)
+    ConfigurationColumnFactory.create(
+        order=101,
+        column_name="locations",
+        filter_interface_type='city_state',
+        filter_interface_display='Contact Location',
+        filter_only=True,
+        configuration=con_comm,
+        multi_value_expansion=False,
+        has_help=True)
+    ConfigurationColumnFactory.create(
+        column_name="tags",
+        order=102,
+        output_format="tags_list",
+        filter_interface_type='tags',
+        filter_interface_display='Tags',
+        configuration=con_comm,
+        multi_value_expansion=False,
+        has_help=True)
+    ConfigurationColumnFactory.create(
+        column_name="communication_type",
+        order=103,
+        filter_interface_type='search_multiselect',
+        filter_interface_display='Communication Type',
+        configuration=con_comm,
+        output_format="text",
+        multi_value_expansion=False)
+    ConfigurationColumnFactory.create(
+        column_name="partner",
+        order=104,
+        output_format="text",
+        filter_interface_type='search_multiselect',
+        filter_interface_display='Partners',
+        configuration=con_comm,
+        multi_value_expansion=False,
+        has_help=True)
+    ConfigurationColumnFactory.create(
         column_name="contact",
-        order=123,
+        order=105,
         output_format="text",
         filter_interface_type='search_multiselect',
         filter_interface_display='Contacts',
@@ -338,125 +381,82 @@ def create_full_fixture():
         has_help=True)
     ConfigurationColumnFactory.create(
         column_name="contact_email",
-        order=104,
+        order=106,
         output_format="text",
         configuration=con_comm,
         multi_value_expansion=False)
     ConfigurationColumnFactory.create(
         column_name="contact_phone",
-        order=105,
-        configuration=con_comm,
-        output_format="text",
-        multi_value_expansion=False)
-    ConfigurationColumnFactory.create(
-        column_name="communication_type",
-        order=109,
-        filter_interface_type='search_multiselect',
-        filter_interface_display='Communication Type',
+        order=107,
         configuration=con_comm,
         output_format="text",
         multi_value_expansion=False)
     ConfigurationColumnFactory.create(
         column_name="created_on",
-        order=107,
+        order=108,
         configuration=con_comm,
         output_format="us_date",
         multi_value_expansion=False)
     ConfigurationColumnFactory.create(
         column_name="created_by",
-        order=108,
+        order=109,
         configuration=con_comm,
         output_format="text",
         multi_value_expansion=False)
     ConfigurationColumnFactory.create(
-        column_name="date_time",
-        order=106,
-        configuration=con_comm,
-        output_format="us_date",
-        filter_interface_type='date_range',
-        filter_interface_display='Date',
-        multi_value_expansion=False)
-    ConfigurationColumnFactory.create(
         column_name="job_applications",
-        order=111,
+        order=110,
         output_format="text",
         configuration=con_comm,
         multi_value_expansion=False)
     ConfigurationColumnFactory.create(
         column_name="job_hires",
-        order=112,
+        order=111,
         output_format="text",
         configuration=con_comm,
         multi_value_expansion=False)
     ConfigurationColumnFactory.create(
         column_name="job_id",
-        order=113,
+        order=112,
         output_format="text",
         configuration=con_comm,
         multi_value_expansion=False)
     ConfigurationColumnFactory.create(
         column_name="job_interviews",
-        order=114,
+        order=113,
         output_format="text",
         configuration=con_comm,
         multi_value_expansion=False)
     ConfigurationColumnFactory.create(
         column_name="last_action_time",
-        order=115,
+        order=114,
         output_format="us_date",
         configuration=con_comm,
         multi_value_expansion=False)
     ConfigurationColumnFactory.create(
         column_name="length",
-        order=116,
+        order=115,
         output_format="text",
         configuration=con_comm,
         multi_value_expansion=False)
     ConfigurationColumnFactory.create(
         column_name="location",
-        order=117,
+        order=116,
         output_format="text",
         configuration=con_comm,
         multi_value_expansion=False)
     ConfigurationColumnFactory.create(
         column_name="notes",
+        order=117,
+        output_format="text",
+        configuration=con_comm,
+        multi_value_expansion=False)
+    ConfigurationColumnFactory.create(
+        column_name="subject",
         order=118,
         output_format="text",
         configuration=con_comm,
         multi_value_expansion=False)
-    ConfigurationColumnFactory.create(
-        column_name="partner",
-        order=122,
-        output_format="text",
-        filter_interface_type='search_multiselect',
-        filter_interface_display='Partners',
-        configuration=con_comm,
-        multi_value_expansion=False,
-        has_help=True)
-    ConfigurationColumnFactory.create(
-        column_name="subject",
-        order=120,
-        output_format="text",
-        configuration=con_comm,
-        multi_value_expansion=False)
-    ConfigurationColumnFactory.create(
-        column_name="tags",
-        order=121,
-        output_format="tags_list",
-        filter_interface_type='tags',
-        filter_interface_display='Tags',
-        configuration=con_comm,
-        multi_value_expansion=False,
-        has_help=True)
-    ConfigurationColumnFactory.create(
-        order=102,
-        column_name="locations",
-        filter_interface_type='city_state',
-        filter_interface_display='Contact Location',
-        filter_only=True,
-        configuration=con_comm,
-        multi_value_expansion=False,
-        has_help=True)
 
     ConfigurationColumnFactory.create(
         column_name="data_source",

--- a/myreports/tests/setup.py
+++ b/myreports/tests/setup.py
@@ -207,55 +207,16 @@ def create_full_fixture():
 
     ConfigurationColumn.objects.all().delete()
     ConfigurationColumnFactory.create(
-        column_name="dead",
-        output_format="text",
-        configuration=con_con,
-        multi_value_expansion=False,
-        is_active=False)
-    ConfigurationColumnFactory.create(
-        column_name="name",
-        order=100,
-        output_format="text",
-        configuration=con_con,
-        multi_value_expansion=False)
-    ConfigurationColumnFactory.create(
-        column_name="partner",
-        order=101,
-        output_format="text",
-        filter_interface_type='search_multiselect',
-        filter_interface_display='Partners',
-        configuration=con_con,
-        multi_value_expansion=False,
-        has_help=True)
-    ConfigurationColumnFactory.create(
-        column_name="email",
-        order=102,
-        output_format="text",
-        configuration=con_con,
-        multi_value_expansion=False)
-    ConfigurationColumnFactory.create(
-        column_name="phone",
-        order=103,
-        output_format="text",
-        configuration=con_con,
-        multi_value_expansion=False)
-    ConfigurationColumnFactory.create(
         column_name="date",
-        order=104,
+        order=100,
         configuration=con_con,
         output_format="us_date",
         filter_interface_type='date_range',
         filter_interface_display='Date',
         multi_value_expansion=False)
     ConfigurationColumnFactory.create(
-        column_name="notes",
-        order=105,
-        output_format="text",
-        configuration=con_con,
-        multi_value_expansion=False)
-    ConfigurationColumnFactory.create(
         column_name="locations",
-        order=106,
+        order=101,
         output_format="city_state_list",
         filter_interface_type='city_state',
         filter_interface_display='Location',
@@ -264,73 +225,57 @@ def create_full_fixture():
         has_help=True)
     ConfigurationColumnFactory.create(
         column_name="tags",
-        order=107,
+        order=102,
         output_format="tags_list",
         filter_interface_type='tags',
         filter_interface_display='Tags',
         configuration=con_con,
         multi_value_expansion=False,
         has_help=True)
-
     ConfigurationColumnFactory.create(
-        column_name="data_source",
+        column_name="partner",
         order=103,
         output_format="text",
-        filter_interface_type='search_select',
-        filter_interface_display='Data Source',
-        configuration=con_part,
-        multi_value_expansion=False)
+        filter_interface_type='search_multiselect',
+        filter_interface_display='Partners',
+        configuration=con_con,
+        multi_value_expansion=False,
+        has_help=True)
+    ConfigurationColumnFactory.create(
+        column_name="dead",
+        output_format="text",
+        configuration=con_con,
+        multi_value_expansion=False,
+        is_active=False)
     ConfigurationColumnFactory.create(
         column_name="name",
         order=104,
         output_format="text",
-        configuration=con_part,
+        configuration=con_con,
         multi_value_expansion=False)
     ConfigurationColumnFactory.create(
+        column_name="email",
         order=105,
-        column_name="locations",
-        filter_interface_type='city_state',
-        filter_interface_display='Contact Location',
-        filter_only=True,
-        configuration=con_part,
-        multi_value_expansion=False,
-        has_help=True)
-    ConfigurationColumnFactory.create(
-        column_name="date",
-        order=106,
-        configuration=con_part,
-        output_format="us_date",
-        filter_interface_type='date_range',
-        filter_interface_display='Date',
+        output_format="text",
+        configuration=con_con,
         multi_value_expansion=False)
     ConfigurationColumnFactory.create(
-        column_name="primary_contact",
+        column_name="phone",
+        order=106,
+        output_format="text",
+        configuration=con_con,
+        multi_value_expansion=False)
+    ConfigurationColumnFactory.create(
+        column_name="notes",
         order=107,
         output_format="text",
-        configuration=con_part,
-        multi_value_expansion=False)
-    ConfigurationColumnFactory.create(
-        column_name="tags",
-        order=108,
-        output_format="tags_list",
-        filter_interface_type='tags',
-        filter_interface_display='Tags',
-        configuration=con_part,
-        multi_value_expansion=False,
-        has_help=True)
-    ConfigurationColumnFactory.create(
-        column_name="uri",
-        order=109,
-        output_format="text",
-        filter_interface_type='search_select',
-        filter_interface_display='URL',
-        configuration=con_part,
+        configuration=con_con,
         multi_value_expansion=False)
 
     ConfigurationColumnFactory.create(
-        column_name="date_time",
+        column_name="date",
         order=100,
-        configuration=con_comm,
+        configuration=con_part,
         output_format="us_date",
         filter_interface_type='date_range',
         filter_interface_display='Date',
@@ -341,7 +286,7 @@ def create_full_fixture():
         filter_interface_type='city_state',
         filter_interface_display='Contact Location',
         filter_only=True,
-        configuration=con_comm,
+        configuration=con_part,
         multi_value_expansion=False,
         has_help=True)
     ConfigurationColumnFactory.create(
@@ -350,12 +295,67 @@ def create_full_fixture():
         output_format="tags_list",
         filter_interface_type='tags',
         filter_interface_display='Tags',
+        configuration=con_part,
+        multi_value_expansion=False,
+        has_help=True)
+    ConfigurationColumnFactory.create(
+        column_name="uri",
+        order=103,
+        output_format="text",
+        filter_interface_type='search_select',
+        filter_interface_display='URL',
+        configuration=con_part,
+        multi_value_expansion=False)
+    ConfigurationColumnFactory.create(
+        column_name="data_source",
+        order=104,
+        output_format="text",
+        filter_interface_type='search_select',
+        filter_interface_display='Data Source',
+        configuration=con_part,
+        multi_value_expansion=False)
+    ConfigurationColumnFactory.create(
+        column_name="name",
+        order=105,
+        output_format="text",
+        configuration=con_part,
+        multi_value_expansion=False)
+    ConfigurationColumnFactory.create(
+        column_name="primary_contact",
+        order=106,
+        output_format="text",
+        configuration=con_part,
+        multi_value_expansion=False)
+
+    ConfigurationColumnFactory.create(
+        column_name="date_time",
+        order=107,
+        configuration=con_comm,
+        output_format="us_date",
+        filter_interface_type='date_range',
+        filter_interface_display='Date',
+        multi_value_expansion=False)
+    ConfigurationColumnFactory.create(
+        order=108,
+        column_name="locations",
+        filter_interface_type='city_state',
+        filter_interface_display='Contact Location',
+        filter_only=True,
+        configuration=con_comm,
+        multi_value_expansion=False,
+        has_help=True)
+    ConfigurationColumnFactory.create(
+        column_name="tags",
+        order=109,
+        output_format="tags_list",
+        filter_interface_type='tags',
+        filter_interface_display='Tags',
         configuration=con_comm,
         multi_value_expansion=False,
         has_help=True)
     ConfigurationColumnFactory.create(
         column_name="communication_type",
-        order=103,
+        order=110,
         filter_interface_type='search_multiselect',
         filter_interface_display='Communication Type',
         configuration=con_comm,
@@ -363,7 +363,7 @@ def create_full_fixture():
         multi_value_expansion=False)
     ConfigurationColumnFactory.create(
         column_name="partner",
-        order=104,
+        order=111,
         output_format="text",
         filter_interface_type='search_multiselect',
         filter_interface_display='Partners',
@@ -372,7 +372,7 @@ def create_full_fixture():
         has_help=True)
     ConfigurationColumnFactory.create(
         column_name="contact",
-        order=105,
+        order=112,
         output_format="text",
         filter_interface_type='search_multiselect',
         filter_interface_display='Contacts',
@@ -381,79 +381,79 @@ def create_full_fixture():
         has_help=True)
     ConfigurationColumnFactory.create(
         column_name="contact_email",
-        order=106,
-        output_format="text",
-        configuration=con_comm,
-        multi_value_expansion=False)
-    ConfigurationColumnFactory.create(
-        column_name="contact_phone",
-        order=107,
-        configuration=con_comm,
-        output_format="text",
-        multi_value_expansion=False)
-    ConfigurationColumnFactory.create(
-        column_name="created_on",
-        order=108,
-        configuration=con_comm,
-        output_format="us_date",
-        multi_value_expansion=False)
-    ConfigurationColumnFactory.create(
-        column_name="created_by",
-        order=109,
-        configuration=con_comm,
-        output_format="text",
-        multi_value_expansion=False)
-    ConfigurationColumnFactory.create(
-        column_name="job_applications",
-        order=110,
-        output_format="text",
-        configuration=con_comm,
-        multi_value_expansion=False)
-    ConfigurationColumnFactory.create(
-        column_name="job_hires",
-        order=111,
-        output_format="text",
-        configuration=con_comm,
-        multi_value_expansion=False)
-    ConfigurationColumnFactory.create(
-        column_name="job_id",
-        order=112,
-        output_format="text",
-        configuration=con_comm,
-        multi_value_expansion=False)
-    ConfigurationColumnFactory.create(
-        column_name="job_interviews",
         order=113,
         output_format="text",
         configuration=con_comm,
         multi_value_expansion=False)
     ConfigurationColumnFactory.create(
-        column_name="last_action_time",
+        column_name="contact_phone",
         order=114,
-        output_format="us_date",
         configuration=con_comm,
+        output_format="text",
         multi_value_expansion=False)
     ConfigurationColumnFactory.create(
-        column_name="length",
+        column_name="created_on",
         order=115,
-        output_format="text",
         configuration=con_comm,
+        output_format="us_date",
         multi_value_expansion=False)
     ConfigurationColumnFactory.create(
-        column_name="location",
+        column_name="created_by",
         order=116,
-        output_format="text",
         configuration=con_comm,
+        output_format="text",
         multi_value_expansion=False)
     ConfigurationColumnFactory.create(
-        column_name="notes",
+        column_name="job_applications",
         order=117,
         output_format="text",
         configuration=con_comm,
         multi_value_expansion=False)
     ConfigurationColumnFactory.create(
-        column_name="subject",
+        column_name="job_hires",
         order=118,
+        output_format="text",
+        configuration=con_comm,
+        multi_value_expansion=False)
+    ConfigurationColumnFactory.create(
+        column_name="job_id",
+        order=119,
+        output_format="text",
+        configuration=con_comm,
+        multi_value_expansion=False)
+    ConfigurationColumnFactory.create(
+        column_name="job_interviews",
+        order=120,
+        output_format="text",
+        configuration=con_comm,
+        multi_value_expansion=False)
+    ConfigurationColumnFactory.create(
+        column_name="last_action_time",
+        order=121,
+        output_format="us_date",
+        configuration=con_comm,
+        multi_value_expansion=False)
+    ConfigurationColumnFactory.create(
+        column_name="length",
+        order=122,
+        output_format="text",
+        configuration=con_comm,
+        multi_value_expansion=False)
+    ConfigurationColumnFactory.create(
+        column_name="location",
+        order=123,
+        output_format="text",
+        configuration=con_comm,
+        multi_value_expansion=False)
+    ConfigurationColumnFactory.create(
+        column_name="notes",
+        order=124,
+        output_format="text",
+        configuration=con_comm,
+        multi_value_expansion=False)
+    ConfigurationColumnFactory.create(
+        column_name="subject",
+        order=125,
         output_format="text",
         configuration=con_comm,
         multi_value_expansion=False)

--- a/myreports/tests/test_models.py
+++ b/myreports/tests/test_models.py
@@ -270,34 +270,16 @@ class TestReportConfiguration(MyReportsTestCase):
         expected_config = ReportConfiguration(
             columns=[
                 ColumnConfiguration(
-                    column='name',
-                    format='text'),
+                    column='date',
+                    format='us_date',
+                    filter_interface='date_range',
+                    filter_display='Date'),
                 ColumnConfiguration(
                     column='',
                     format=None,
                     help=True,
                     filter_interface=u'city_state',
                     filter_display=u'Contact Location'),
-                ColumnConfiguration(
-                    column='partner',
-                    format='text',
-                    filter_interface='search_multiselect',
-                    filter_display='Partners',
-                    help=True),
-                ColumnConfiguration(
-                    column='email',
-                    format='text'),
-                ColumnConfiguration(
-                    column='phone',
-                    format='text'),
-                ColumnConfiguration(
-                    column='date',
-                    format='us_date',
-                    filter_interface='date_range',
-                    filter_display='Date'),
-                ColumnConfiguration(
-                    column='notes',
-                    format='text'),
                 ColumnConfiguration(
                     column='locations',
                     format='city_state_list',
@@ -310,6 +292,24 @@ class TestReportConfiguration(MyReportsTestCase):
                     filter_interface='tags',
                     filter_display='Tags',
                     help=True),
+                ColumnConfiguration(
+                    column='partner',
+                    format='text',
+                    filter_interface='search_multiselect',
+                    filter_display='Partners',
+                    help=True),
+                ColumnConfiguration(
+                    column='name',
+                    format='text'),
+                ColumnConfiguration(
+                    column='email',
+                    format='text'),
+                ColumnConfiguration(
+                    column='phone',
+                    format='text'),
+                ColumnConfiguration(
+                    column='notes',
+                    format='text'),
             ])
         config_model = self.dynamic_models['configuration']['contacts']
         # Add a filter_only column.


### PR DESCRIPTION
Reordered columns in each report to match the following (per @fezick's feedback): 

Communication Records Report

-     Report Name
-     Start Date
-     End Date
-     State
-     City
-     Tags
-     Communication Type
-     Partners
-     Contacts

Partner Report

-     Report Name
-     Start Date
-     End Date
-     Tags
-     URL
-     Partner Source

Contacts Report

-     Report Name
-     Start Date
-     End Date
-     State
-     City
-     Tags
-     Partners

