### PR TITLE
Made sure redirects go to react urls instead of old profile units.

### DIFF
--- a/gulp/src/myprofile/main.jsx
+++ b/gulp/src/myprofile/main.jsx
@@ -107,7 +107,7 @@ class Module extends React.Component {
     };
 
     await myJobsApi.get('/profile/view/delete?' + param(formData));
-    window.location.assign('/profile/view/');
+    window.location.assign('/profile/view/react');
   }
   handleCancel() {
     window.location.assign('/profile/view/react');
@@ -144,7 +144,7 @@ class Module extends React.Component {
         apiResponse: apiResponse,
       });
     } else {
-      window.location.assign('/profile/view/');
+      window.location.assign('/profile/view/react');
     }
   }
   processForm(apiResponse) {


### PR DESCRIPTION
Before, trying to save or delete a profile unit would send you back to the regular django profile unit overview instead of the react-based one. This corrects that.