### PR TITLE
Miscellaneous Reporting Fixes

### DIFF
--- a/gulp/src/reporting/ExportReport.jsx
+++ b/gulp/src/reporting/ExportReport.jsx
@@ -94,7 +94,7 @@ export default class ExportReport extends Component {
     const options = await reportFinder.getExportOptions(reportId);
 
     const fields = options.report_options.values;
-    const sortBy = get(fields, '[0].display');
+    const sortBy = get(fields, '[0].value');
     const fieldsSelected = map(fields, o =>
       ({...o, checked: true}));
 
@@ -121,7 +121,7 @@ export default class ExportReport extends Component {
       fieldsSelected,
     } = this.state;
     const baseUri = '/reports/view/dynamicdownload';
-
+    const orderBy = {...find(fieldsSelected, f => f.value === sortBy)}.display;
     const values = map(
         filter(fieldsSelected, f => f.checked),
         f => `&values=${f.value}`).join('');
@@ -130,7 +130,7 @@ export default class ExportReport extends Component {
       baseUri
       + `?id=${reportId}`
       + `&report_presentation_id=${formatId}`
-      + `&order_by=${sortBy}`
+      + `&order_by=${orderBy}`
       + `&direction=${sortDirection}`
       + values);
   }

--- a/myreports/datasources/comm_records.py
+++ b/myreports/datasources/comm_records.py
@@ -274,7 +274,7 @@ class CommRecordsFilter(DataSourceFilter):
         qs = filter_date_range(self.date_time, 'date_time', qs)
 
         if self.communication_type:
-            qs = qs.filter(contact_type=self.communication_type)
+            qs = qs.filter(contact_type__in=self.communication_type)
 
         if self.tags:
             or_qs = []

--- a/myreports/datasources/comm_records.py
+++ b/myreports/datasources/comm_records.py
@@ -287,7 +287,7 @@ class CommRecordsFilter(DataSourceFilter):
         qs = filter_date_range(self.date_time, 'date_time', qs)
 
         if self.communication_type:
-            qs = qs.filter(contact_type__in=self.communication_type)
+            qs = qs.filter(contact_type=self.communication_type)
 
         if self.tags:
             or_qs = []

--- a/myreports/tests/setup.py
+++ b/myreports/tests/setup.py
@@ -345,7 +345,7 @@ def create_full_fixture():
 
     ConfigurationColumnFactory.create(
         column_name="date_time",
-        alias="Date",
+        alias="Date of Communication",
         order=107,
         configuration=con_comm,
         output_format="us_datetime",

--- a/myreports/views.py
+++ b/myreports/views.py
@@ -755,9 +755,11 @@ def download_dynamic_report(request):
     response['Content-Disposition'] = disposition
 
     output = StringIO()
-    columns = [
-        c.alias for c in report_configuration.columns if c.column in values]
-    presentation.write_presentation(columns, sorted_records, output)
+    values = [
+        c.alias for value in values for c in report_configuration.columns
+        if c.column == value
+    ]
+    presentation.write_presentation(values, sorted_records, output)
     response.write(output.getvalue())
 
     return response


### PR DESCRIPTION
What's changed:

-     ~~filtering by communication type now filters properly, which was the cause for the communication reports with 0 results~~ Reverted this since Darrin did the same in his PR already
-     the notes field of the communication record report is now plain text and has normalized whitespace – much smaller report downloads now.
-     regression from implementing human readable sorting where the sort by box wasn't being loaded when initially visiting the export page
-     another regression which caused column order to not be retained on export
- Date is now called "Date of Communication" in the communication record report
