### PR TITLE
[PD-2392, PD-2393] Implemented report version switching.

### DIFF
--- a/gulp/src/reporting/ReportList.jsx
+++ b/gulp/src/reporting/ReportList.jsx
@@ -126,6 +126,12 @@ export class ReportList extends Component {
               {reportLinks}
             </ul>
           </div>
+          <h2>Reporting Version</h2>
+          <button
+            className="button primary wide"
+            onClick={() => window.location.assign('/reports/view/overview')}>
+            Switch to Classic Reporting
+          </button>
         </div>
       </div>
     );

--- a/myjobs/templatetags/common_tags.py
+++ b/myjobs/templatetags/common_tags.py
@@ -324,13 +324,13 @@ def get_menus(context):
         ]
 
         version_urls = {
-            'beta': url("reports/view/dynamicoverview"),
+            'dynamic': url("reports/view/dynamicoverview"),
             'classic': url("reports/view/overview"),
         }
-        reporting_version = request.COOKIES.get('reporting_version', 'beta')
+        reporting_version = request.COOKIES.get('reporting_version', 'dynamic')
         employer_menu["submenus"].append({
             "id": "reports-tab",
-            "href": version_urls[reporting_version],
+            "href": version_urls.get(reporting_version, "beta"),
             "label": "Reports",
         })
 

--- a/myjobs/templatetags/common_tags.py
+++ b/myjobs/templatetags/common_tags.py
@@ -294,11 +294,6 @@ def get_menus(context):
             "id": "beta-menu",
             "submenus": [
                 {
-                    "id": "dynamic-reports-tab",
-                    "href": url("reports/view/dynamicoverview"),
-                    "label": "Dynamic Reports",
-                },
-                {
                     "id": "nonuseroutreach",
                     "href": url("prm/view/nonuseroutreach"),
                     "label": "Non-User Outreach",
@@ -326,12 +321,18 @@ def get_menus(context):
                 "href": url("prm/view"),
                 "label": "PRM"
             },
-            {
-                "id": "reports-tab",
-                "href": url("reports/view/overview"),
-                "label": "Reports",
-            }
         ]
+
+        version_urls = {
+            'beta': url("reports/view/dynamicoverview"),
+            'classic': url("reports/view/overview"),
+        }
+        reporting_version = request.COOKIES.get('reporting_version', 'beta')
+        employer_menu["submenus"].append({
+            "id": "reports-tab",
+            "href": version_urls[reporting_version],
+            "label": "Reports",
+        })
 
     if employer_menu and user.can(company, "read role", check_access=False):
         employer_menu["submenus"].append(

--- a/myreports/tests/test_views.py
+++ b/myreports/tests/test_views.py
@@ -39,12 +39,12 @@ class TestOverview(MyReportsTestCase):
     def test_dynamic_report_version(self):
         """
         Visiting 'dynamicoverview' should set the reporting_version cookie to
-        'beta'.
+        'dynamic'.
 
         """
         response = self.client.get(reverse('overview'))
         self.assertEqual(
-            response.cookies['reporting_version'].value, 'beta')
+            response.cookies['reporting_version'].value, 'dynamic')
 
 
 

--- a/myreports/tests/test_views.py
+++ b/myreports/tests/test_views.py
@@ -26,6 +26,27 @@ class TestOverview(MyReportsTestCase):
 
         self.assertEqual(response.status_code, 200)
 
+    def test_classic_report_version(self):
+        """
+        Visiting 'overview' should set the reporting_version cookie to
+        'classic'.
+
+        """
+        response = self.client.get(reverse('overview'))
+        self.assertEqual(
+            response.cookies['reporting_version'].value, 'classic')
+
+    def test_dynamic_report_version(self):
+        """
+        Visiting 'dynamicoverview' should set the reporting_version cookie to
+        'beta'.
+
+        """
+        response = self.client.get(reverse('overview'))
+        self.assertEqual(
+            response.cookies['reporting_version'].value, 'beta')
+
+
 
 class TestViewRecords(MyReportsTestCase):
     """

--- a/myreports/tests/test_views.py
+++ b/myreports/tests/test_views.py
@@ -42,7 +42,7 @@ class TestOverview(MyReportsTestCase):
         'dynamic'.
 
         """
-        response = self.client.get(reverse('overview'))
+        response = self.client.get(reverse('dynamicoverview'))
         self.assertEqual(
             response.cookies['reporting_version'].value, 'dynamic')
 

