### PR TITLE
[PD-1971] fix bug

### DIFF
--- a/gulp/src/myprofile/main.jsx
+++ b/gulp/src/myprofile/main.jsx
@@ -253,7 +253,7 @@ class Module extends React.Component {
           let month;
           let day;
           // If date value is empty use today's date
-          if ((!formContents[item]) || (formContents[item] === '')) {
+          if ((!apiResponse.data[item]) || (apiResponse.data[item] === '')) {
             const now = new Date();
             year = now.getFullYear();
             // month and day must both be two characters


### PR DESCRIPTION
Another simple fix.

If a date field is empty, it defaults to today. I was checking the wrong thing, so it was always "empty" and therefor always defaulting to today (and overwriting data).