### PR TITLE
[PD-2294] Add DateField component to Reporting

### DIFF
--- a/gulp/src/common/ui/DateField.jsx
+++ b/gulp/src/common/ui/DateField.jsx
@@ -176,7 +176,7 @@ class DateField extends React.Component {
     }
 
     let errorComponent;
-    if (error) {
+    if (errorMessage) {
       errorComponent = (
         <div className="error-text">{errorMessage}</div>
       );

--- a/gulp/src/common/ui/DateField.jsx
+++ b/gulp/src/common/ui/DateField.jsx
@@ -169,7 +169,7 @@ class DateField extends React.Component {
       month = momentObject.month();
       year = momentObject.year();
     } else {
-      errorMessage = "Date error. Must be of format: MM/DD/YYYY";
+      errorMessage = 'Date error. Must be of format: MM/DD/YYYY';
       day = 0;
       month = 1;
       year = 2000;
@@ -178,10 +178,10 @@ class DateField extends React.Component {
     let errorComponent;
     if (error) {
       errorComponent = (
-        <div className="error-text">{error}</div>
+        <div className="error-text">{errorMessage}</div>
       );
     }
-    
+
     let calendar;
     if (this.state.displayCalendar) {
       calendar = (<div className="input-group datepicker-dropdown dropdown-menu"

--- a/gulp/src/common/ui/DateField.jsx
+++ b/gulp/src/common/ui/DateField.jsx
@@ -148,13 +148,20 @@ class DateField extends React.Component {
       maxLength,
       isHidden,
       value,
-      placeholder} = this.props;
+      placeholder,
+      error} = this.props;
 
     let momentObject = moment(value, 'MM/DD/YYYY');
     let day;
     let month;
     let year;
-    let error;
+
+    // Handle error message
+    let errorMessage;
+    if (error) {
+      errorMessage = error;
+    }
+
     // Date value must match our custom format (not ISO 8601)
     if (moment(value, 'MM/DD/YYYY', true).isValid()) {
       momentObject = moment(value, 'MM/DD/YYYY');
@@ -162,13 +169,19 @@ class DateField extends React.Component {
       month = momentObject.month();
       year = momentObject.year();
     } else {
-      error = (
-        <div className="error-text">Date error. Must be of format: MM/DD/YYYY</div>
-      );
+      errorMessage = "Date error. Must be of format: MM/DD/YYYY";
       day = 0;
       month = 1;
       year = 2000;
     }
+
+    let errorComponent;
+    if (error) {
+      errorComponent = (
+        <div className="error-text">{error}</div>
+      );
+    }
+    
     let calendar;
     if (this.state.displayCalendar) {
       calendar = (<div className="input-group datepicker-dropdown dropdown-menu"
@@ -204,7 +217,7 @@ class DateField extends React.Component {
             onBlur={e => this.onInputBlur(e)}
           />
         </div>
-        {error}
+        {errorComponent}
         {calendar}
       </ClickOutHandler>
     );
@@ -247,6 +260,10 @@ DateField.propTypes = {
    * Should this bad boy focus, all auto like?
    */
   autoFocus: React.PropTypes.string,
+  /**
+   * Validation error
+   */
+  error: React.PropTypes.string,
 };
 
 DateField.defaultProps = {
@@ -256,6 +273,7 @@ DateField.defaultProps = {
   isHidden: false,
   required: false,
   autoFocus: '',
+  error: null,
 };
 
 export default DateField;

--- a/gulp/src/reporting/SetUpReport.jsx
+++ b/gulp/src/reporting/SetUpReport.jsx
@@ -231,7 +231,7 @@ export default class SetUpReport extends Component {
           }
 
           rows.push(
-            <FieldWrapper key={col.filter} label={col.display}>
+            <FieldWrapper key={col.filter} label="Date range">
               <WizardFilterDateRange
                 id={col.filter}
                 updateFilter={v => reportConfig.setFilter(col.filter, v)}

--- a/gulp/src/reporting/SetUpReport.jsx
+++ b/gulp/src/reporting/SetUpReport.jsx
@@ -223,13 +223,12 @@ export default class SetUpReport extends Component {
             const day = now.getDate() < 10 ? '0' + now.getDate() : now.getDate();
             const today = month + '/' + day + '/' + year;
 
-            begin = today;
+            begin = '01/01/2014';
             end = today;
           } else {
             begin = reportConfig.currentFilter[col.filter][0];
             end = reportConfig.currentFilter[col.filter][1];
           }
-
 
           rows.push(
             <FieldWrapper key={col.filter} label={col.display}>

--- a/gulp/src/reporting/SetUpReport.jsx
+++ b/gulp/src/reporting/SetUpReport.jsx
@@ -212,11 +212,33 @@ export default class SetUpReport extends Component {
       reportConfig.filters.forEach(col => {
         switch (col.interface_type) {
         case 'date_range':
+          let begin;
+          let end;
+          if(!reportConfig.currentFilter[col.filter]){
+            // Default is today
+            const now = new Date();
+            const year = now.getFullYear();
+            // month and day must both be two characters
+            const month = (now.getMonth() + 1) < 10 ? '0' + (now.getMonth() + 1) : (now.getMonth() + 1);
+            const day = now.getDate() < 10 ? '0' + now.getDate() : now.getDate();
+            const today = month + '/' + day + '/' + year;
+
+            begin = today;
+            end = today;
+          } else {
+            begin = reportConfig.currentFilter[col.filter][0];
+            end = reportConfig.currentFilter[col.filter][1];
+          }
+
+
           rows.push(
             <FieldWrapper key={col.filter} label={col.display}>
               <WizardFilterDateRange
                 id={col.filter}
-                updateFilter={v => reportConfig.setFilter(col.filter, v)}/>
+                updateFilter={v => reportConfig.setFilter(col.filter, v)}
+                begin={begin}
+                end={end}
+                />
             </FieldWrapper>
           );
           break;

--- a/gulp/src/reporting/SetUpReport.jsx
+++ b/gulp/src/reporting/SetUpReport.jsx
@@ -214,7 +214,7 @@ export default class SetUpReport extends Component {
         case 'date_range':
           let begin;
           let end;
-          if(!reportConfig.currentFilter[col.filter]){
+          if (!reportConfig.currentFilter[col.filter]) {
             // Default is today
             const now = new Date();
             const year = now.getFullYear();

--- a/gulp/src/reporting/wizard/WizardFilterDateRange.jsx
+++ b/gulp/src/reporting/wizard/WizardFilterDateRange.jsx
@@ -60,20 +60,23 @@ export class WizardFilterDateRange extends Component {
       }
 
       return (
-        <span>
-          <DateField
-            onChange={e => this.updateField(e, 'begin')}
-            placeholder="begin date"
-            value={this.props.begin}
-            />
-
-          <DateField
-            onChange={e => this.updateField(e, 'end')}
-            placeholder="end date"
-            value={this.props.end}
-            error={error}
-            />
-        </span>
+        <div className="row">
+          <div className="col-xs-12 col-md-6">
+            <DateField
+              onChange={e => this.updateField(e, 'begin')}
+              placeholder="begin date"
+              value={this.props.begin}
+              />
+          </div>
+          <div className="col-xs-12 col-md-6">
+            <DateField
+              onChange={e => this.updateField(e, 'end')}
+              placeholder="end date"
+              value={this.props.end}
+              error={error}
+              />
+          </div>
+        </div>
       );
     }
 }

--- a/gulp/src/reporting/wizard/WizardFilterDateRange.jsx
+++ b/gulp/src/reporting/wizard/WizardFilterDateRange.jsx
@@ -39,11 +39,11 @@ export class WizardFilterDateRange extends Component {
         const newState = {...this.state};
 
         if (field === 'begin') {
-          newState['begin'] = finalValue;
-          newState['end'] = this.props.end;
+          newState.begin = finalValue;
+          newState.end = this.props.end;
         } else if (field === 'end') {
-          newState['begin'] = this.props.begin;
-          newState['end'] = finalValue;
+          newState.begin = this.props.begin;
+          newState.end = finalValue;
         }
         this.setState(newState);
         updateFilter([newState.begin, newState.end]);
@@ -56,7 +56,7 @@ export class WizardFilterDateRange extends Component {
       const beginDateObject = moment(this.props.begin, 'MM/DD/YYYY');
       const endDateObject = moment(this.props.end, 'MM/DD/YYYY');
       if (endDateObject.isBefore(beginDateObject)) {
-        error = "End date must be the same or after begin date";
+        error = 'End date must be the same or after begin date';
       }
 
       return (

--- a/gulp/src/reporting/wizard/WizardFilterDateRange.jsx
+++ b/gulp/src/reporting/wizard/WizardFilterDateRange.jsx
@@ -1,44 +1,76 @@
 import React, {PropTypes, Component} from 'react';
+import DateField from '../../common/ui/DateField';
 
-
+// TODO rip this out into a generalized begin/end dual Datefield
 export class WizardFilterDateRange extends Component {
     constructor() {
       super();
-      this.state = {begin: '', end: ''};
     }
 
-    updateField(field, value) {
-      const {updateFilter} = this.props;
-      const newState = {...this.state};
-      newState[field] = value;
-      this.setState(newState);
-      updateFilter([newState.begin, newState.end]);
+    updateField(event, field) {
+      let finalValue;
+      if (event.target.type === 'calendar-month') {
+        const existingDate = (field === 'begin') ? this.props.begin : this.props.end;
+        // month must be 2 chars
+        const newMonth = (event.target.value < 10) ? '0' + event.target.value : event.target.value;
+        // If user mangled date string, reset it so we can use substring
+        const afterMonth = existingDate.substring(2, 10);
+        const updatedDate = newMonth + afterMonth;
+        finalValue = updatedDate;
+      } else if (event.target.type === 'calendar-day') {
+        const existingDate = (field === 'begin') ? this.props.begin : this.props.end;
+        // day must be 2 chars
+        const newDay = (event.target.value < 10) ? '0' + event.target.value : event.target.value;
+        // If user mangled date string, reset it so we can use substring
+        const beforeDay = existingDate.substring(0, 3);
+        const afterDay = existingDate.substring(5, 10);
+        finalValue = beforeDay + newDay + afterDay;
+      } else if (event.target.type === 'calendar-year') {
+        const existingDate = (field === 'begin') ? this.props.begin : this.props.end;
+        const newYear = event.target.value;
+        // If user mangled date string, reset it so we can use substring
+        const beforeYear = existingDate.substring(0, 6);
+        finalValue = beforeYear + newYear;
+      }
+
+      if (finalValue) {
+        const {updateFilter} = this.props;
+        const newState = {...this.state};
+
+        if (field === 'begin') {
+          newState['begin'] = finalValue;
+          newState['end'] = this.props.end;
+        } else if (field === 'end') {
+          newState['begin'] = this.props.begin;
+          newState['end'] = finalValue;
+        }
+        this.setState(newState);
+        updateFilter([newState.begin, newState.end]);
+      }
     }
 
     render() {
       return (
         <span>
-          <div>
-            <input
-              type="text"
-              placeholder="begin date"
-              onChange={e =>
-                this.updateField('begin', e.target.value)} />
-          </div>
-          <div style={{margin: '20px 0 0'}}>
-            <input
-              type="text"
-              placeholder="end date"
-              onChange={e =>
-                this.updateField('end', e.target.value)} />
-          </div>
+          <DateField
+            onChange={e => this.updateField(e, 'begin')}
+            placeholder="begin date"
+            value={this.props.begin}
+            />
+
+          <DateField
+            onChange={e => this.updateField(e, 'end')}
+            placeholder="end date"
+            value={this.props.end}
+            />
         </span>
       );
     }
-
 }
 
 WizardFilterDateRange.propTypes = {
   id: PropTypes.string.isRequired,
   updateFilter: PropTypes.func.isRequired,
+  begin: PropTypes.string,
+  end: PropTypes.string,
 };

--- a/gulp/src/reporting/wizard/WizardFilterDateRange.jsx
+++ b/gulp/src/reporting/wizard/WizardFilterDateRange.jsx
@@ -1,5 +1,6 @@
 import React, {PropTypes, Component} from 'react';
 import DateField from '../../common/ui/DateField';
+import moment from 'moment';
 
 // TODO rip this out into a generalized begin/end dual Datefield
 export class WizardFilterDateRange extends Component {
@@ -50,6 +51,14 @@ export class WizardFilterDateRange extends Component {
     }
 
     render() {
+      // End date should be after begin date
+      let error;
+      const beginDateObject = moment(this.props.begin, 'MM/DD/YYYY');
+      const endDateObject = moment(this.props.end, 'MM/DD/YYYY');
+      if (endDateObject.isBefore(beginDateObject)) {
+        error = "End date must be the same or after begin date";
+      }
+
       return (
         <span>
           <DateField
@@ -62,6 +71,7 @@ export class WizardFilterDateRange extends Component {
             onChange={e => this.updateField(e, 'end')}
             placeholder="end date"
             value={this.props.end}
+            error={error}
             />
         </span>
       );


### PR DESCRIPTION
# This PR:

* adds DateField to reporting
* enables the DateField to display errors as props from above ( https://github.com/DirectEmployers/MyJobs/pull/2311/files#diff-c5b207334a4c11ac32df04a2b0ba657cR177 ) which enables validation like...
* adds a new validation to confirm end date is after begin date ( https://github.com/DirectEmployers/MyJobs/pull/2311/files#diff-d50ed71fb5078e252db0450db9459aedR54 ).

# Future

I'll create another ticket to update export so it takes this date range into account.

I *can* create another ticket to improve the implementation of this component, if that's important. For example, enable free-text editing (and not just selecting the date fromt he popup).

# Old
![screen shot 2016-05-12 at 11 44 32 am](https://cloud.githubusercontent.com/assets/15107331/15220855/0ec8c644-1837-11e6-9f33-4eee79f49080.png)

Which opens:

![screen shot 2016-05-12 at 11 44 38 am](https://cloud.githubusercontent.com/assets/15107331/15220862/11cf70d6-1837-11e6-80a0-12d189ca1f7d.png)


# New

<img width="538" alt="screen shot 2016-05-12 at 2 20 42 pm" src="https://cloud.githubusercontent.com/assets/15107331/15225524/d03a6f48-184c-11e6-8c4e-cff55d01249a.png">


Which opens:

![screen shot 2016-05-12 at 2 21 01 pm](https://cloud.githubusercontent.com/assets/15107331/15225521/cd6214e2-184c-11e6-9eae-8d7e565f28fa.png)
