### PR TITLE
Add shrinkwrap info for react-bootstrap-table.

### DIFF
--- a/gulp/npm-shrinkwrap.json
+++ b/gulp/npm-shrinkwrap.json
@@ -427,6 +427,9 @@
     "ee-first": {
       "version": "1.1.1"
     },
+    "element-class": {
+      "version": "0.2.2"
+    },
     "end-of-stream": {
       "version": "0.1.5"
     },
@@ -1441,6 +1444,9 @@
     "react-bootstrap": {
       "version": "0.28.2"
     },
+    "react-bootstrap-table": {
+      "version": "2.2.0"
+    },
     "react-dom": {
       "version": "0.14.3"
     },
@@ -1461,11 +1467,17 @@
     "react-prop-types": {
       "version": "0.3.0"
     },
+    "react-reorder": {
+      "version": "2.0.0"
+    },
     "react-router": {
       "version": "1.0.3"
     },
     "react-sortablejs": {
       "version": "1.0.0"
+    },
+    "react-toastr": {
+      "version": "2.6.1"
     },
     "read-json-sync": {
       "version": "1.1.1"

--- a/gulp/npm-shrinkwrap.json
+++ b/gulp/npm-shrinkwrap.json
@@ -1467,9 +1467,6 @@
     "react-prop-types": {
       "version": "0.3.0"
     },
-    "react-reorder": {
-      "version": "2.0.0"
-    },
     "react-router": {
       "version": "1.0.3"
     },

--- a/gulp/package.json
+++ b/gulp/package.json
@@ -40,7 +40,6 @@
     "react-dom": "^0.14.3",
     "react-filtered-multiselect": "^0.4.2",
     "react-onclickout": "^2.0.4",
-    "react-reorder": "^2.0.0",
     "react-router": "^1.0.0",
     "react-sortablejs": "^1.0.0",
     "sortablejs": "^1.4.2",


### PR DESCRIPTION
Without these shrinkwrap entries the build and many dev tasks won't work.