### PR TITLE
PD-2322 - Cancel the tag highlight on removal

### DIFF
--- a/gulp/src/common/ui/tags/TagSelect.jsx
+++ b/gulp/src/common/ui/tags/TagSelect.jsx
@@ -58,6 +58,7 @@ export default class TagSelect extends Component {
 
   handleRemove(tag) {
     const {onRemove} = this.props;
+    this.setHighlight(tag.value, false);
     onRemove(tag);
   }
 


### PR DESCRIPTION
# What happened
I added a line to cancel the highlight of a tag, when you remove that tag, per the ticket.