### PR TITLE
Stop Masking Errors

### DIFF
--- a/myjobs/tests/setup.py
+++ b/myjobs/tests/setup.py
@@ -55,14 +55,9 @@ class TestClient(Client):
         path = path or self.path
         data = data or self.data
 
-        try:
-            return super(TestClient, self).post(
-                path, data=data, content_type=content_type,
-                secure=secure, **extra)
-        except TypeError:
-            raise Exception("Calls to TestClient's methods require that "
-                            "either path be passed explicit, or the "
-                            "path be specified in the constructor")
+        return super(TestClient, self).post(
+            path, data=data, content_type=content_type,
+            secure=secure, **extra)
 
     def login_user(self, user):
         if 'django.contrib.sessions' not in settings.INSTALLED_APPS:


### PR DESCRIPTION
When I first wrote this bit of functionality, I was hoping to raise more meaningful errors when the method was called improperly. Ironically, it had the opposite effect, masking useful errors during development.

Thanks to @tdphillips  for reminding me how bad of an idea this is. Sorry to @koonsies for dev making life more difficult.