### PR TITLE
Update makefile to push all needed files.

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -182,7 +182,7 @@ ghpages: html
 	git checkout quality-control; \
 	cd .. && \
 	touch doc/build/html/.nojekyll && \
-	git add doc/build/html/.nojekyll && \
+	git add doc/build/html/ && \
 	git commit -am "Added .nojekyll" && \
 	git subtree split --prefix doc/build/html -b gh-pages && \
 	git push origin -f gh-pages:gh-pages && \


### PR DESCRIPTION
git subtree split only copies committed files.  So we need to commit everything that is generated before we commit it, not just the .nojekyll file.