### PR TITLE
[PD-2351] Add "live" filtering to the partner and contact fields

### DIFF
--- a/gulp/src/reporting/DynamicReportApp.jsx
+++ b/gulp/src/reporting/DynamicReportApp.jsx
@@ -14,7 +14,7 @@ export class DynamicReportApp extends Component {
 
   componentDidMount() {
     const {reportFinder} = this.props;
-    this.callbackRef =
+    this.unsubscribeToNewReports =
       reportFinder.subscribeToNewReports(
           (reportId, runningReport) =>
             this.handleNewReport(reportId, runningReport),
@@ -23,8 +23,7 @@ export class DynamicReportApp extends Component {
   }
 
   componentWillUnmount() {
-    const {reportFinder} = this.props;
-    reportFinder.unsubscribeToReportList(this.callbackRef);
+    this.unsubscribeToNewReports();
   }
 
   async handleNewReport(reportId, runningReport) {

--- a/gulp/src/reporting/MultiSelectFilter.jsx
+++ b/gulp/src/reporting/MultiSelectFilter.jsx
@@ -15,7 +15,7 @@ export default class MultiSelectFilter extends Component {
     // This is used to reload the available list anytime the filter changes.
     this.mounted = true;
     if (reportFinder) {
-      this.filterChangesRef = reportFinder.subscribeToFilterChanges(
+      this.unsubscribeToFilterChanges = reportFinder.subscribeToFilterChanges(
           () => this.getHints());
     }
     this.getHints();
@@ -24,8 +24,7 @@ export default class MultiSelectFilter extends Component {
   componentWillUnmount() {
     this.mounted = true;
     if (this.filterChangesRef) {
-      const {reportFinder} = this.props;
-      reportFinder.unsubscribeToFilterChanges(this.filterChangesRef);
+      this.unsubscribeToFilterChanges();
     }
   }
 

--- a/gulp/src/reporting/MultiSelectFilter.jsx
+++ b/gulp/src/reporting/MultiSelectFilter.jsx
@@ -7,16 +7,37 @@ export default class MultiSelectFilter extends Component {
     this.state = {
       available: [],
     };
+    this.mounted = false;
   }
 
   componentDidMount() {
+    const {reportFinder} = this.props;
+    // This is used to reload the available list anytime the filter changes.
+    this.mounted = true;
+    if (reportFinder) {
+      this.filterChangesRef = reportFinder.subscribeToFilterChanges(
+          () => this.getHints());
+    }
     this.getHints();
+  }
+
+  componentWillUnmount() {
+    this.mounted = true;
+    if (this.filterChangesRef) {
+      const {reportFinder} = this.props;
+      reportFinder.unsubscribeToFilterChanges(this.filterChangesRef);
+    }
   }
 
   async getHints() {
     const {getHints} = this.props;
-    const available = await getHints();
-    this.setState({available});
+    if (this.mounted) {
+      const available = await getHints();
+      // gotta check again. Save me redux.
+      if (this.mounted) {
+        this.setState({available});
+      }
+    }
   }
 
   render() {
@@ -71,4 +92,8 @@ MultiSelectFilter.propTypes = {
    * Function fired when an item is selected from the right side
    */
   onRemove: React.PropTypes.func.isRequired,
+  /**
+   * Used for hack to refresh available list.
+   */
+  reportFinder: React.PropTypes.object,
 };

--- a/gulp/src/reporting/SetUpReport.jsx
+++ b/gulp/src/reporting/SetUpReport.jsx
@@ -282,6 +282,10 @@ export default class SetUpReport extends Component {
           if (col.filter === 'contact' || col.filter === 'partner') {
             passReportFinder = reportFinder;
           }
+          let removeSelected;
+          if (col.filter === 'contact') {
+            removeSelected = true;
+          }
 
           rows.push(
             <FieldWrapper
@@ -298,7 +302,8 @@ export default class SetUpReport extends Component {
                   reportConfig.addToMultifilter(col.filter, v))}
                 onRemove = {vs => forEach(vs, v =>
                   reportConfig.removeFromMultifilter(col.filter, v))}
-                reportFinder={passReportFinder}/>
+                reportFinder={passReportFinder}
+                removeSelected={removeSelected}/>
 
             </FieldWrapper>
             );

--- a/gulp/src/reporting/SetUpReport.jsx
+++ b/gulp/src/reporting/SetUpReport.jsx
@@ -70,7 +70,9 @@ export default class SetUpReport extends Component {
   }
 
   onFilterUpdate(filter) {
+    const {reportFinder} = this.props;
     this.setState({filter});
+    reportFinder.noteFilterChanges();
   }
 
   onErrorsChanged(errors) {
@@ -173,6 +175,7 @@ export default class SetUpReport extends Component {
   }
 
   render() {
+    const {reportFinder} = this.props;
     const {
       intention: reportingType,
       category: reportType,
@@ -264,9 +267,13 @@ export default class SetUpReport extends Component {
             );
           break;
         case 'search_multiselect':
-          // getHintsWithFilter is an ugly hack to work around the fact that we
-          // are using a two pane multiselect here. Really we want a tag select
-          // here. Tag select should not need getHintsWithFilter.
+          // Hack. MultiSelect filter will subscribe to filter updates if we
+          // pass reportFinder.
+          let passReportFinder;
+          if (col.filter === 'contact' || col.filter === 'partner') {
+            passReportFinder = reportFinder;
+          }
+
           rows.push(
             <FieldWrapper
               key={col.filter}
@@ -276,12 +283,13 @@ export default class SetUpReport extends Component {
                 availableHeader="Available"
                 selectedHeader="Selected"
                 getHints={v =>
-                  reportConfig.getHintsWithFilter(col.filter, {}, v)}
+                  reportConfig.getHints(col.filter, v)}
                 selected={reportConfig.currentFilter[col.filter] || []}
                 onAdd = {vs => forEach(vs, v =>
                   reportConfig.addToMultifilter(col.filter, v))}
                 onRemove = {vs => forEach(vs, v =>
-                  reportConfig.removeFromMultifilter(col.filter, v))}/>
+                  reportConfig.removeFromMultifilter(col.filter, v))}
+                reportFinder={passReportFinder}/>
 
             </FieldWrapper>
             );

--- a/gulp/src/reporting/reportEngine.js
+++ b/gulp/src/reporting/reportEngine.js
@@ -18,6 +18,7 @@ export class ReportFinder {
     this.configBuilder = configBuilder;
     this.newReportSubscribers = {};
     this.newMenuChoicesSubscribers = {};
+    this.filterChangesSubscribers = {};
   }
 
   /**
@@ -184,6 +185,35 @@ export class ReportFinder {
    */
   async refreshReport(reportId) {
     return await this.api.refreshReport(reportId);
+  }
+
+  /**
+   * Submit a callback to be called any time a filter changes
+   *
+   * callback params: none
+   * returns a reference which can be used later to unsubscribe.
+   */
+  subscribeToFilterChanges(callback) {
+    this.filterChangesSubscribers[callback] = callback;
+    return callback;
+  }
+
+  /**
+   * Remove a callback from the filter changes subscription.
+   */
+  unsubscribeToFilterChanges(ref) {
+    delete this.filterChangesSubscribers[ref];
+  }
+
+  /**
+   * Let subscribers know that a filter has changed.
+   */
+  noteFilterChanges() {
+    for (const ref in this.filterChangesSubscribers) {
+      if (this.filterChangesSubscribers.hasOwnProperty(ref)) {
+        this.filterChangesSubscribers[ref]();
+      }
+    }
   }
 }
 

--- a/gulp/src/reporting/reportEngine.js
+++ b/gulp/src/reporting/reportEngine.js
@@ -268,17 +268,6 @@ export class ReportConfiguration {
       this.reportDataId, this.getFilter(), field, partial);
   }
 
-  /**
-   * See `getHints`. Same as that but override the filter used.
-   *
-   * Ugly hack to make two pane selects work ok. Remove this when we stop
-   * using two pane selects for reporting filters.
-   */
-  async getHintsWithFilter(field, filter, partial) {
-    return await this.api.getHelp(
-      this.reportDataId, filter, field, partial);
-  }
-
   callUpdateFilter() {
     this.onUpdateFilter(this.currentFilter);
   }

--- a/gulp/src/reporting/reportEngine.js
+++ b/gulp/src/reporting/reportEngine.js
@@ -274,6 +274,9 @@ export class ReportConfiguration {
 
   /**
    * Set a value for a multiple valued "or" filter.
+   *
+   * field: field to filter, i.e. contact
+   * obj: object to add to "or" filter; i.e. {value: 3, display: "Pam"}
    */
   addToMultifilter(field, obj) {
     if (!(field in this.currentFilter)) {
@@ -288,6 +291,9 @@ export class ReportConfiguration {
 
   /**
    * Get a previously set value for a multiple valued "or" filter.
+   *
+   * field: field to filter, i.e. contact
+   * obj: object to add to "or" filter; i.e. {value: 3, display: "Pam"}
    */
   removeFromMultifilter(field, obj) {
     remove(this.currentFilter[field], i => i.value === obj.value);

--- a/gulp/src/reporting/spec/reportEngineSpec.js
+++ b/gulp/src/reporting/spec/reportEngineSpec.js
@@ -106,6 +106,28 @@ describe('ReportFinder', () => {
       expect(newId).toEqual(22);
     });
   });
+
+  describe('filter change subscriptions', () => {
+    let filterChanged;
+
+    const ref = finder.subscribeToFilterChanges(
+      () => {filterChanged = true;});
+
+    beforeEach(() => {
+      filterChanged = false;
+    });
+
+    it('can inform subscribers of filter changes', () => {
+      finder.noteFilterChanges();
+      expect(filterChanged).toBe(true);
+    });
+
+    it('can unsubscribe', () => {
+      finder.unsubscribeToFilterChanges(ref);
+      finder.noteFilterChanges();
+      expect(filterChanged).toBe(false);
+    });
+  });
 });
 
 describe('ReportConfiguration', () => {

--- a/gulp/src/reporting/spec/reportEngineSpec.js
+++ b/gulp/src/reporting/spec/reportEngineSpec.js
@@ -1,10 +1,59 @@
 import {
+  Subscription,
   ReportFinder,
   ReportConfiguration,
 } from '../reportEngine';
 
 import {promiseTest} from '../../common/spec';
 
+
+describe('Subscription', () => {
+  let i;
+  let j;
+  let subscription;
+  beforeEach(() => {
+    i = 0;
+    j = 0;
+    subscription = new Subscription();
+  });
+
+  it('does nothing when called with no subscribers', () => {
+    subscription.note(4);
+    expect(i).toBe(0);
+    expect(j).toBe(0);
+  });
+
+  it('can handle multiple subscribers', () => {
+    subscription.subscribe(n => {i = n;});
+    subscription.subscribe(n => {j = n;});
+    subscription.note(4);
+    expect(i).toBe(4);
+    expect(j).toBe(4);
+  });
+
+  it('can handle multiple subscribers with similar callback identity', () => {
+    function bumpI(n) {
+      i += n;
+    }
+    subscription.subscribe(bumpI);
+    subscription.subscribe(bumpI);
+    subscription.note(4);
+    expect(i).toBe(8);
+  });
+
+  it('can unsubscribe', () => {
+    function bumpI(n) {
+      i += n;
+    }
+    const unsubscribe = subscription.subscribe(bumpI);
+    subscription.subscribe(bumpI);
+    subscription.note(4);
+    expect(i).toBe(8);
+    unsubscribe();
+    subscription.note(5);
+    expect(i).toBe(13);
+  });
+});
 
 class FakeBuilder {
   build(name, rpId, filters) {
@@ -81,7 +130,7 @@ describe('ReportFinder', () => {
   describe('new report subscriptions', () => {
     let newId = null;
     let newRunningReport = null;
-    const ref = finder.subscribeToNewReports(
+    const unsubscribe = finder.subscribeToNewReports(
       (id, r) => {
         newId = id;
         newRunningReport = r;
@@ -101,7 +150,7 @@ describe('ReportFinder', () => {
 
     it('can unsubscribe', () => {
       finder.noteNewReport(22);
-      finder.unsubscribeToNewReports(ref);
+      unsubscribe();
       finder.noteNewReport(33);
       expect(newId).toEqual(22);
     });
@@ -110,7 +159,7 @@ describe('ReportFinder', () => {
   describe('filter change subscriptions', () => {
     let filterChanged;
 
-    const ref = finder.subscribeToFilterChanges(
+    finder.subscribeToFilterChanges(
       () => {filterChanged = true;});
 
     beforeEach(() => {
@@ -120,12 +169,6 @@ describe('ReportFinder', () => {
     it('can inform subscribers of filter changes', () => {
       finder.noteFilterChanges();
       expect(filterChanged).toBe(true);
-    });
-
-    it('can unsubscribe', () => {
-      finder.unsubscribeToFilterChanges(ref);
-      finder.noteFilterChanges();
-      expect(filterChanged).toBe(false);
     });
   });
 });
@@ -249,6 +292,9 @@ describe('ReportConfiguration', () => {
     expect(fakeComponent.onUpdateFilter).toHaveBeenCalledWith({
       'tag': [{value: 'blue', display: 'Blue'}],
     });
+    config.removeFromMultifilter('tag', {value: 'blue'});
+    expect(config.getFilter()).toEqual({});
+    expect(fakeComponent.onUpdateFilter).toHaveBeenCalledWith({});
   });
 
   it('can remember and/or filters', () => {
@@ -282,6 +328,9 @@ describe('ReportConfiguration', () => {
     expect(config.getFilter()).toEqual({
       tag: [['blue']],
     });
+    config.removeFromAndOrFilter('tag', 0, {value: 'blue'});
+    expect(fakeComponent.onUpdateFilter).toHaveBeenCalledWith({});
+    expect(config.getFilter()).toEqual({});
   });
 
   it('removes empty tag lists on demand for and/or filters', () => {

--- a/myreports/datasources/comm_records.py
+++ b/myreports/datasources/comm_records.py
@@ -124,7 +124,9 @@ class CommRecordsDataSource(DataSource):
 
     def help_partner(self, company, filter_spec, partial):
         """Get help for the partner field."""
-        modified_filter_spec = filter_spec.clone_without_partner()
+        # Don't let this help be dependent on filtered contacts.
+        modified_filter_spec = (
+            filter_spec.clone_without_contact().clone_without_partner())
         comm_records_qs = self.filtered_query_set(
             company, modified_filter_spec)
         partner_qs = (


### PR DESCRIPTION
## Test

* Create a Contacts or Communication Record report
* Filter by some field.
* Notice how the partners/contacts update as you make changes.
* Try to break it with history navigation and cloning.

## Review

* If any filter changes, the fields "subscribed" to the filter change notification call help again.
* Two pane selects update the filter repeatedly when [de]selecting many items at once. That's why the debounce is there.