### PR TITLE
[PD-2352] Changed Data Source to Source

### DIFF
--- a/myreports/tests/setup.py
+++ b/myreports/tests/setup.py
@@ -277,7 +277,7 @@ def create_full_fixture():
         order=103,
         output_format="text",
         filter_interface_type='search_select',
-        filter_interface_display='Data Source',
+        filter_interface_display='Source',
         configuration=con_part,
         multi_value_expansion=False)
     ConfigurationColumnFactory.create(
@@ -463,7 +463,7 @@ def create_full_fixture():
         order=103,
         output_format="text",
         filter_interface_type='search_select',
-        filter_interface_display='Data Source',
+        filter_interface_display='Source',
         configuration=con_comm_count,
         multi_value_expansion=False)
     ConfigurationColumnFactory.create(


### PR DESCRIPTION
Exactly what it says. This is on the report generation page, not export.

@darrint there are a couple of tickets dedicated to fixing export names (column and values). For columns, what's the best place to change that? For values, I think you mentioned needing to come up with some other way to handle that, like some kind of format parameter or something.