--- a/myreports/urls.py
+++ b/myreports/urls.py
@@ -3,7 +3,7 @@ from myreports.views import ReportView
 
 urlpatterns = patterns(
     'myreports.views',
-    url(r'^view/overview$', 'overview', name='overview'),
+    url(r'^view/overview/$', 'overview', name='overview'),
     url(r'^view/archive$', 'report_archive', name='report_archive'),
     url(r'view/(?P<app>\w+)/(?P<model>\w+)$', ReportView.as_view(),
         name='reports'),

--- a/myreports/views.py
+++ b/myreports/views.py
@@ -375,7 +375,7 @@ def dynamicoverview(request):
     company = get_company_or_404(request)
     ctx = {"company": company}
     response = HttpResponse()
-    response.set_cookie('reporting_version', 'beta')
+    response.set_cookie('reporting_version', 'dynamic')
     html = render_to_response('myreports/dynamicreports.html', ctx,
                               RequestContext(request))
     response.content = html

--- a/templates/myreports/includes/report-sidebar.html
+++ b/templates/myreports/includes/report-sidebar.html
@@ -20,6 +20,6 @@
     {% endif %}
     <h2>Reporting Versions</h2>
     <div class="navigation">
-        <a class="btn" href="{% url 'dynamicoverview' %}">Switch to Beta Reporting</a>
+        <a class="btn" href="{% url 'dynamicoverview' %}">Switch to Dynamic Reporting</a>
     </div>
 </div>

--- a/templates/myreports/includes/report-sidebar.html
+++ b/templates/myreports/includes/report-sidebar.html
@@ -1,21 +1,25 @@
 <div class="sidebar">
     <h2 class="top">Past Reports</h2>
     {% for report in past_reports %}
-        <div class="report-row" data-report="{{ report.id }}" data-model="{{ report.model }}">
-            <a class="report-link {% if not report.results %}disabled{% endif %}" data-toggle="tooltip" title="View Report">{{ report.name }}</a>
-            <div class="icon-set">
-                <i id="view-{{ report.id }}" data-toggle="tooltip" class="fa fa-eye {% if not report.results %}disabled{% endif %}" title="View Report"></i>
-                <i id="clone-{{ report.id }}" data-toggle="tooltip" class="fa fa-copy" title="Clone Report"></i>
-                <i id="regen-{{ report.id }}" data-toggle="tooltip" class="fa fa-refresh" title="Regenerate Report"></i>
-                <i id="export-{{ report.id }}" data-toggle="tooltip" class="fa fa-download {% if not report.results %}disabled{% endif %}" title="Export Report"></i>
-            </div>
+    <div class="report-row" data-report="{{ report.id }}" data-model="{{ report.model }}">
+        <a class="report-link {% if not report.results %}disabled{% endif %}" data-toggle="tooltip" title="View Report">{{ report.name }}</a>
+        <div class="icon-set">
+            <i id="view-{{ report.id }}" data-toggle="tooltip" class="fa fa-eye {% if not report.results %}disabled{% endif %}" title="View Report"></i>
+            <i id="clone-{{ report.id }}" data-toggle="tooltip" class="fa fa-copy" title="Clone Report"></i>
+            <i id="regen-{{ report.id }}" data-toggle="tooltip" class="fa fa-refresh" title="Regenerate Report"></i>
+            <i id="export-{{ report.id }}" data-toggle="tooltip" class="fa fa-download {% if not report.results %}disabled{% endif %}" title="Export Report"></i>
         </div>
+    </div>
     {% empty %}
-        No past reports
+    No past reports
     {% endfor %}
     {% if report_count > 0 %}
     <div class="navigation">
         <a id="report-archive" class="btn">View All Reports</a>
     </div>
-     {% endif %}
+    {% endif %}
+    <h2>Reporting Versions</h2>
+    <div class="navigation">
+        <a class="btn" href="{% url 'dynamicoverview' %}">Switch to Beta Reporting</a>
+    </div>
 </div>

--- a/templates/myreports/reports.html
+++ b/templates/myreports/reports.html
@@ -3,7 +3,7 @@
 {% load staticfiles %}
 
 {% block site-title %}
-    <title>My.jobs - Reports - {{ company.name }} (beta)</title>
+    <title>My.jobs - Reports - {{ company.name }}</title>
     <meta name="title" content="My.jobs - Reports - {{ company.name }}">
 {% endblock %}
 


### PR DESCRIPTION
# Changes
- Dynamic Reporting is no longer in the beta menu
- Dynamic Reporting is no longer restricted to staff
- Switching between Dynamic and Classic reporting can be done via a button on the right-hand side
- Dynamic (Beta) reporting is the default.
- As such, the "Reporting" topbar submenu will remember which reporting you last went to.
- Classic Reporting no longer says "beta"