### PR TITLE
Fixed sidebar width.

### DIFF
--- a/gulp/src/nonuseroutreach/components/Content.jsx
+++ b/gulp/src/nonuseroutreach/components/Content.jsx
@@ -23,7 +23,7 @@ export function Content(props) {
     pageComponent = '';
   }
   return (
-    <div className="col-xs-8">
+    <div className="col-xs-12 col-md-8">
         {pageComponent}
     </div>
   );

--- a/gulp/src/nonuseroutreach/components/Menu.jsx
+++ b/gulp/src/nonuseroutreach/components/Menu.jsx
@@ -15,7 +15,7 @@ export function Menu(props) {
     tipsHeader = <h2>Tips</h2>;
   }
   return (
-    <div className="col-xs-4">
+    <div className="col-xs-12 col-md-4">
       <div className="sidebar">
         <h2 className="top">Navigation</h2>
         <OverviewButton changePage={changePage} />

--- a/gulp/src/reporting/DynamicReportApp.jsx
+++ b/gulp/src/reporting/DynamicReportApp.jsx
@@ -72,7 +72,7 @@ export class DynamicReportApp extends Component {
           <div className="col-xs-12 col-md-8">
             {this.props.children}
           </div>
-          <div className="col-xs-6 col-md-4">
+          <div className="col-xs-12 col-md-4">
             <ReportList
               history={history}
               reportFinder={reportFinder}


### PR DESCRIPTION
Here, I was worried about making the sidebar not look awkward on mobile. 

# Caveats
- Order of content and nav is still different, but that wasn't my focus here. If someone can offer pointers on how best to fix that, I'll gladly include those changes, but otherwise I'm not concerned here. 
- I also didn't move the Menu component to a common component because I wasn't sure if anything that was done in reporting should carry over. If we decide that reporting is a special snow flake, I think we could move the sidebar from nonuseroutreach up a level.
- I didn't mess with profile units because it was using bootstrap 2 which doesn't really do responsive so well, as I understand it. It'd be easy enough to update to bootstrap 3 using the react template, but I suspect that the design of the page in general will change and so didn't worry about it, especially with deam around the corner.

# Before
![2016-05-11-165938_860x1056_scrot](https://cloud.githubusercontent.com/assets/93686/15196348/cb54de22-1799-11e6-8382-bdbb716fa2fe.png)

# After
![2016-05-11-165920_860x1056_scrot](https://cloud.githubusercontent.com/assets/93686/15196345/c5bd96e8-1799-11e6-8a21-3952a37a3c1b.png)
