### PR TITLE
[PD-2383] Reporting doesn't hate Null foreign keys anymore

### DIFF
--- a/myjobs/tests/test_helpers.py
+++ b/myjobs/tests/test_helpers.py
@@ -6,6 +6,7 @@ from django.core.urlresolvers import reverse
 from setup import MyJobsBase
 from myjobs.tests.factories import UserFactory
 from myjobs.tests.test_views import TestClient
+from universal.helpers import extract_value
 
 
 class MyJobsHelpersTests(MyJobsBase):
@@ -61,3 +62,29 @@ class MyJobsHelpersTests(MyJobsBase):
         # Session expiration should be two weeks from now - comparing number
         # of days should be good enough
         self.assertEqual(session.expire_date.toordinal(), weeks.toordinal())
+
+    def test_extract_value(self):
+        """Tests that the proper values are extracted from an object."""
+
+        class Foo(object):
+            value = 'foo'
+
+
+        class Bar(object):
+            value = 'bar'
+            foo = Foo()
+
+        foo = Foo()
+        bar = Bar()
+
+        # single-level object traversal
+        self.assertEqual(extract_value(foo, 'value'), 'foo')
+        self.assertEqual(extract_value(foo, 'bar'), None)
+
+        # default values
+        self.assertEqual(extract_value(foo, 'bar', default='bar'), 'bar')
+        self.assertEqual(extract_value(foo, 'value', default='bar'), 'foo')
+
+        # multiple-level object traversal
+        self.assertEqual(extract_value(bar, 'foo', 'value'), 'foo')
+        self.assertEqual(extract_value(bar, 'foo', 'buz'), None)

--- a/myreports/datasources/comm_records.py
+++ b/myreports/datasources/comm_records.py
@@ -9,7 +9,7 @@ from myreports.datasources.util import (
     filter_date_range, extract_tags)
 from myreports.datasources.base import DataSource, DataSourceFilter
 
-from universal.helpers import dict_identity
+from universal.helpers import dict_identity, extract_value
 from mypartners.models import CONTACT_TYPE_CHOICES
 
 from django.db.models import Q
@@ -36,12 +36,12 @@ class CommRecordsDataSource(DataSource):
 
     def extract_record(self, record):
         return {
-            'contact': record.contact.name,
+            'contact': extract_value(record, 'contact', 'name'),
             'contact_email': record.contact_email,
             'contact_phone': record.contact_phone,
             'communication_type': record.contact_type,
             'created_on': record.created_on,
-            'created_by': self.extract_user_email(record.created_by),
+            'created_by': extract_value(record, 'created_by', 'email'),
             'date_time': record.date_time,
             'job_applications': record.job_applications,
             'job_hires': record.job_hires,
@@ -51,16 +51,10 @@ class CommRecordsDataSource(DataSource):
             'length': record.length,
             'location': record.location,
             'notes': record.notes,
-            'partner': record.partner.name,
+            'partner': extract_value(record, 'partner', 'name'),
             'subject': record.subject,
             'tags': extract_tags(record.tags.all()),
         }
-
-    def extract_user_email(self, user):
-        if user:
-            return user.email
-        else:
-            return None
 
     def filter_type(self):
         return CommRecordsFilter

--- a/myreports/datasources/contacts.py
+++ b/myreports/datasources/contacts.py
@@ -8,7 +8,7 @@ from myreports.datasources.base import DataSource, DataSourceFilter
 
 from mypartners.models import Contact, Location, Tag, Partner, Status
 
-from universal.helpers import dict_identity
+from universal.helpers import dict_identity, extract_value
 
 from django.db.models import Q
 
@@ -90,7 +90,7 @@ class ContactsDataSource(DataSource):
         """Translate from a query set record to a dictionary."""
         return {
             'name': record.name,
-            'partner': record.partner.name,
+            'partner': extract_value(record, 'partner', 'name'),
             'email': record.email,
             'phone': record.phone,
             'notes': record.notes,

--- a/universal/helpers.py
+++ b/universal/helpers.py
@@ -513,5 +513,44 @@ def autofocus_input(form, field_name=None):
 
 
 def extract_value(obj, *attrs, **kwargs):
+    """
+    Traverse a value following named attributes.
+
+    Inputs:
+        :obj: The object to traverse for attributes.
+        :attrs: Each positional argument is assumed to be the name of an
+        attribute to access on the attribute which preceded it, or the object
+        passed in if no attribute preceded it.
+        :kwargs: The only recognized keyword argument is ``default``, which is
+        the value returned if, after traversal, no matching attribute is found.
+        If not specified, default is assumed to be ``None``.
+
+    Output:
+        Returns the value of the final attribute requested or default when such
+        an attribute doesn't exist.
+
+    Examples:
+        >>> class Foo(object):
+        ...    x = 7
+        ...    y = 3
+
+
+        >>> class Bar(object):
+        ...    foo = Foo()
+        ...    x = 9
+        ...    y = 4
+
+        >>> foo = Foo()
+        >>> bar = Bar()
+        >>> print extract_value(foo, 'x')
+        7
+        extract_value(foo, 'z')
+        None
+        extract_value(bar, 'foo', 'y')
+        3
+        extract_value(bar, 'y', 'q', default=8)
+        8
+
+    """
     default = kwargs.get('default', None)
     return reduce(lambda acc, x: getattr(acc, x, default), attrs, obj)

--- a/universal/helpers.py
+++ b/universal/helpers.py
@@ -514,4 +514,4 @@ def autofocus_input(form, field_name=None):
 
 def extract_value(obj, *attrs, **kwargs):
     default = kwargs.get('default', None)
-    return reduce(lambda acc, x: getattr(acc, x, default), attrs)
+    return reduce(lambda acc, x: getattr(acc, x, default), attrs, obj)

--- a/universal/helpers.py
+++ b/universal/helpers.py
@@ -510,3 +510,8 @@ def autofocus_input(form, field_name=None):
         # field attribute which we can use to set autofocus.
         field = visible_fields[0].field
     field.widget.attrs.update({'autofocus': 'autofocus'})
+
+
+def extract_value(obj, *attrs, **kwargs):
+    default = kwargs.get('default', None)
+    return reduce(lambda acc, x: getattr(acc, x, default), attrs)


### PR DESCRIPTION
Basically, I wrote a generic function which folds over an object to grab an attribute or a default if such an attribute does not exist. See the documentation for usage examples. Testing this will require having access to broken data, or breaking your data. I had a recent DB dump that I grabbed from Jenkins, which included such broken data. Once it's on QC, testing will be a matter of running a communication record for DirectEmployers Association and noting that there is now output, where before, all we had were column names. 

