### PR TITLE
Started using native events for report.

### DIFF
--- a/gulp/npm-shrinkwrap.json
+++ b/gulp/npm-shrinkwrap.json
@@ -4,2412 +4,1477 @@
   "dependencies": {
     "accepts": {
       "version": "1.3.2",
-      "from": "accepts@1.3.2",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.2.tgz",
       "dependencies": {
         "mime-db": {
-          "version": "1.22.0",
-          "from": "mime-db@1.22.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz"
+          "version": "1.22.0"
         },
         "mime-types": {
-          "version": "2.1.10",
-          "from": "mime-types@2.1.10",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz"
+          "version": "2.1.10"
         }
       }
     },
     "acorn": {
-      "version": "1.2.2",
-      "from": "acorn@1.2.2",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
+      "version": "1.2.2"
     },
     "acorn-to-esprima": {
-      "version": "1.0.7",
-      "from": "acorn-to-esprima@1.0.7",
-      "resolved": "https://registry.npmjs.org/acorn-to-esprima/-/acorn-to-esprima-1.0.7.tgz"
+      "version": "1.0.7"
     },
     "align-text": {
-      "version": "0.1.3",
-      "from": "align-text@0.1.3",
-      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz"
+      "version": "0.1.3"
     },
     "alter": {
-      "version": "0.2.0",
-      "from": "alter@0.2.0",
-      "resolved": "https://registry.npmjs.org/alter/-/alter-0.2.0.tgz"
+      "version": "0.2.0"
     },
     "amdefine": {
-      "version": "1.0.0",
-      "from": "amdefine@1.0.0",
-      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "ansi-escapes": {
-      "version": "1.1.1",
-      "from": "ansi-escapes@1.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.1.1.tgz"
+      "version": "1.1.1"
     },
     "ansi-regex": {
-      "version": "2.0.0",
-      "from": "ansi-regex@2.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+      "version": "2.0.0"
     },
     "ansi-styles": {
-      "version": "2.1.0",
-      "from": "ansi-styles@2.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+      "version": "2.1.0"
     },
     "anymatch": {
-      "version": "1.3.0",
-      "from": "anymatch@1.3.0",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz"
+      "version": "1.3.0"
     },
     "archy": {
-      "version": "1.0.0",
-      "from": "archy@1.0.0",
-      "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "argparse": {
       "version": "1.0.4",
-      "from": "argparse@1.0.4",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.4.tgz",
       "dependencies": {
         "lodash": {
-          "version": "4.0.0",
-          "from": "lodash@4.0.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.0.0.tgz"
+          "version": "4.0.0"
         }
       }
     },
     "arr-diff": {
-      "version": "2.0.0",
-      "from": "arr-diff@2.0.0",
-      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz"
+      "version": "2.0.0"
     },
     "arr-flatten": {
-      "version": "1.0.1",
-      "from": "arr-flatten@1.0.1",
-      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz"
+      "version": "1.0.1"
     },
     "array-differ": {
-      "version": "1.0.0",
-      "from": "array-differ@1.0.0",
-      "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "array-flatten": {
-      "version": "1.1.1",
-      "from": "array-flatten@1.1.1",
-      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz"
+      "version": "1.1.1"
     },
     "array-union": {
-      "version": "1.0.1",
-      "from": "array-union@1.0.1",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz"
+      "version": "1.0.1"
     },
     "array-uniq": {
-      "version": "1.0.2",
-      "from": "array-uniq@1.0.2",
-      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
+      "version": "1.0.2"
     },
     "array-unique": {
-      "version": "0.2.1",
-      "from": "array-unique@0.2.1",
-      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
+      "version": "0.2.1"
     },
     "arrify": {
-      "version": "1.0.1",
-      "from": "arrify@1.0.1",
-      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
+      "version": "1.0.1"
     },
     "asap": {
-      "version": "2.0.3",
-      "from": "asap@2.0.3",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.3.tgz"
+      "version": "2.0.3"
     },
     "asn1": {
-      "version": "0.2.3",
-      "from": "asn1@0.2.3",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
+      "version": "0.2.3"
     },
     "assert": {
-      "version": "1.3.0",
-      "from": "assert@1.3.0",
-      "resolved": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz"
+      "version": "1.3.0"
     },
     "assert-plus": {
-      "version": "0.1.5",
-      "from": "assert-plus@0.1.5",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+      "version": "0.1.5"
     },
     "ast-traverse": {
-      "version": "0.1.1",
-      "from": "ast-traverse@0.1.1",
-      "resolved": "https://registry.npmjs.org/ast-traverse/-/ast-traverse-0.1.1.tgz"
+      "version": "0.1.1"
     },
     "ast-types": {
-      "version": "0.8.12",
-      "from": "ast-types@0.8.12",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.12.tgz"
+      "version": "0.8.12"
     },
     "async": {
-      "version": "1.5.2",
-      "from": "async@1.5.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
+      "version": "1.5.2"
     },
     "async-each": {
-      "version": "0.1.6",
-      "from": "async-each@0.1.6",
-      "resolved": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz"
+      "version": "0.1.6"
     },
     "aws-sign2": {
-      "version": "0.6.0",
-      "from": "aws-sign2@0.6.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
+      "version": "0.6.0"
     },
     "babel": {
-      "version": "5.8.34",
-      "from": "babel@5.8.34",
-      "resolved": "https://registry.npmjs.org/babel/-/babel-5.8.34.tgz"
+      "version": "5.8.34"
     },
     "babel-core": {
-      "version": "5.8.34",
-      "from": "babel-core@5.8.34",
-      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.34.tgz"
+      "version": "5.8.34"
     },
     "babel-eslint": {
-      "version": "4.1.6",
-      "from": "babel-eslint@4.1.6",
-      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-4.1.6.tgz"
+      "version": "4.1.6"
     },
     "babel-loader": {
-      "version": "5.4.0",
-      "from": "babel-loader@5.4.0",
-      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-5.4.0.tgz"
+      "version": "5.4.0"
     },
     "babel-plugin-constant-folding": {
-      "version": "1.0.1",
-      "from": "babel-plugin-constant-folding@1.0.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-constant-folding/-/babel-plugin-constant-folding-1.0.1.tgz"
+      "version": "1.0.1"
     },
     "babel-plugin-dead-code-elimination": {
-      "version": "1.0.2",
-      "from": "babel-plugin-dead-code-elimination@1.0.2",
-      "resolved": "https://registry.npmjs.org/babel-plugin-dead-code-elimination/-/babel-plugin-dead-code-elimination-1.0.2.tgz"
+      "version": "1.0.2"
     },
     "babel-plugin-eval": {
-      "version": "1.0.1",
-      "from": "babel-plugin-eval@1.0.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-eval/-/babel-plugin-eval-1.0.1.tgz"
+      "version": "1.0.1"
     },
     "babel-plugin-inline-environment-variables": {
-      "version": "1.0.1",
-      "from": "babel-plugin-inline-environment-variables@1.0.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-inline-environment-variables/-/babel-plugin-inline-environment-variables-1.0.1.tgz"
+      "version": "1.0.1"
     },
     "babel-plugin-jscript": {
-      "version": "1.0.4",
-      "from": "babel-plugin-jscript@1.0.4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jscript/-/babel-plugin-jscript-1.0.4.tgz"
+      "version": "1.0.4"
     },
     "babel-plugin-member-expression-literals": {
-      "version": "1.0.1",
-      "from": "babel-plugin-member-expression-literals@1.0.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-member-expression-literals/-/babel-plugin-member-expression-literals-1.0.1.tgz"
+      "version": "1.0.1"
     },
     "babel-plugin-property-literals": {
-      "version": "1.0.1",
-      "from": "babel-plugin-property-literals@1.0.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-property-literals/-/babel-plugin-property-literals-1.0.1.tgz"
+      "version": "1.0.1"
     },
     "babel-plugin-proto-to-assign": {
-      "version": "1.0.4",
-      "from": "babel-plugin-proto-to-assign@1.0.4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-proto-to-assign/-/babel-plugin-proto-to-assign-1.0.4.tgz"
+      "version": "1.0.4"
     },
     "babel-plugin-react-constant-elements": {
-      "version": "1.0.3",
-      "from": "babel-plugin-react-constant-elements@1.0.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-react-constant-elements/-/babel-plugin-react-constant-elements-1.0.3.tgz"
+      "version": "1.0.3"
     },
     "babel-plugin-react-display-name": {
-      "version": "1.0.3",
-      "from": "babel-plugin-react-display-name@1.0.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-react-display-name/-/babel-plugin-react-display-name-1.0.3.tgz"
+      "version": "1.0.3"
     },
     "babel-plugin-remove-console": {
-      "version": "1.0.1",
-      "from": "babel-plugin-remove-console@1.0.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-remove-console/-/babel-plugin-remove-console-1.0.1.tgz"
+      "version": "1.0.1"
     },
     "babel-plugin-remove-debugger": {
-      "version": "1.0.1",
-      "from": "babel-plugin-remove-debugger@1.0.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-remove-debugger/-/babel-plugin-remove-debugger-1.0.1.tgz"
+      "version": "1.0.1"
     },
     "babel-plugin-runtime": {
-      "version": "1.0.7",
-      "from": "babel-plugin-runtime@1.0.7",
-      "resolved": "https://registry.npmjs.org/babel-plugin-runtime/-/babel-plugin-runtime-1.0.7.tgz"
+      "version": "1.0.7"
     },
     "babel-plugin-undeclared-variables-check": {
-      "version": "1.0.2",
-      "from": "babel-plugin-undeclared-variables-check@1.0.2",
-      "resolved": "https://registry.npmjs.org/babel-plugin-undeclared-variables-check/-/babel-plugin-undeclared-variables-check-1.0.2.tgz"
+      "version": "1.0.2"
     },
     "babel-plugin-undefined-to-void": {
-      "version": "1.1.6",
-      "from": "babel-plugin-undefined-to-void@1.1.6",
-      "resolved": "https://registry.npmjs.org/babel-plugin-undefined-to-void/-/babel-plugin-undefined-to-void-1.1.6.tgz"
+      "version": "1.1.6"
     },
     "babel-runtime": {
-      "version": "5.8.34",
-      "from": "babel-runtime@5.8.34",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz"
+      "version": "5.8.34"
     },
     "babylon": {
-      "version": "5.8.34",
-      "from": "babylon@5.8.34",
-      "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.34.tgz"
+      "version": "5.8.34"
     },
     "balanced-match": {
-      "version": "0.3.0",
-      "from": "balanced-match@0.3.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+      "version": "0.3.0"
     },
     "base62": {
-      "version": "0.1.1",
-      "from": "base62@0.1.1",
-      "resolved": "https://registry.npmjs.org/base62/-/base62-0.1.1.tgz"
+      "version": "0.1.1"
     },
     "Base64": {
-      "version": "0.2.1",
-      "from": "Base64@0.2.1",
-      "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz"
+      "version": "0.2.1"
     },
     "base64-js": {
-      "version": "0.0.8",
-      "from": "base64-js@0.0.8",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz"
+      "version": "0.0.8"
     },
     "batch": {
-      "version": "0.5.3",
-      "from": "batch@0.5.3",
-      "resolved": "https://registry.npmjs.org/batch/-/batch-0.5.3.tgz"
+      "version": "0.5.3"
     },
     "beeper": {
-      "version": "1.1.0",
-      "from": "beeper@1.1.0",
-      "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz"
+      "version": "1.1.0"
     },
     "big.js": {
-      "version": "3.1.3",
-      "from": "big.js@3.1.3",
-      "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
+      "version": "3.1.3"
     },
     "binary-extensions": {
-      "version": "1.4.0",
-      "from": "binary-extensions@1.4.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.4.0.tgz"
+      "version": "1.4.0"
     },
     "bl": {
-      "version": "1.0.1",
-      "from": "bl@1.0.1",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.1.tgz"
+      "version": "1.0.1"
     },
     "bluebird": {
-      "version": "2.10.2",
-      "from": "bluebird@2.10.2",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz"
+      "version": "2.10.2"
     },
     "boom": {
-      "version": "2.10.1",
-      "from": "boom@2.10.1",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+      "version": "2.10.1"
     },
     "brace-expansion": {
-      "version": "1.1.2",
-      "from": "brace-expansion@1.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz"
+      "version": "1.1.2"
     },
     "braces": {
-      "version": "1.8.3",
-      "from": "braces@1.8.3",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.3.tgz"
+      "version": "1.8.3"
     },
     "breakable": {
-      "version": "1.0.0",
-      "from": "breakable@1.0.0",
-      "resolved": "https://registry.npmjs.org/breakable/-/breakable-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "browserify-zlib": {
-      "version": "0.1.4",
-      "from": "browserify-zlib@0.1.4",
-      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz"
+      "version": "0.1.4"
     },
     "buffer": {
       "version": "3.6.0",
-      "from": "buffer@3.6.0",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
       "dependencies": {
         "isarray": {
-          "version": "1.0.0",
-          "from": "isarray@1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+          "version": "1.0.0"
         }
       }
     },
     "builtin-modules": {
-      "version": "1.1.1",
-      "from": "builtin-modules@1.1.1",
-      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
+      "version": "1.1.1"
     },
     "bytes": {
-      "version": "2.2.0",
-      "from": "bytes@2.2.0",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.2.0.tgz"
+      "version": "2.2.0"
     },
     "calendar-base": {
-      "version": "0.2.1",
-      "from": "calendar-base@>=0.2.1 <0.3.0",
-      "resolved": "https://registry.npmjs.org/calendar-base/-/calendar-base-0.2.1.tgz"
+      "version": "0.2.1"
     },
     "camelcase": {
-      "version": "1.2.1",
-      "from": "camelcase@1.2.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+      "version": "1.2.1"
     },
     "camelcase-keys": {
       "version": "2.0.0",
-      "from": "camelcase-keys@2.0.0",
-      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.0.0.tgz",
       "dependencies": {
         "camelcase": {
-          "version": "2.0.1",
-          "from": "camelcase@2.0.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.0.1.tgz"
+          "version": "2.0.1"
         }
       }
     },
     "caseless": {
-      "version": "0.11.0",
-      "from": "caseless@0.11.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
+      "version": "0.11.0"
     },
     "center-align": {
-      "version": "0.1.2",
-      "from": "center-align@0.1.2",
-      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.2.tgz"
+      "version": "0.1.2"
     },
     "chalk": {
-      "version": "1.1.1",
-      "from": "chalk@1.1.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz"
+      "version": "1.1.1"
     },
     "chokidar": {
-      "version": "1.4.2",
-      "from": "chokidar@1.4.2",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.4.2.tgz"
+      "version": "1.4.2"
     },
     "classnames": {
-      "version": "2.2.3",
-      "from": "classnames@2.2.3",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.3.tgz"
+      "version": "2.2.3"
     },
     "clean-css": {
       "version": "2.0.8",
-      "from": "clean-css@2.0.8",
-      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-2.0.8.tgz",
       "dependencies": {
         "commander": {
-          "version": "2.0.0",
-          "from": "commander@2.0.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.0.0.tgz"
+          "version": "2.0.0"
         }
       }
     },
     "cli-cursor": {
-      "version": "1.0.2",
-      "from": "cli-cursor@1.0.2",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz"
+      "version": "1.0.2"
     },
     "cli-width": {
-      "version": "1.1.0",
-      "from": "cli-width@1.1.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-1.1.0.tgz"
+      "version": "1.1.0"
     },
     "cliui": {
-      "version": "2.1.0",
-      "from": "cliui@2.1.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz"
+      "version": "2.1.0"
     },
     "clone": {
-      "version": "1.0.2",
-      "from": "clone@1.0.2",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
+      "version": "1.0.2"
     },
     "clone-stats": {
-      "version": "0.0.1",
-      "from": "clone-stats@0.0.1",
-      "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+      "version": "0.0.1"
     },
     "code-point-at": {
-      "version": "1.0.0",
-      "from": "code-point-at@1.0.0",
-      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "combined-stream": {
-      "version": "1.0.5",
-      "from": "combined-stream@1.0.5",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
+      "version": "1.0.5"
     },
     "commander": {
-      "version": "2.9.0",
-      "from": "commander@2.9.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
+      "version": "2.9.0"
     },
     "commoner": {
-      "version": "0.10.4",
-      "from": "commoner@0.10.4",
-      "resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.4.tgz"
+      "version": "0.10.4"
     },
     "compressible": {
-      "version": "2.0.7",
-      "from": "compressible@2.0.7",
-      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.7.tgz"
+      "version": "2.0.7"
     },
     "compression": {
-      "version": "1.6.1",
-      "from": "compression@1.6.1",
-      "resolved": "https://registry.npmjs.org/compression/-/compression-1.6.1.tgz"
+      "version": "1.6.1"
     },
     "concat-map": {
-      "version": "0.0.1",
-      "from": "concat-map@0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+      "version": "0.0.1"
     },
     "concat-stream": {
-      "version": "1.5.1",
-      "from": "concat-stream@1.5.1",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz"
+      "version": "1.5.1"
     },
     "connect-history-api-fallback": {
-      "version": "1.1.0",
-      "from": "connect-history-api-fallback@1.1.0",
-      "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.1.0.tgz"
+      "version": "1.1.0"
     },
     "console-browserify": {
       "version": "1.1.0",
-      "from": "console-browserify@1.1.0",
-      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
       "dependencies": {
         "date-now": {
-          "version": "0.1.4",
-          "from": "date-now@0.1.4",
-          "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
+          "version": "0.1.4"
         }
       }
     },
     "constants-browserify": {
-      "version": "0.0.1",
-      "from": "constants-browserify@0.0.1",
-      "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz"
+      "version": "0.0.1"
     },
     "content-disposition": {
-      "version": "0.5.1",
-      "from": "content-disposition@0.5.1",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.1.tgz"
+      "version": "0.5.1"
     },
     "content-type": {
-      "version": "1.0.1",
-      "from": "content-type@1.0.1",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.1.tgz"
+      "version": "1.0.1"
     },
     "convert-source-map": {
-      "version": "1.1.3",
-      "from": "convert-source-map@1.1.3",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz"
+      "version": "1.1.3"
     },
     "cookie": {
-      "version": "0.1.5",
-      "from": "cookie@0.1.5",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.5.tgz"
+      "version": "0.1.5"
     },
     "cookie-signature": {
-      "version": "1.0.6",
-      "from": "cookie-signature@1.0.6",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
+      "version": "1.0.6"
     },
     "core-js": {
-      "version": "1.2.6",
-      "from": "core-js@1.2.6",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+      "version": "1.2.6"
     },
     "core-util-is": {
-      "version": "1.0.2",
-      "from": "core-util-is@1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+      "version": "1.0.2"
     },
     "cryptiles": {
-      "version": "2.0.5",
-      "from": "cryptiles@2.0.5",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+      "version": "2.0.5"
     },
     "crypto-browserify": {
-      "version": "3.2.8",
-      "from": "crypto-browserify@3.2.8",
-      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.2.8.tgz"
+      "version": "3.2.8"
     },
     "d": {
-      "version": "0.1.1",
-      "from": "d@0.1.1",
-      "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
+      "version": "0.1.1"
     },
     "dashdash": {
       "version": "1.12.2",
-      "from": "dashdash@1.12.2",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.12.2.tgz",
       "dependencies": {
         "assert-plus": {
-          "version": "0.2.0",
-          "from": "assert-plus@0.2.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
+          "version": "0.2.0"
         }
       }
     },
     "dateformat": {
-      "version": "1.0.12",
-      "from": "dateformat@1.0.12",
-      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz"
+      "version": "1.0.12"
     },
     "debug": {
-      "version": "2.2.0",
-      "from": "debug@2.2.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
+      "version": "2.2.0"
     },
     "decamelize": {
-      "version": "1.1.2",
-      "from": "decamelize@1.1.2",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.2.tgz"
+      "version": "1.1.2"
     },
     "deep-equal": {
-      "version": "1.0.1",
-      "from": "deep-equal@1.0.1",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz"
+      "version": "1.0.1"
     },
     "deep-is": {
-      "version": "0.1.3",
-      "from": "deep-is@0.1.3",
-      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
+      "version": "0.1.3"
     },
     "defaults": {
-      "version": "1.0.3",
-      "from": "defaults@1.0.3",
-      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz"
+      "version": "1.0.3"
     },
     "defined": {
-      "version": "1.0.0",
-      "from": "defined@1.0.0",
-      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "defs": {
-      "version": "1.1.1",
-      "from": "defs@1.1.1",
-      "resolved": "https://registry.npmjs.org/defs/-/defs-1.1.1.tgz"
+      "version": "1.1.1"
     },
     "del": {
       "version": "2.2.0",
-      "from": "del@2.2.0",
-      "resolved": "https://registry.npmjs.org/del/-/del-2.2.0.tgz",
       "dependencies": {
         "object-assign": {
-          "version": "4.0.1",
-          "from": "object-assign@4.0.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
+          "version": "4.0.1"
         }
       }
     },
     "delayed-stream": {
-      "version": "1.0.0",
-      "from": "delayed-stream@1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "depd": {
-      "version": "1.1.0",
-      "from": "depd@1.1.0",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
+      "version": "1.1.0"
     },
     "deprecated": {
-      "version": "0.0.1",
-      "from": "deprecated@0.0.1",
-      "resolved": "https://registry.npmjs.org/deprecated/-/deprecated-0.0.1.tgz"
+      "version": "0.0.1"
     },
     "destroy": {
-      "version": "1.0.4",
-      "from": "destroy@1.0.4",
-      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz"
+      "version": "1.0.4"
     },
     "detect-indent": {
-      "version": "3.0.1",
-      "from": "detect-indent@3.0.1",
-      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz"
+      "version": "3.0.1"
     },
     "detective": {
-      "version": "4.3.1",
-      "from": "detective@4.3.1",
-      "resolved": "https://registry.npmjs.org/detective/-/detective-4.3.1.tgz"
+      "version": "4.3.1"
     },
     "doctrine": {
       "version": "0.7.2",
-      "from": "doctrine@0.7.2",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-0.7.2.tgz",
       "dependencies": {
         "esutils": {
-          "version": "1.1.6",
-          "from": "esutils@1.1.6",
-          "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz"
+          "version": "1.1.6"
         }
       }
     },
     "dom-helpers": {
-      "version": "2.4.0",
-      "from": "dom-helpers@2.4.0",
-      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-2.4.0.tgz"
+      "version": "2.4.0"
     },
     "domain-browser": {
-      "version": "1.1.7",
-      "from": "domain-browser@1.1.7",
-      "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz"
+      "version": "1.1.7"
     },
     "duplexer2": {
       "version": "0.0.2",
-      "from": "duplexer2@0.0.2",
-      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
       "dependencies": {
         "readable-stream": {
-          "version": "1.1.13",
-          "from": "readable-stream@1.1.13",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz"
+          "version": "1.1.13"
         }
       }
     },
     "ecc-jsbn": {
-      "version": "0.1.1",
-      "from": "ecc-jsbn@0.1.1",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
+      "version": "0.1.1"
     },
     "ee-first": {
-      "version": "1.1.1",
-      "from": "ee-first@1.1.1",
-      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
+      "version": "1.1.1"
     },
     "element-class": {
       "version": "0.2.2"
     },
     "end-of-stream": {
-      "version": "0.1.5",
-      "from": "end-of-stream@0.1.5",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz"
+      "version": "0.1.5"
     },
     "enhanced-resolve": {
       "version": "0.9.1",
-      "from": "enhanced-resolve@0.9.1",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-0.9.1.tgz",
       "dependencies": {
         "memory-fs": {
-          "version": "0.2.0",
-          "from": "memory-fs@0.2.0",
-          "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.2.0.tgz"
+          "version": "0.2.0"
         }
       }
     },
     "envify": {
-      "version": "3.4.0",
-      "from": "envify@3.4.0",
-      "resolved": "https://registry.npmjs.org/envify/-/envify-3.4.0.tgz"
+      "version": "3.4.0"
     },
     "errno": {
-      "version": "0.1.4",
-      "from": "errno@0.1.4",
-      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz"
+      "version": "0.1.4"
     },
     "error-ex": {
-      "version": "1.3.0",
-      "from": "error-ex@1.3.0",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz"
+      "version": "1.3.0"
     },
     "es5-ext": {
-      "version": "0.10.11",
-      "from": "es5-ext@0.10.11",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.11.tgz"
+      "version": "0.10.11"
     },
     "es6-iterator": {
-      "version": "2.0.0",
-      "from": "es6-iterator@2.0.0",
-      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz"
+      "version": "2.0.0"
     },
     "es6-map": {
-      "version": "0.1.3",
-      "from": "es6-map@0.1.3",
-      "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.3.tgz"
+      "version": "0.1.3"
     },
     "es6-promise": {
-      "version": "3.0.2",
-      "from": "es6-promise@3.0.2",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz"
+      "version": "3.0.2"
     },
     "es6-set": {
-      "version": "0.1.4",
-      "from": "es6-set@0.1.4",
-      "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.4.tgz"
+      "version": "0.1.4"
     },
     "es6-symbol": {
-      "version": "3.0.2",
-      "from": "es6-symbol@3.0.2",
-      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.2.tgz"
+      "version": "3.0.2"
     },
     "es6-weak-map": {
-      "version": "2.0.1",
-      "from": "es6-weak-map@2.0.1",
-      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.1.tgz"
+      "version": "2.0.1"
     },
     "escape-html": {
-      "version": "1.0.3",
-      "from": "escape-html@1.0.3",
-      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
+      "version": "1.0.3"
     },
     "escape-string-regexp": {
-      "version": "1.0.4",
-      "from": "escape-string-regexp@1.0.4",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
+      "version": "1.0.4"
     },
     "escope": {
-      "version": "3.3.0",
-      "from": "escope@3.3.0",
-      "resolved": "https://registry.npmjs.org/escope/-/escope-3.3.0.tgz"
+      "version": "3.3.0"
     },
     "eslint": {
       "version": "1.10.3",
-      "from": "eslint@1.10.3",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-1.10.3.tgz",
       "dependencies": {
         "espree": {
-          "version": "2.2.5",
-          "from": "espree@2.2.5",
-          "resolved": "https://registry.npmjs.org/espree/-/espree-2.2.5.tgz"
+          "version": "2.2.5"
         },
         "globals": {
-          "version": "8.18.0",
-          "from": "globals@8.18.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz"
+          "version": "8.18.0"
         },
         "minimatch": {
-          "version": "3.0.0",
-          "from": "minimatch@3.0.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz"
+          "version": "3.0.0"
         },
         "object-assign": {
-          "version": "4.0.1",
-          "from": "object-assign@4.0.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
+          "version": "4.0.1"
         },
         "user-home": {
-          "version": "2.0.0",
-          "from": "user-home@2.0.0",
-          "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz"
+          "version": "2.0.0"
         }
       }
     },
     "eslint-config-airbnb": {
-      "version": "1.0.2",
-      "from": "eslint-config-airbnb@1.0.2",
-      "resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-1.0.2.tgz"
+      "version": "1.0.2"
     },
     "eslint-loader": {
       "version": "1.2.1",
-      "from": "eslint-loader@1.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-loader/-/eslint-loader-1.2.1.tgz",
       "dependencies": {
         "object-assign": {
-          "version": "4.0.1",
-          "from": "object-assign@4.0.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
+          "version": "4.0.1"
         }
       }
     },
     "eslint-plugin-babel": {
-      "version": "3.0.0",
-      "from": "eslint-plugin-babel@3.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-babel/-/eslint-plugin-babel-3.0.0.tgz"
+      "version": "3.0.0"
     },
     "eslint-plugin-react": {
-      "version": "3.15.0",
-      "from": "eslint-plugin-react@3.15.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-3.15.0.tgz"
+      "version": "3.15.0"
     },
     "esprima-fb": {
-      "version": "15001.1001.0-dev-harmony-fb",
-      "from": "esprima-fb@15001.1001.0-dev-harmony-fb",
-      "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz"
+      "version": "15001.1001.0-dev-harmony-fb"
     },
     "esrecurse": {
       "version": "3.1.1",
-      "from": "esrecurse@3.1.1",
-      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-3.1.1.tgz",
       "dependencies": {
         "estraverse": {
-          "version": "3.1.0",
-          "from": "estraverse@3.1.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-3.1.0.tgz"
+          "version": "3.1.0"
         }
       }
     },
     "estraverse": {
-      "version": "4.1.1",
-      "from": "estraverse@4.1.1",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz"
+      "version": "4.1.1"
     },
     "estraverse-fb": {
-      "version": "1.3.1",
-      "from": "estraverse-fb@1.3.1",
-      "resolved": "https://registry.npmjs.org/estraverse-fb/-/estraverse-fb-1.3.1.tgz"
+      "version": "1.3.1"
     },
     "esutils": {
-      "version": "2.0.2",
-      "from": "esutils@2.0.2",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+      "version": "2.0.2"
     },
     "etag": {
-      "version": "1.7.0",
-      "from": "etag@1.7.0",
-      "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz"
+      "version": "1.7.0"
     },
     "event-emitter": {
-      "version": "0.3.4",
-      "from": "event-emitter@0.3.4",
-      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.4.tgz"
+      "version": "0.3.4"
     },
     "eventemitter3": {
-      "version": "1.1.1",
-      "from": "eventemitter3@1.1.1",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.1.1.tgz"
+      "version": "1.1.1"
     },
     "events": {
-      "version": "1.1.0",
-      "from": "events@1.1.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-1.1.0.tgz"
+      "version": "1.1.0"
     },
     "eventsource": {
-      "version": "0.1.6",
-      "from": "eventsource@0.1.6",
-      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.6.tgz"
+      "version": "0.1.6"
     },
     "exit": {
-      "version": "0.1.2",
-      "from": "exit@0.1.2",
-      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
+      "version": "0.1.2"
     },
     "exit-hook": {
-      "version": "1.1.1",
-      "from": "exit-hook@1.1.1",
-      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz"
+      "version": "1.1.1"
     },
     "expand-brackets": {
-      "version": "0.1.4",
-      "from": "expand-brackets@0.1.4",
-      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.4.tgz"
+      "version": "0.1.4"
     },
     "expand-range": {
-      "version": "1.8.1",
-      "from": "expand-range@1.8.1",
-      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz"
+      "version": "1.8.1"
     },
     "express": {
       "version": "4.13.4",
-      "from": "express@4.13.4",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.13.4.tgz",
       "dependencies": {
         "accepts": {
-          "version": "1.2.13",
-          "from": "accepts@1.2.13",
-          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.13.tgz"
+          "version": "1.2.13"
         },
         "negotiator": {
-          "version": "0.5.3",
-          "from": "negotiator@0.5.3",
-          "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz"
+          "version": "0.5.3"
         },
         "qs": {
-          "version": "4.0.0",
-          "from": "qs@4.0.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz"
+          "version": "4.0.0"
         },
         "vary": {
-          "version": "1.0.1",
-          "from": "vary@1.0.1",
-          "resolved": "https://registry.npmjs.org/vary/-/vary-1.0.1.tgz"
+          "version": "1.0.1"
         }
       }
     },
     "extend": {
-      "version": "2.0.1",
-      "from": "extend@2.0.1",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-2.0.1.tgz"
+      "version": "2.0.1"
     },
     "extglob": {
-      "version": "0.3.2",
-      "from": "extglob@0.3.2",
-      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz"
+      "version": "0.3.2"
     },
     "extsprintf": {
-      "version": "1.0.2",
-      "from": "extsprintf@1.0.2",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
+      "version": "1.0.2"
     },
     "fancy-log": {
-      "version": "1.1.0",
-      "from": "fancy-log@1.1.0",
-      "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.1.0.tgz"
+      "version": "1.1.0"
     },
     "fast-levenshtein": {
-      "version": "1.0.7",
-      "from": "fast-levenshtein@1.0.7",
-      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz"
+      "version": "1.0.7"
     },
     "faye-websocket": {
-      "version": "0.9.4",
-      "from": "faye-websocket@0.9.4",
-      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.9.4.tgz"
+      "version": "0.9.4"
     },
     "fbjs": {
-      "version": "0.3.2",
-      "from": "fbjs@0.3.2",
-      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.3.2.tgz"
+      "version": "0.3.2"
     },
     "fetch-polyfill": {
-      "version": "0.8.2",
-      "from": "fetch-polyfill@0.8.2",
-      "resolved": "https://registry.npmjs.org/fetch-polyfill/-/fetch-polyfill-0.8.2.tgz"
+      "version": "0.8.2"
     },
     "figures": {
-      "version": "1.4.0",
-      "from": "figures@1.4.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-1.4.0.tgz"
+      "version": "1.4.0"
     },
     "file-entry-cache": {
       "version": "1.2.4",
-      "from": "file-entry-cache@1.2.4",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-1.2.4.tgz",
       "dependencies": {
         "object-assign": {
-          "version": "4.0.1",
-          "from": "object-assign@4.0.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
+          "version": "4.0.1"
         }
       }
     },
     "filename-regex": {
-      "version": "2.0.0",
-      "from": "filename-regex@2.0.0",
-      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz"
+      "version": "2.0.0"
     },
     "fill-range": {
-      "version": "2.2.3",
-      "from": "fill-range@2.2.3",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz"
+      "version": "2.2.3"
     },
     "finalhandler": {
-      "version": "0.4.1",
-      "from": "finalhandler@0.4.1",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.4.1.tgz"
+      "version": "0.4.1"
     },
     "find-index": {
-      "version": "0.1.1",
-      "from": "find-index@0.1.1",
-      "resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz"
+      "version": "0.1.1"
     },
     "find-up": {
       "version": "1.1.0",
-      "from": "find-up@1.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.0.tgz",
       "dependencies": {
         "path-exists": {
-          "version": "2.1.0",
-          "from": "path-exists@2.1.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
+          "version": "2.1.0"
         }
       }
     },
     "findup-sync": {
-      "version": "0.3.0",
-      "from": "findup-sync@0.3.0",
-      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz"
+      "version": "0.3.0"
     },
     "first-chunk-stream": {
-      "version": "1.0.0",
-      "from": "first-chunk-stream@1.0.0",
-      "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "flagged-respawn": {
-      "version": "0.3.1",
-      "from": "flagged-respawn@0.3.1",
-      "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-0.3.1.tgz"
+      "version": "0.3.1"
     },
     "flat-cache": {
-      "version": "1.0.10",
-      "from": "flat-cache@1.0.10",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.0.10.tgz"
+      "version": "1.0.10"
     },
     "for-in": {
-      "version": "0.1.4",
-      "from": "for-in@0.1.4",
-      "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz"
+      "version": "0.1.4"
     },
     "for-own": {
-      "version": "0.1.3",
-      "from": "for-own@0.1.3",
-      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz"
+      "version": "0.1.3"
     },
     "forever-agent": {
-      "version": "0.6.1",
-      "from": "forever-agent@0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+      "version": "0.6.1"
     },
     "form-data": {
-      "version": "1.0.0-rc3",
-      "from": "form-data@1.0.0-rc3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz"
+      "version": "1.0.0-rc3"
     },
     "forwarded": {
-      "version": "0.1.0",
-      "from": "forwarded@0.1.0",
-      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz"
+      "version": "0.1.0"
     },
     "fresh": {
-      "version": "0.3.0",
-      "from": "fresh@0.3.0",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz"
+      "version": "0.3.0"
     },
     "fs-readdir-recursive": {
-      "version": "0.1.2",
-      "from": "fs-readdir-recursive@0.1.2",
-      "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-0.1.2.tgz"
+      "version": "0.1.2"
     },
     "gaze": {
-      "version": "0.5.2",
-      "from": "gaze@0.5.2",
-      "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz"
+      "version": "0.5.2"
     },
     "generate-function": {
-      "version": "2.0.0",
-      "from": "generate-function@2.0.0",
-      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+      "version": "2.0.0"
     },
     "generate-object-property": {
-      "version": "1.2.0",
-      "from": "generate-object-property@1.2.0",
-      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz"
+      "version": "1.2.0"
     },
     "get-stdin": {
-      "version": "4.0.1",
-      "from": "get-stdin@4.0.1",
-      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+      "version": "4.0.1"
     },
     "glob": {
-      "version": "5.0.15",
-      "from": "glob@5.0.15",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz"
+      "version": "5.0.15"
     },
     "glob-base": {
-      "version": "0.3.0",
-      "from": "glob-base@0.3.0",
-      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz"
+      "version": "0.3.0"
     },
     "glob-parent": {
-      "version": "2.0.0",
-      "from": "glob-parent@2.0.0",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz"
+      "version": "2.0.0"
     },
     "glob-stream": {
       "version": "3.1.18",
-      "from": "glob-stream@3.1.18",
-      "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz",
       "dependencies": {
         "glob": {
-          "version": "4.5.3",
-          "from": "glob@4.5.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz"
+          "version": "4.5.3"
         },
         "readable-stream": {
-          "version": "1.0.33",
-          "from": "readable-stream@1.0.33",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz"
+          "version": "1.0.33"
         },
         "through2": {
-          "version": "0.6.5",
-          "from": "through2@0.6.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz"
+          "version": "0.6.5"
         }
       }
     },
     "glob-watcher": {
-      "version": "0.0.6",
-      "from": "glob-watcher@0.0.6",
-      "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.6.tgz"
+      "version": "0.0.6"
     },
     "glob2base": {
-      "version": "0.0.12",
-      "from": "glob2base@0.0.12",
-      "resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz"
+      "version": "0.0.12"
     },
     "globals": {
-      "version": "6.4.1",
-      "from": "globals@6.4.1",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz"
+      "version": "6.4.1"
     },
     "globby": {
       "version": "4.0.0",
-      "from": "globby@4.0.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-4.0.0.tgz",
       "dependencies": {
         "glob": {
-          "version": "6.0.4",
-          "from": "glob@6.0.4",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz"
+          "version": "6.0.4"
         },
         "object-assign": {
-          "version": "4.0.1",
-          "from": "object-assign@4.0.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
+          "version": "4.0.1"
         }
       }
     },
     "globule": {
       "version": "0.1.0",
-      "from": "globule@0.1.0",
-      "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
       "dependencies": {
         "glob": {
-          "version": "3.1.21",
-          "from": "glob@3.1.21",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz"
+          "version": "3.1.21"
         },
         "graceful-fs": {
-          "version": "1.2.3",
-          "from": "graceful-fs@1.2.3",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
+          "version": "1.2.3"
         },
         "inherits": {
-          "version": "1.0.2",
-          "from": "inherits@1.0.2",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz"
+          "version": "1.0.2"
         },
         "lodash": {
-          "version": "1.0.2",
-          "from": "lodash@1.0.2",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz"
+          "version": "1.0.2"
         },
         "minimatch": {
-          "version": "0.2.14",
-          "from": "minimatch@0.2.14",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz"
+          "version": "0.2.14"
         }
       }
     },
     "glogg": {
-      "version": "1.0.0",
-      "from": "glogg@1.0.0",
-      "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "graceful-fs": {
-      "version": "4.1.2",
-      "from": "graceful-fs@4.1.2",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
+      "version": "4.1.2"
     },
     "graceful-readlink": {
-      "version": "1.0.1",
-      "from": "graceful-readlink@1.0.1",
-      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+      "version": "1.0.1"
     },
     "gulp": {
-      "version": "3.9.0",
-      "from": "gulp@3.9.0",
-      "resolved": "https://registry.npmjs.org/gulp/-/gulp-3.9.0.tgz"
+      "version": "3.9.0"
     },
     "gulp-jasmine": {
-      "version": "2.2.1",
-      "from": "gulp-jasmine@2.2.1",
-      "resolved": "https://registry.npmjs.org/gulp-jasmine/-/gulp-jasmine-2.2.1.tgz"
+      "version": "2.2.1"
     },
     "gulp-util": {
-      "version": "3.0.7",
-      "from": "gulp-util@3.0.7",
-      "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.7.tgz"
+      "version": "3.0.7"
     },
     "gulplog": {
-      "version": "1.0.0",
-      "from": "gulplog@1.0.0",
-      "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "handlebars": {
       "version": "4.0.5",
-      "from": "handlebars@4.0.5",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.5.tgz",
       "dependencies": {
         "source-map": {
-          "version": "0.4.4",
-          "from": "source-map@0.4.4",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz"
+          "version": "0.4.4"
         }
       }
     },
     "har-validator": {
-      "version": "2.0.6",
-      "from": "har-validator@2.0.6",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz"
+      "version": "2.0.6"
     },
     "has-ansi": {
-      "version": "2.0.0",
-      "from": "has-ansi@2.0.0",
-      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
+      "version": "2.0.0"
     },
     "has-flag": {
-      "version": "1.0.0",
-      "from": "has-flag@1.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "has-gulplog": {
-      "version": "0.1.0",
-      "from": "has-gulplog@0.1.0",
-      "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz"
+      "version": "0.1.0"
     },
     "hawk": {
-      "version": "3.1.2",
-      "from": "hawk@3.1.2",
-      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.2.tgz"
+      "version": "3.1.2"
     },
     "history": {
-      "version": "1.17.0",
-      "from": "history@1.17.0",
-      "resolved": "https://registry.npmjs.org/history/-/history-1.17.0.tgz"
+      "version": "1.17.0"
     },
     "hoek": {
-      "version": "2.16.3",
-      "from": "hoek@2.16.3",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+      "version": "2.16.3"
     },
     "home-or-tmp": {
-      "version": "1.0.0",
-      "from": "home-or-tmp@1.0.0",
-      "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "hosted-git-info": {
-      "version": "2.1.4",
-      "from": "hosted-git-info@2.1.4",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz"
+      "version": "2.1.4"
     },
     "http-browserify": {
-      "version": "1.7.0",
-      "from": "http-browserify@1.7.0",
-      "resolved": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz"
+      "version": "1.7.0"
     },
     "http-errors": {
-      "version": "1.3.1",
-      "from": "http-errors@1.3.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz"
+      "version": "1.3.1"
     },
     "http-proxy": {
-      "version": "1.13.2",
-      "from": "http-proxy@1.13.2",
-      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.13.2.tgz"
+      "version": "1.13.2"
     },
     "http-signature": {
-      "version": "1.1.0",
-      "from": "http-signature@1.1.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.0.tgz"
+      "version": "1.1.0"
     },
     "https-browserify": {
-      "version": "0.0.0",
-      "from": "https-browserify@0.0.0",
-      "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.0.tgz"
+      "version": "0.0.0"
     },
     "iconv-lite": {
-      "version": "0.4.13",
-      "from": "iconv-lite@0.4.13",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
+      "version": "0.4.13"
     },
     "ieee754": {
-      "version": "1.1.6",
-      "from": "ieee754@1.1.6",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.6.tgz"
+      "version": "1.1.6"
     },
     "indent-string": {
       "version": "2.1.0",
-      "from": "indent-string@2.1.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
       "dependencies": {
         "repeating": {
-          "version": "2.0.0",
-          "from": "repeating@2.0.0",
-          "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz"
+          "version": "2.0.0"
         }
       }
     },
     "indexof": {
-      "version": "0.0.1",
-      "from": "indexof@0.0.1",
-      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
+      "version": "0.0.1"
     },
     "inflight": {
-      "version": "1.0.4",
-      "from": "inflight@1.0.4",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz"
+      "version": "1.0.4"
     },
     "inherits": {
-      "version": "2.0.1",
-      "from": "inherits@2.0.1",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+      "version": "2.0.1"
     },
     "inquirer": {
-      "version": "0.11.3",
-      "from": "inquirer@0.11.3",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.11.3.tgz"
+      "version": "0.11.3"
     },
     "interpret": {
-      "version": "0.6.6",
-      "from": "interpret@0.6.6",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-0.6.6.tgz"
+      "version": "0.6.6"
     },
     "invariant": {
-      "version": "2.2.0",
-      "from": "invariant@2.2.0",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz"
+      "version": "2.2.0"
     },
     "invert-kv": {
-      "version": "1.0.0",
-      "from": "invert-kv@1.0.0",
-      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "ipaddr.js": {
-      "version": "1.0.5",
-      "from": "ipaddr.js@1.0.5",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.0.5.tgz"
+      "version": "1.0.5"
     },
     "is-arrayish": {
-      "version": "0.2.1",
-      "from": "is-arrayish@0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
+      "version": "0.2.1"
     },
     "is-binary-path": {
-      "version": "1.0.1",
-      "from": "is-binary-path@1.0.1",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz"
+      "version": "1.0.1"
     },
     "is-buffer": {
-      "version": "1.1.1",
-      "from": "is-buffer@1.1.1",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.1.tgz"
+      "version": "1.1.1"
     },
     "is-builtin-module": {
-      "version": "1.0.0",
-      "from": "is-builtin-module@1.0.0",
-      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "is-dotfile": {
-      "version": "1.0.2",
-      "from": "is-dotfile@1.0.2",
-      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz"
+      "version": "1.0.2"
     },
     "is-equal-shallow": {
-      "version": "0.1.3",
-      "from": "is-equal-shallow@0.1.3",
-      "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
+      "version": "0.1.3"
     },
     "is-extendable": {
-      "version": "0.1.1",
-      "from": "is-extendable@0.1.1",
-      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
+      "version": "0.1.1"
     },
     "is-extglob": {
-      "version": "1.0.0",
-      "from": "is-extglob@1.0.0",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "is-finite": {
-      "version": "1.0.1",
-      "from": "is-finite@1.0.1",
-      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz"
+      "version": "1.0.1"
     },
     "is-fullwidth-code-point": {
-      "version": "1.0.0",
-      "from": "is-fullwidth-code-point@1.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "is-glob": {
-      "version": "2.0.1",
-      "from": "is-glob@2.0.1",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
+      "version": "2.0.1"
     },
     "is-integer": {
-      "version": "1.0.6",
-      "from": "is-integer@1.0.6",
-      "resolved": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.6.tgz"
+      "version": "1.0.6"
     },
     "is-my-json-valid": {
-      "version": "2.12.4",
-      "from": "is-my-json-valid@2.12.4",
-      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.4.tgz"
+      "version": "2.12.4"
     },
     "is-number": {
       "version": "2.1.0",
-      "from": "is-number@2.1.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
       "dependencies": {
         "kind-of": {
-          "version": "3.0.2",
-          "from": "kind-of@3.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz"
+          "version": "3.0.2"
         }
       }
     },
     "is-path-cwd": {
-      "version": "1.0.0",
-      "from": "is-path-cwd@1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "is-path-in-cwd": {
-      "version": "1.0.0",
-      "from": "is-path-in-cwd@1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "is-path-inside": {
-      "version": "1.0.0",
-      "from": "is-path-inside@1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "is-primitive": {
-      "version": "2.0.0",
-      "from": "is-primitive@2.0.0",
-      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
+      "version": "2.0.0"
     },
     "is-property": {
-      "version": "1.0.2",
-      "from": "is-property@1.0.2",
-      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+      "version": "1.0.2"
     },
     "is-resolvable": {
-      "version": "1.0.0",
-      "from": "is-resolvable@1.0.0",
-      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "is-typedarray": {
-      "version": "1.0.0",
-      "from": "is-typedarray@1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "is-utf8": {
-      "version": "0.2.1",
-      "from": "is-utf8@0.2.1",
-      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
+      "version": "0.2.1"
     },
     "isarray": {
-      "version": "0.0.1",
-      "from": "isarray@0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+      "version": "0.0.1"
     },
     "isobject": {
-      "version": "2.0.0",
-      "from": "isobject@2.0.0",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.0.0.tgz"
+      "version": "2.0.0"
     },
     "isstream": {
-      "version": "0.1.2",
-      "from": "isstream@0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+      "version": "0.1.2"
     },
     "jasmine": {
       "version": "2.4.1",
-      "from": "jasmine@2.4.1",
-      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-2.4.1.tgz",
       "dependencies": {
         "glob": {
-          "version": "3.2.11",
-          "from": "glob@3.2.11",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz"
+          "version": "3.2.11"
         },
         "minimatch": {
-          "version": "0.3.0",
-          "from": "minimatch@0.3.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz"
+          "version": "0.3.0"
         }
       }
     },
     "jasmine-core": {
-      "version": "2.4.1",
-      "from": "jasmine-core@2.4.1",
-      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.4.1.tgz"
+      "version": "2.4.1"
     },
     "jasmine-terminal-reporter": {
       "version": "1.0.0",
-      "from": "jasmine-terminal-reporter@1.0.0",
-      "resolved": "https://registry.npmjs.org/jasmine-terminal-reporter/-/jasmine-terminal-reporter-1.0.0.tgz",
       "dependencies": {
         "indent-string": {
-          "version": "1.2.2",
-          "from": "indent-string@1.2.2",
-          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz"
+          "version": "1.2.2"
         }
       }
     },
     "jodid25519": {
-      "version": "1.0.2",
-      "from": "jodid25519@1.0.2",
-      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
+      "version": "1.0.2"
     },
     "jquery-param": {
-      "version": "0.2.0",
-      "from": "jquery-param@0.2.0",
-      "resolved": "https://registry.npmjs.org/jquery-param/-/jquery-param-0.2.0.tgz"
+      "version": "0.2.0"
     },
     "js-tokens": {
-      "version": "1.0.1",
-      "from": "js-tokens@1.0.1",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.1.tgz"
+      "version": "1.0.1"
     },
     "js-yaml": {
       "version": "3.4.5",
-      "from": "js-yaml@3.4.5",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.4.5.tgz",
       "dependencies": {
         "esprima": {
-          "version": "2.7.1",
-          "from": "esprima@2.7.1",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.1.tgz"
+          "version": "2.7.1"
         }
       }
     },
     "jsbn": {
-      "version": "0.1.0",
-      "from": "jsbn@0.1.0",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
+      "version": "0.1.0"
     },
     "jsesc": {
-      "version": "0.5.0",
-      "from": "jsesc@0.5.0",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
+      "version": "0.5.0"
     },
     "json-schema": {
-      "version": "0.2.2",
-      "from": "json-schema@0.2.2",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz"
+      "version": "0.2.2"
     },
     "json-stable-stringify": {
-      "version": "1.0.0",
-      "from": "json-stable-stringify@1.0.0",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "json-stringify-safe": {
-      "version": "5.0.1",
-      "from": "json-stringify-safe@5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+      "version": "5.0.1"
     },
     "json3": {
-      "version": "3.3.2",
-      "from": "json3@3.3.2",
-      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz"
+      "version": "3.3.2"
     },
     "json5": {
-      "version": "0.4.0",
-      "from": "json5@0.4.0",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
+      "version": "0.4.0"
     },
     "jsonify": {
-      "version": "0.0.0",
-      "from": "jsonify@0.0.0",
-      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
+      "version": "0.0.0"
     },
     "jsonpointer": {
-      "version": "2.0.0",
-      "from": "jsonpointer@2.0.0",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
+      "version": "2.0.0"
     },
     "jsprim": {
-      "version": "1.2.2",
-      "from": "jsprim@1.2.2",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz"
+      "version": "1.2.2"
     },
     "jstransform": {
       "version": "10.1.0",
-      "from": "jstransform@10.1.0",
-      "resolved": "https://registry.npmjs.org/jstransform/-/jstransform-10.1.0.tgz",
       "dependencies": {
         "esprima-fb": {
-          "version": "13001.1001.0-dev-harmony-fb",
-          "from": "esprima-fb@13001.1001.0-dev-harmony-fb",
-          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-13001.1001.0-dev-harmony-fb.tgz"
+          "version": "13001.1001.0-dev-harmony-fb"
         },
         "source-map": {
-          "version": "0.1.31",
-          "from": "source-map@0.1.31",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.31.tgz"
+          "version": "0.1.31"
         }
       }
     },
     "keycode": {
-      "version": "2.1.0",
-      "from": "keycode@2.1.0",
-      "resolved": "https://registry.npmjs.org/keycode/-/keycode-2.1.0.tgz"
+      "version": "2.1.0"
     },
     "kind-of": {
-      "version": "2.0.1",
-      "from": "kind-of@2.0.1",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz"
+      "version": "2.0.1"
     },
     "lazy-cache": {
-      "version": "0.2.7",
-      "from": "lazy-cache@0.2.7",
-      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz"
+      "version": "0.2.7"
     },
     "lcid": {
-      "version": "1.0.0",
-      "from": "lcid@1.0.0",
-      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "left-pad": {
-      "version": "0.0.3",
-      "from": "left-pad@0.0.3",
-      "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
+      "version": "0.0.3"
     },
     "less": {
       "version": "1.6.3",
-      "from": "less@1.6.3",
-      "resolved": "https://registry.npmjs.org/less/-/less-1.6.3.tgz",
       "dependencies": {
         "mkdirp": {
-          "version": "0.3.5",
-          "from": "mkdirp@0.3.5",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+          "version": "0.3.5"
         },
         "source-map": {
-          "version": "0.1.43",
-          "from": "source-map@0.1.43",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz"
+          "version": "0.1.43"
         }
       }
     },
     "leven": {
-      "version": "1.0.2",
-      "from": "leven@1.0.2",
-      "resolved": "https://registry.npmjs.org/leven/-/leven-1.0.2.tgz"
+      "version": "1.0.2"
     },
     "levn": {
-      "version": "0.2.5",
-      "from": "levn@0.2.5",
-      "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz"
+      "version": "0.2.5"
     },
     "liftoff": {
-      "version": "2.2.0",
-      "from": "liftoff@2.2.0",
-      "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.2.0.tgz"
+      "version": "2.2.0"
     },
     "line-numbers": {
-      "version": "0.2.0",
-      "from": "line-numbers@0.2.0",
-      "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz"
+      "version": "0.2.0"
     },
     "load-json-file": {
-      "version": "1.1.0",
-      "from": "load-json-file@1.1.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz"
+      "version": "1.1.0"
     },
     "loader-utils": {
-      "version": "0.2.12",
-      "from": "loader-utils@0.2.12",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.12.tgz"
+      "version": "0.2.12"
     },
     "lodash": {
-      "version": "3.10.1",
-      "from": "lodash@3.10.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+      "version": "3.10.1"
     },
     "lodash-compat": {
-      "version": "3.10.1",
-      "from": "lodash-compat@3.10.1",
-      "resolved": "https://registry.npmjs.org/lodash-compat/-/lodash-compat-3.10.1.tgz"
+      "version": "3.10.1"
     },
     "lodash._arraycopy": {
-      "version": "3.0.0",
-      "from": "lodash._arraycopy@3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz"
+      "version": "3.0.0"
     },
     "lodash._arrayeach": {
-      "version": "3.0.0",
-      "from": "lodash._arrayeach@3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz"
+      "version": "3.0.0"
     },
     "lodash._arraymap": {
-      "version": "3.0.0",
-      "from": "lodash._arraymap@3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._arraymap/-/lodash._arraymap-3.0.0.tgz"
+      "version": "3.0.0"
     },
     "lodash._baseassign": {
-      "version": "3.2.0",
-      "from": "lodash._baseassign@3.2.0",
-      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz"
+      "version": "3.2.0"
     },
     "lodash._baseclone": {
-      "version": "3.3.0",
-      "from": "lodash._baseclone@3.3.0",
-      "resolved": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-3.3.0.tgz"
+      "version": "3.3.0"
     },
     "lodash._basecopy": {
-      "version": "3.0.1",
-      "from": "lodash._basecopy@3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
+      "version": "3.0.1"
     },
     "lodash._basedifference": {
-      "version": "3.0.3",
-      "from": "lodash._basedifference@3.0.3",
-      "resolved": "https://registry.npmjs.org/lodash._basedifference/-/lodash._basedifference-3.0.3.tgz"
+      "version": "3.0.3"
     },
     "lodash._baseflatten": {
-      "version": "3.1.4",
-      "from": "lodash._baseflatten@3.1.4",
-      "resolved": "https://registry.npmjs.org/lodash._baseflatten/-/lodash._baseflatten-3.1.4.tgz"
+      "version": "3.1.4"
     },
     "lodash._basefor": {
-      "version": "3.0.3",
-      "from": "lodash._basefor@3.0.3",
-      "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.3.tgz"
+      "version": "3.0.3"
     },
     "lodash._baseindexof": {
-      "version": "3.1.0",
-      "from": "lodash._baseindexof@3.1.0",
-      "resolved": "https://registry.npmjs.org/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz"
+      "version": "3.1.0"
     },
     "lodash._basetostring": {
-      "version": "3.0.1",
-      "from": "lodash._basetostring@3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
+      "version": "3.0.1"
     },
     "lodash._basevalues": {
-      "version": "3.0.0",
-      "from": "lodash._basevalues@3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz"
+      "version": "3.0.0"
     },
     "lodash._bindcallback": {
-      "version": "3.0.1",
-      "from": "lodash._bindcallback@3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
+      "version": "3.0.1"
     },
     "lodash._cacheindexof": {
-      "version": "3.0.2",
-      "from": "lodash._cacheindexof@3.0.2",
-      "resolved": "https://registry.npmjs.org/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz"
+      "version": "3.0.2"
     },
     "lodash._createassigner": {
-      "version": "3.1.1",
-      "from": "lodash._createassigner@3.1.1",
-      "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz"
+      "version": "3.1.1"
     },
     "lodash._createcache": {
-      "version": "3.1.2",
-      "from": "lodash._createcache@3.1.2",
-      "resolved": "https://registry.npmjs.org/lodash._createcache/-/lodash._createcache-3.1.2.tgz"
+      "version": "3.1.2"
     },
     "lodash._getnative": {
-      "version": "3.9.1",
-      "from": "lodash._getnative@3.9.1",
-      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
+      "version": "3.9.1"
     },
     "lodash._isiterateecall": {
-      "version": "3.0.9",
-      "from": "lodash._isiterateecall@3.0.9",
-      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
+      "version": "3.0.9"
     },
     "lodash._pickbyarray": {
-      "version": "3.0.2",
-      "from": "lodash._pickbyarray@3.0.2",
-      "resolved": "https://registry.npmjs.org/lodash._pickbyarray/-/lodash._pickbyarray-3.0.2.tgz"
+      "version": "3.0.2"
     },
     "lodash._pickbycallback": {
-      "version": "3.0.0",
-      "from": "lodash._pickbycallback@3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._pickbycallback/-/lodash._pickbycallback-3.0.0.tgz"
+      "version": "3.0.0"
     },
     "lodash._reescape": {
-      "version": "3.0.0",
-      "from": "lodash._reescape@3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz"
+      "version": "3.0.0"
     },
     "lodash._reevaluate": {
-      "version": "3.0.0",
-      "from": "lodash._reevaluate@3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz"
+      "version": "3.0.0"
     },
     "lodash._reinterpolate": {
-      "version": "3.0.0",
-      "from": "lodash._reinterpolate@3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
+      "version": "3.0.0"
     },
     "lodash.assign": {
-      "version": "3.2.0",
-      "from": "lodash.assign@3.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz"
+      "version": "3.2.0"
     },
     "lodash.clonedeep": {
-      "version": "3.0.2",
-      "from": "lodash.clonedeep@3.0.2",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-3.0.2.tgz"
+      "version": "3.0.2"
     },
     "lodash.escape": {
-      "version": "3.1.0",
-      "from": "lodash.escape@3.1.0",
-      "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.1.0.tgz"
+      "version": "3.1.0"
     },
     "lodash.isarguments": {
-      "version": "3.0.5",
-      "from": "lodash.isarguments@3.0.5",
-      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.5.tgz"
+      "version": "3.0.5"
     },
     "lodash.isarray": {
-      "version": "3.0.4",
-      "from": "lodash.isarray@3.0.4",
-      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+      "version": "3.0.4"
     },
     "lodash.isplainobject": {
-      "version": "3.2.0",
-      "from": "lodash.isplainobject@3.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-3.2.0.tgz"
+      "version": "3.2.0"
     },
     "lodash.istypedarray": {
-      "version": "3.0.3",
-      "from": "lodash.istypedarray@3.0.3",
-      "resolved": "https://registry.npmjs.org/lodash.istypedarray/-/lodash.istypedarray-3.0.3.tgz"
+      "version": "3.0.3"
     },
     "lodash.keys": {
-      "version": "3.1.2",
-      "from": "lodash.keys@3.1.2",
-      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz"
+      "version": "3.1.2"
     },
     "lodash.keysin": {
-      "version": "3.0.8",
-      "from": "lodash.keysin@3.0.8",
-      "resolved": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz"
+      "version": "3.0.8"
     },
     "lodash.merge": {
-      "version": "3.3.2",
-      "from": "lodash.merge@3.3.2",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-3.3.2.tgz"
+      "version": "3.3.2"
     },
     "lodash.omit": {
-      "version": "3.1.0",
-      "from": "lodash.omit@3.1.0",
-      "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-3.1.0.tgz"
+      "version": "3.1.0"
     },
     "lodash.pick": {
-      "version": "3.1.0",
-      "from": "lodash.pick@3.1.0",
-      "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-3.1.0.tgz"
+      "version": "3.1.0"
     },
     "lodash.restparam": {
-      "version": "3.6.1",
-      "from": "lodash.restparam@3.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
+      "version": "3.6.1"
     },
     "lodash.template": {
-      "version": "3.6.2",
-      "from": "lodash.template@3.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz"
+      "version": "3.6.2"
     },
     "lodash.templatesettings": {
-      "version": "3.1.1",
-      "from": "lodash.templatesettings@3.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz"
+      "version": "3.1.1"
     },
     "lodash.toplainobject": {
-      "version": "3.0.0",
-      "from": "lodash.toplainobject@3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.toplainobject/-/lodash.toplainobject-3.0.0.tgz"
+      "version": "3.0.0"
     },
     "longest": {
-      "version": "1.0.1",
-      "from": "longest@1.0.1",
-      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+      "version": "1.0.1"
     },
     "loose-envify": {
-      "version": "1.1.0",
-      "from": "loose-envify@1.1.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz"
+      "version": "1.1.0"
     },
     "loud-rejection": {
-      "version": "1.2.0",
-      "from": "loud-rejection@1.2.0",
-      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.2.0.tgz"
+      "version": "1.2.0"
     },
     "lru-cache": {
-      "version": "2.7.3",
-      "from": "lru-cache@2.7.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
+      "version": "2.7.3"
     },
     "map-obj": {
-      "version": "1.0.1",
-      "from": "map-obj@1.0.1",
-      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+      "version": "1.0.1"
     },
     "media-typer": {
-      "version": "0.3.0",
-      "from": "media-typer@0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
+      "version": "0.3.0"
     },
     "memory-fs": {
-      "version": "0.3.0",
-      "from": "memory-fs@0.3.0",
-      "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.3.0.tgz"
+      "version": "0.3.0"
     },
     "meow": {
       "version": "3.7.0",
-      "from": "meow@3.7.0",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "dependencies": {
         "object-assign": {
-          "version": "4.0.1",
-          "from": "object-assign@4.0.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
+          "version": "4.0.1"
         }
       }
     },
     "merge-descriptors": {
-      "version": "1.0.1",
-      "from": "merge-descriptors@1.0.1",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz"
+      "version": "1.0.1"
     },
     "methods": {
-      "version": "1.1.2",
-      "from": "methods@1.1.2",
-      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz"
+      "version": "1.1.2"
     },
     "micromatch": {
       "version": "2.3.7",
-      "from": "micromatch@2.3.7",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.7.tgz",
       "dependencies": {
         "kind-of": {
-          "version": "3.0.2",
-          "from": "kind-of@3.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz"
+          "version": "3.0.2"
         }
       }
     },
     "mime": {
-      "version": "1.2.11",
-      "from": "mime@1.2.11",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+      "version": "1.2.11"
     },
     "mime-db": {
-      "version": "1.21.0",
-      "from": "mime-db@1.21.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.21.0.tgz"
+      "version": "1.21.0"
     },
     "mime-types": {
-      "version": "2.1.9",
-      "from": "mime-types@2.1.9",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.9.tgz"
+      "version": "2.1.9"
     },
     "minimatch": {
-      "version": "2.0.10",
-      "from": "minimatch@2.0.10",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz"
+      "version": "2.0.10"
     },
     "minimist": {
-      "version": "1.2.0",
-      "from": "minimist@1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+      "version": "1.2.0"
     },
     "mkdirp": {
       "version": "0.5.1",
-      "from": "mkdirp@0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "dependencies": {
         "minimist": {
-          "version": "0.0.8",
-          "from": "minimist@0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+          "version": "0.0.8"
         }
       }
     },
     "moment": {
-      "version": "2.13.0",
-      "from": "moment@latest",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.13.0.tgz"
+      "version": "2.13.0"
     },
     "ms": {
-      "version": "0.7.1",
-      "from": "ms@0.7.1",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+      "version": "0.7.1"
     },
     "multipipe": {
-      "version": "0.1.2",
-      "from": "multipipe@0.1.2",
-      "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz"
+      "version": "0.1.2"
     },
     "mute-stream": {
-      "version": "0.0.5",
-      "from": "mute-stream@0.0.5",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz"
+      "version": "0.0.5"
     },
     "negotiator": {
-      "version": "0.6.0",
-      "from": "negotiator@0.6.0",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.0.tgz"
+      "version": "0.6.0"
     },
     "node-libs-browser": {
       "version": "0.5.3",
-      "from": "node-libs-browser@0.5.3",
-      "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.5.3.tgz",
       "dependencies": {
         "readable-stream": {
-          "version": "1.1.13",
-          "from": "readable-stream@1.1.13",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz"
+          "version": "1.1.13"
         }
       }
     },
     "node-uuid": {
-      "version": "1.4.7",
-      "from": "node-uuid@1.4.7",
-      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
+      "version": "1.4.7"
     },
     "normalize-package-data": {
-      "version": "2.3.5",
-      "from": "normalize-package-data@2.3.5",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz"
+      "version": "2.3.5"
     },
     "normalize-path": {
-      "version": "2.0.1",
-      "from": "normalize-path@2.0.1",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz"
+      "version": "2.0.1"
     },
     "number-is-nan": {
-      "version": "1.0.0",
-      "from": "number-is-nan@1.0.0",
-      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "oauth-sign": {
-      "version": "0.8.0",
-      "from": "oauth-sign@0.8.0",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
+      "version": "0.8.0"
     },
     "object-assign": {
-      "version": "3.0.0",
-      "from": "object-assign@3.0.0",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
+      "version": "3.0.0"
     },
     "object.omit": {
-      "version": "2.0.0",
-      "from": "object.omit@2.0.0",
-      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz"
+      "version": "2.0.0"
     },
     "on-finished": {
-      "version": "2.3.0",
-      "from": "on-finished@2.3.0",
-      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz"
+      "version": "2.3.0"
     },
     "on-headers": {
-      "version": "1.0.1",
-      "from": "on-headers@1.0.1",
-      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz"
+      "version": "1.0.1"
     },
     "once": {
-      "version": "1.3.3",
-      "from": "once@1.3.3",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz"
+      "version": "1.3.3"
     },
     "onetime": {
-      "version": "1.1.0",
-      "from": "onetime@1.1.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz"
+      "version": "1.1.0"
     },
     "optimist": {
       "version": "0.6.1",
-      "from": "optimist@0.6.1",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "dependencies": {
         "minimist": {
-          "version": "0.0.10",
-          "from": "minimist@0.0.10",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+          "version": "0.0.10"
         }
       }
     },
     "optionator": {
-      "version": "0.6.0",
-      "from": "optionator@0.6.0",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.6.0.tgz"
+      "version": "0.6.0"
     },
     "orchestrator": {
-      "version": "0.3.7",
-      "from": "orchestrator@0.3.7",
-      "resolved": "https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.7.tgz"
+      "version": "0.3.7"
     },
     "ordered-read-streams": {
-      "version": "0.1.0",
-      "from": "ordered-read-streams@0.1.0",
-      "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz"
+      "version": "0.1.0"
     },
     "original": {
-      "version": "1.0.0",
-      "from": "original@1.0.0",
-      "resolved": "https://registry.npmjs.org/original/-/original-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "os-browserify": {
-      "version": "0.1.2",
-      "from": "os-browserify@0.1.2",
-      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz"
+      "version": "0.1.2"
     },
     "os-homedir": {
-      "version": "1.0.1",
-      "from": "os-homedir@1.0.1",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
+      "version": "1.0.1"
     },
     "os-locale": {
-      "version": "1.4.0",
-      "from": "os-locale@1.4.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz"
+      "version": "1.4.0"
     },
     "os-tmpdir": {
-      "version": "1.0.1",
-      "from": "os-tmpdir@1.0.1",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
+      "version": "1.0.1"
     },
     "output-file-sync": {
-      "version": "1.1.1",
-      "from": "output-file-sync@1.1.1",
-      "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.1.tgz"
+      "version": "1.1.1"
     },
     "pako": {
-      "version": "0.2.8",
-      "from": "pako@0.2.8",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.8.tgz"
+      "version": "0.2.8"
     },
     "parse-glob": {
-      "version": "3.0.4",
-      "from": "parse-glob@3.0.4",
-      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz"
+      "version": "3.0.4"
     },
     "parse-json": {
-      "version": "2.2.0",
-      "from": "parse-json@2.2.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz"
+      "version": "2.2.0"
     },
     "parseurl": {
-      "version": "1.3.1",
-      "from": "parseurl@1.3.1",
-      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz"
+      "version": "1.3.1"
     },
     "path-browserify": {
-      "version": "0.0.0",
-      "from": "path-browserify@0.0.0",
-      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz"
+      "version": "0.0.0"
     },
     "path-exists": {
-      "version": "1.0.0",
-      "from": "path-exists@1.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "path-is-absolute": {
-      "version": "1.0.0",
-      "from": "path-is-absolute@1.0.0",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "path-is-inside": {
-      "version": "1.0.1",
-      "from": "path-is-inside@1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.1.tgz"
+      "version": "1.0.1"
     },
     "path-to-regexp": {
-      "version": "0.1.7",
-      "from": "path-to-regexp@0.1.7",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz"
+      "version": "0.1.7"
     },
     "path-type": {
-      "version": "1.1.0",
-      "from": "path-type@1.1.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz"
+      "version": "1.1.0"
     },
     "pbkdf2-compat": {
-      "version": "2.0.1",
-      "from": "pbkdf2-compat@2.0.1",
-      "resolved": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-2.0.1.tgz"
+      "version": "2.0.1"
     },
     "pify": {
-      "version": "2.3.0",
-      "from": "pify@2.3.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
+      "version": "2.3.0"
     },
     "pinkie": {
-      "version": "2.0.1",
-      "from": "pinkie@2.0.1",
-      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
+      "version": "2.0.1"
     },
     "pinkie-promise": {
-      "version": "2.0.0",
-      "from": "pinkie-promise@2.0.0",
-      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz"
+      "version": "2.0.0"
     },
     "pluralize": {
-      "version": "1.2.1",
-      "from": "pluralize@1.2.1",
-      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz"
+      "version": "1.2.1"
     },
     "prelude-ls": {
-      "version": "1.1.2",
-      "from": "prelude-ls@1.1.2",
-      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
+      "version": "1.1.2"
     },
     "preserve": {
-      "version": "0.2.0",
-      "from": "preserve@0.2.0",
-      "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
+      "version": "0.2.0"
     },
     "pretty-hrtime": {
-      "version": "1.0.1",
-      "from": "pretty-hrtime@1.0.1",
-      "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.1.tgz"
+      "version": "1.0.1"
     },
     "private": {
-      "version": "0.1.6",
-      "from": "private@0.1.6",
-      "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
+      "version": "0.1.6"
     },
     "process": {
-      "version": "0.11.2",
-      "from": "process@0.11.2",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.2.tgz"
+      "version": "0.11.2"
     },
     "process-nextick-args": {
-      "version": "1.0.6",
-      "from": "process-nextick-args@1.0.6",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+      "version": "1.0.6"
     },
     "promise": {
-      "version": "7.1.1",
-      "from": "promise@7.1.1",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-7.1.1.tgz"
+      "version": "7.1.1"
     },
     "proxy-addr": {
-      "version": "1.0.10",
-      "from": "proxy-addr@1.0.10",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.10.tgz"
+      "version": "1.0.10"
     },
     "prr": {
-      "version": "0.0.0",
-      "from": "prr@0.0.0",
-      "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz"
+      "version": "0.0.0"
     },
     "punycode": {
-      "version": "1.4.0",
-      "from": "punycode@1.4.0",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.0.tgz"
+      "version": "1.4.0"
     },
     "q": {
-      "version": "1.4.1",
-      "from": "q@1.4.1",
-      "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
+      "version": "1.4.1"
     },
     "qs": {
-      "version": "5.2.0",
-      "from": "qs@5.2.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz"
+      "version": "5.2.0"
     },
     "query-string": {
-      "version": "3.0.0",
-      "from": "query-string@3.0.0",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-3.0.0.tgz"
+      "version": "3.0.0"
     },
     "querystring": {
-      "version": "0.2.0",
-      "from": "querystring@0.2.0",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
+      "version": "0.2.0"
     },
     "querystring-es3": {
-      "version": "0.2.1",
-      "from": "querystring-es3@0.2.1",
-      "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz"
+      "version": "0.2.1"
     },
     "querystringify": {
-      "version": "0.0.3",
-      "from": "querystringify@0.0.3",
-      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-0.0.3.tgz"
+      "version": "0.0.3"
     },
     "randomatic": {
       "version": "1.1.5",
-      "from": "randomatic@1.1.5",
-      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz",
       "dependencies": {
         "kind-of": {
-          "version": "3.0.2",
-          "from": "kind-of@3.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz"
+          "version": "3.0.2"
         }
       }
     },
     "range-parser": {
-      "version": "1.0.3",
-      "from": "range-parser@1.0.3",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz"
+      "version": "1.0.3"
     },
     "react": {
-      "version": "0.14.3",
-      "from": "react@0.14.3",
-      "resolved": "https://registry.npmjs.org/react/-/react-0.14.3.tgz"
+      "version": "0.14.3"
     },
     "react-bootstrap": {
-      "version": "0.28.2",
-      "from": "react-bootstrap@0.28.2",
-      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-0.28.2.tgz"
+      "version": "0.28.2"
     },
     "react-bootstrap-table": {
       "version": "2.2.0"
     },
     "react-dom": {
-      "version": "0.14.3",
-      "from": "react-dom@0.14.3",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-0.14.3.tgz"
+      "version": "0.14.3"
     },
     "react-filtered-multiselect": {
-      "version": "0.4.2",
-      "from": "react-filtered-multiselect@0.4.2",
-      "resolved": "https://registry.npmjs.org/react-filtered-multiselect/-/react-filtered-multiselect-0.4.2.tgz"
-    },
-    "react-onclickout": {
-      "version": "2.0.4",
-      "from": "react-onclickout@>=2.0.4 <3.0.0",
-      "resolved": "https://registry.npmjs.org/react-onclickout/-/react-onclickout-2.0.4.tgz"
+      "version": "0.4.2"
     },
     "react-onclickout": {
       "version": "2.0.4"
     },
     "react-overlays": {
       "version": "0.5.4",
-      "from": "react-overlays@0.5.4",
-      "resolved": "https://registry.npmjs.org/react-overlays/-/react-overlays-0.5.4.tgz",
       "dependencies": {
         "react-prop-types": {
-          "version": "0.2.2",
-          "from": "react-prop-types@0.2.2",
-          "resolved": "https://registry.npmjs.org/react-prop-types/-/react-prop-types-0.2.2.tgz"
+          "version": "0.2.2"
         }
       }
     },
     "react-prop-types": {
-      "version": "0.3.0",
-      "from": "react-prop-types@0.3.0",
-      "resolved": "https://registry.npmjs.org/react-prop-types/-/react-prop-types-0.3.0.tgz"
+      "version": "0.3.0"
     },
     "react-router": {
-      "version": "1.0.3",
-      "from": "react-router@1.0.3",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-1.0.3.tgz"
+      "version": "1.0.3"
     },
     "react-sortablejs": {
       "version": "1.0.0"
@@ -2418,269 +1483,167 @@
       "version": "2.6.1"
     },
     "read-json-sync": {
-      "version": "1.1.1",
-      "from": "read-json-sync@1.1.1",
-      "resolved": "https://registry.npmjs.org/read-json-sync/-/read-json-sync-1.1.1.tgz"
+      "version": "1.1.1"
     },
     "read-pkg": {
-      "version": "1.1.0",
-      "from": "read-pkg@1.1.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz"
+      "version": "1.1.0"
     },
     "read-pkg-up": {
-      "version": "1.0.1",
-      "from": "read-pkg-up@1.0.1",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz"
+      "version": "1.0.1"
     },
     "readable-stream": {
-      "version": "2.0.5",
-      "from": "readable-stream@2.0.5",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz"
+      "version": "2.0.5"
     },
     "readdirp": {
-      "version": "2.0.0",
-      "from": "readdirp@2.0.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.0.0.tgz"
+      "version": "2.0.0"
     },
     "readline2": {
-      "version": "1.0.1",
-      "from": "readline2@1.0.1",
-      "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz"
+      "version": "1.0.1"
     },
     "recast": {
-      "version": "0.10.33",
-      "from": "recast@0.10.33",
-      "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.33.tgz"
+      "version": "0.10.33"
     },
     "rechoir": {
-      "version": "0.6.2",
-      "from": "rechoir@0.6.2",
-      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz"
+      "version": "0.6.2"
     },
     "redent": {
-      "version": "1.0.0",
-      "from": "redent@1.0.0",
-      "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "regenerate": {
-      "version": "1.2.1",
-      "from": "regenerate@1.2.1",
-      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.2.1.tgz"
+      "version": "1.2.1"
     },
     "regenerator": {
-      "version": "0.8.40",
-      "from": "regenerator@0.8.40",
-      "resolved": "https://registry.npmjs.org/regenerator/-/regenerator-0.8.40.tgz"
+      "version": "0.8.40"
     },
     "regex-cache": {
-      "version": "0.4.2",
-      "from": "regex-cache@0.4.2",
-      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.2.tgz"
+      "version": "0.4.2"
     },
     "regexpu": {
       "version": "1.3.0",
-      "from": "regexpu@1.3.0",
-      "resolved": "https://registry.npmjs.org/regexpu/-/regexpu-1.3.0.tgz",
       "dependencies": {
         "esprima": {
-          "version": "2.7.1",
-          "from": "esprima@2.7.1",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.1.tgz"
+          "version": "2.7.1"
         }
       }
     },
     "regjsgen": {
-      "version": "0.2.0",
-      "from": "regjsgen@0.2.0",
-      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz"
+      "version": "0.2.0"
     },
     "regjsparser": {
-      "version": "0.1.5",
-      "from": "regjsparser@0.1.5",
-      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz"
+      "version": "0.1.5"
     },
     "repeat-element": {
-      "version": "1.1.2",
-      "from": "repeat-element@1.1.2",
-      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
+      "version": "1.1.2"
     },
     "repeat-string": {
-      "version": "1.5.2",
-      "from": "repeat-string@1.5.2",
-      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+      "version": "1.5.2"
     },
     "repeating": {
-      "version": "1.1.3",
-      "from": "repeating@1.1.3",
-      "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz"
+      "version": "1.1.3"
     },
     "replace-ext": {
-      "version": "0.0.1",
-      "from": "replace-ext@0.0.1",
-      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
+      "version": "0.0.1"
     },
     "request": {
       "version": "2.67.0",
-      "from": "request@2.67.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.67.0.tgz",
       "dependencies": {
         "extend": {
-          "version": "3.0.0",
-          "from": "extend@3.0.0",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
+          "version": "3.0.0"
         }
       }
     },
     "requires-port": {
-      "version": "1.0.0",
-      "from": "requires-port@1.0.0",
-      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "resolve": {
-      "version": "1.1.6",
-      "from": "resolve@1.1.6",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz"
+      "version": "1.1.6"
     },
     "restore-cursor": {
-      "version": "1.0.1",
-      "from": "restore-cursor@1.0.1",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz"
+      "version": "1.0.1"
     },
     "right-align": {
-      "version": "0.1.3",
-      "from": "right-align@0.1.3",
-      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz"
+      "version": "0.1.3"
     },
     "rimraf": {
       "version": "2.5.0",
-      "from": "rimraf@2.5.0",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.0.tgz",
       "dependencies": {
         "glob": {
-          "version": "6.0.4",
-          "from": "glob@6.0.4",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz"
+          "version": "6.0.4"
         }
       }
     },
     "ripemd160": {
-      "version": "0.2.0",
-      "from": "ripemd160@0.2.0",
-      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-0.2.0.tgz"
+      "version": "0.2.0"
     },
     "run-async": {
-      "version": "0.1.0",
-      "from": "run-async@0.1.0",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz"
+      "version": "0.1.0"
     },
     "rx-lite": {
-      "version": "3.1.2",
-      "from": "rx-lite@3.1.2",
-      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz"
+      "version": "3.1.2"
     },
     "semver": {
-      "version": "4.3.6",
-      "from": "semver@4.3.6",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
+      "version": "4.3.6"
     },
     "send": {
       "version": "0.13.1",
-      "from": "send@0.13.1",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.13.1.tgz",
       "dependencies": {
         "mime": {
-          "version": "1.3.4",
-          "from": "mime@1.3.4",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
+          "version": "1.3.4"
         }
       }
     },
     "sequencify": {
-      "version": "0.0.7",
-      "from": "sequencify@0.0.7",
-      "resolved": "https://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz"
+      "version": "0.0.7"
     },
     "serve-index": {
       "version": "1.7.3",
-      "from": "serve-index@1.7.3",
-      "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.7.3.tgz",
       "dependencies": {
         "accepts": {
-          "version": "1.2.13",
-          "from": "accepts@1.2.13",
-          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.13.tgz"
+          "version": "1.2.13"
         },
         "negotiator": {
-          "version": "0.5.3",
-          "from": "negotiator@0.5.3",
-          "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz"
+          "version": "0.5.3"
         }
       }
     },
     "serve-static": {
-      "version": "1.10.2",
-      "from": "serve-static@1.10.2",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.10.2.tgz"
+      "version": "1.10.2"
     },
     "sha.js": {
-      "version": "2.2.6",
-      "from": "sha.js@2.2.6",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.2.6.tgz"
+      "version": "2.2.6"
     },
     "shebang-regex": {
-      "version": "1.0.0",
-      "from": "shebang-regex@1.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "shelljs": {
-      "version": "0.5.3",
-      "from": "shelljs@0.5.3",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.5.3.tgz"
+      "version": "0.5.3"
     },
     "sigmund": {
-      "version": "1.0.1",
-      "from": "sigmund@1.0.1",
-      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+      "version": "1.0.1"
     },
     "signal-exit": {
-      "version": "2.1.2",
-      "from": "signal-exit@2.1.2",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz"
+      "version": "2.1.2"
     },
     "simple-fmt": {
-      "version": "0.1.0",
-      "from": "simple-fmt@0.1.0",
-      "resolved": "https://registry.npmjs.org/simple-fmt/-/simple-fmt-0.1.0.tgz"
+      "version": "0.1.0"
     },
     "simple-is": {
-      "version": "0.2.0",
-      "from": "simple-is@0.2.0",
-      "resolved": "https://registry.npmjs.org/simple-is/-/simple-is-0.2.0.tgz"
+      "version": "0.2.0"
     },
     "slash": {
-      "version": "1.0.0",
-      "from": "slash@1.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "sntp": {
-      "version": "1.0.9",
-      "from": "sntp@1.0.9",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+      "version": "1.0.9"
     },
     "sockjs": {
-      "version": "0.3.15",
-      "from": "sockjs@0.3.15",
-      "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.15.tgz"
+      "version": "0.3.15"
     },
     "sockjs-client": {
       "version": "1.0.3",
-      "from": "sockjs-client@1.0.3",
-      "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.0.3.tgz",
       "dependencies": {
         "faye-websocket": {
-          "version": "0.7.3",
-          "from": "faye-websocket@0.7.3",
-          "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.7.3.tgz"
+          "version": "0.7.3"
         }
       }
     },
@@ -2688,543 +1651,337 @@
       "version": "1.4.2"
     },
     "source-list-map": {
-      "version": "0.1.5",
-      "from": "source-list-map@0.1.5",
-      "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.5.tgz"
+      "version": "0.1.5"
     },
     "source-map": {
-      "version": "0.5.3",
-      "from": "source-map@0.5.3",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
+      "version": "0.5.3"
     },
     "source-map-support": {
       "version": "0.2.10",
-      "from": "source-map-support@0.2.10",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
       "dependencies": {
         "source-map": {
-          "version": "0.1.32",
-          "from": "source-map@0.1.32",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz"
+          "version": "0.1.32"
         }
       }
     },
     "sparkles": {
-      "version": "1.0.0",
-      "from": "sparkles@1.0.0",
-      "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "spdx-correct": {
-      "version": "1.0.2",
-      "from": "spdx-correct@1.0.2",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz"
+      "version": "1.0.2"
     },
     "spdx-exceptions": {
-      "version": "1.0.4",
-      "from": "spdx-exceptions@1.0.4",
-      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz"
+      "version": "1.0.4"
     },
     "spdx-expression-parse": {
-      "version": "1.0.2",
-      "from": "spdx-expression-parse@1.0.2",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz"
+      "version": "1.0.2"
     },
     "spdx-license-ids": {
-      "version": "1.2.0",
-      "from": "spdx-license-ids@1.2.0",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz"
+      "version": "1.2.0"
     },
     "sprintf-js": {
-      "version": "1.0.3",
-      "from": "sprintf-js@1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
+      "version": "1.0.3"
     },
     "sshpk": {
       "version": "1.7.3",
-      "from": "sshpk@1.7.3",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.3.tgz",
       "dependencies": {
         "assert-plus": {
-          "version": "0.2.0",
-          "from": "assert-plus@0.2.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
+          "version": "0.2.0"
         }
       }
     },
     "stable": {
-      "version": "0.1.5",
-      "from": "stable@0.1.5",
-      "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.5.tgz"
+      "version": "0.1.5"
     },
     "statuses": {
-      "version": "1.2.1",
-      "from": "statuses@1.2.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
+      "version": "1.2.1"
     },
     "stream-browserify": {
       "version": "1.0.0",
-      "from": "stream-browserify@1.0.0",
-      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz",
       "dependencies": {
         "readable-stream": {
-          "version": "1.1.13",
-          "from": "readable-stream@1.1.13",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz"
+          "version": "1.1.13"
         }
       }
     },
     "stream-cache": {
-      "version": "0.0.2",
-      "from": "stream-cache@0.0.2",
-      "resolved": "https://registry.npmjs.org/stream-cache/-/stream-cache-0.0.2.tgz"
+      "version": "0.0.2"
     },
     "stream-consume": {
-      "version": "0.1.0",
-      "from": "stream-consume@0.1.0",
-      "resolved": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.0.tgz"
+      "version": "0.1.0"
     },
     "strict-uri-encode": {
-      "version": "1.1.0",
-      "from": "strict-uri-encode@1.1.0",
-      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz"
+      "version": "1.1.0"
     },
     "string_decoder": {
-      "version": "0.10.31",
-      "from": "string_decoder@0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+      "version": "0.10.31"
     },
     "string-width": {
-      "version": "1.0.1",
-      "from": "string-width@1.0.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.1.tgz"
+      "version": "1.0.1"
     },
     "stringmap": {
-      "version": "0.2.2",
-      "from": "stringmap@0.2.2",
-      "resolved": "https://registry.npmjs.org/stringmap/-/stringmap-0.2.2.tgz"
+      "version": "0.2.2"
     },
     "stringset": {
-      "version": "0.2.1",
-      "from": "stringset@0.2.1",
-      "resolved": "https://registry.npmjs.org/stringset/-/stringset-0.2.1.tgz"
+      "version": "0.2.1"
     },
     "stringstream": {
-      "version": "0.0.5",
-      "from": "stringstream@0.0.5",
-      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
+      "version": "0.0.5"
     },
     "strip-ansi": {
-      "version": "3.0.0",
-      "from": "strip-ansi@3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz"
+      "version": "3.0.0"
     },
     "strip-bom": {
-      "version": "2.0.0",
-      "from": "strip-bom@2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz"
+      "version": "2.0.0"
     },
     "strip-indent": {
-      "version": "1.0.1",
-      "from": "strip-indent@1.0.1",
-      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz"
+      "version": "1.0.1"
     },
     "strip-json-comments": {
-      "version": "1.0.4",
-      "from": "strip-json-comments@1.0.4",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
+      "version": "1.0.4"
     },
     "supports-color": {
-      "version": "2.0.0",
-      "from": "supports-color@2.0.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+      "version": "2.0.0"
     },
     "tapable": {
-      "version": "0.1.10",
-      "from": "tapable@0.1.10",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.1.10.tgz"
+      "version": "0.1.10"
     },
     "text-table": {
-      "version": "0.2.0",
-      "from": "text-table@0.2.0",
-      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
+      "version": "0.2.0"
     },
     "through": {
-      "version": "2.3.8",
-      "from": "through@2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+      "version": "2.3.8"
     },
     "through2": {
-      "version": "2.0.0",
-      "from": "through2@2.0.0",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz"
+      "version": "2.0.0"
     },
     "tildify": {
-      "version": "1.1.2",
-      "from": "tildify@1.1.2",
-      "resolved": "https://registry.npmjs.org/tildify/-/tildify-1.1.2.tgz"
+      "version": "1.1.2"
     },
     "timers-browserify": {
-      "version": "1.4.2",
-      "from": "timers-browserify@1.4.2",
-      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz"
+      "version": "1.4.2"
     },
     "tinycolor2": {
-      "version": "1.3.0",
-      "from": "tinycolor2@1.3.0",
-      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.3.0.tgz"
+      "version": "1.3.0"
     },
     "to-fast-properties": {
-      "version": "1.0.1",
-      "from": "to-fast-properties@1.0.1",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
+      "version": "1.0.1"
     },
     "tough-cookie": {
-      "version": "2.2.1",
-      "from": "tough-cookie@2.2.1",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz"
+      "version": "2.2.1"
     },
     "trim-newlines": {
-      "version": "1.0.0",
-      "from": "trim-newlines@1.0.0",
-      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "trim-right": {
-      "version": "1.0.1",
-      "from": "trim-right@1.0.1",
-      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz"
+      "version": "1.0.1"
     },
     "try-resolve": {
-      "version": "1.0.1",
-      "from": "try-resolve@1.0.1",
-      "resolved": "https://registry.npmjs.org/try-resolve/-/try-resolve-1.0.1.tgz"
+      "version": "1.0.1"
     },
     "tryit": {
-      "version": "1.0.2",
-      "from": "tryit@1.0.2",
-      "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.2.tgz"
+      "version": "1.0.2"
     },
     "tryor": {
-      "version": "0.1.2",
-      "from": "tryor@0.1.2",
-      "resolved": "https://registry.npmjs.org/tryor/-/tryor-0.1.2.tgz"
+      "version": "0.1.2"
     },
     "tty-browserify": {
-      "version": "0.0.0",
-      "from": "tty-browserify@0.0.0",
-      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz"
+      "version": "0.0.0"
     },
     "tunnel-agent": {
-      "version": "0.4.2",
-      "from": "tunnel-agent@0.4.2",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
+      "version": "0.4.2"
     },
     "tweetnacl": {
-      "version": "0.13.3",
-      "from": "tweetnacl@0.13.3",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz"
+      "version": "0.13.3"
     },
     "type-check": {
-      "version": "0.3.2",
-      "from": "type-check@0.3.2",
-      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz"
+      "version": "0.3.2"
     },
     "type-is": {
       "version": "1.6.12",
-      "from": "type-is@1.6.12",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.12.tgz",
       "dependencies": {
         "mime-db": {
-          "version": "1.22.0",
-          "from": "mime-db@1.22.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz"
+          "version": "1.22.0"
         },
         "mime-types": {
-          "version": "2.1.10",
-          "from": "mime-types@2.1.10",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz"
+          "version": "2.1.10"
         }
       }
     },
     "typedarray": {
-      "version": "0.0.6",
-      "from": "typedarray@0.0.6",
-      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+      "version": "0.0.6"
     },
     "ua-parser-js": {
-      "version": "0.7.10",
-      "from": "ua-parser-js@0.7.10",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.10.tgz"
+      "version": "0.7.10"
     },
     "uglify-js": {
       "version": "2.6.1",
-      "from": "uglify-js@2.6.1",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.1.tgz",
       "dependencies": {
         "async": {
-          "version": "0.2.10",
-          "from": "async@0.2.10",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+          "version": "0.2.10"
         },
         "window-size": {
-          "version": "0.1.0",
-          "from": "window-size@0.1.0",
-          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+          "version": "0.1.0"
         },
         "yargs": {
-          "version": "3.10.0",
-          "from": "yargs@3.10.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz"
+          "version": "3.10.0"
         }
       }
     },
     "uglify-to-browserify": {
-      "version": "1.0.2",
-      "from": "uglify-to-browserify@1.0.2",
-      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
+      "version": "1.0.2"
     },
     "uncontrollable": {
-      "version": "3.2.1",
-      "from": "uncontrollable@3.2.1",
-      "resolved": "https://registry.npmjs.org/uncontrollable/-/uncontrollable-3.2.1.tgz"
+      "version": "3.2.1"
     },
     "unique-stream": {
-      "version": "1.0.0",
-      "from": "unique-stream@1.0.0",
-      "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "unpipe": {
-      "version": "1.0.0",
-      "from": "unpipe@1.0.0",
-      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "url": {
       "version": "0.10.3",
-      "from": "url@0.10.3",
-      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
       "dependencies": {
         "punycode": {
-          "version": "1.3.2",
-          "from": "punycode@1.3.2",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
+          "version": "1.3.2"
         }
       }
     },
     "url-parse": {
-      "version": "1.0.5",
-      "from": "url-parse@1.0.5",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.0.5.tgz"
+      "version": "1.0.5"
     },
     "user-home": {
-      "version": "1.1.1",
-      "from": "user-home@1.1.1",
-      "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
+      "version": "1.1.1"
     },
     "util": {
-      "version": "0.10.3",
-      "from": "util@0.10.3",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz"
+      "version": "0.10.3"
     },
     "util-deprecate": {
-      "version": "1.0.2",
-      "from": "util-deprecate@1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+      "version": "1.0.2"
     },
     "utils-merge": {
-      "version": "1.0.0",
-      "from": "utils-merge@1.0.0",
-      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "v8flags": {
-      "version": "2.0.11",
-      "from": "v8flags@2.0.11",
-      "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.0.11.tgz"
+      "version": "2.0.11"
     },
     "validate-npm-package-license": {
-      "version": "3.0.1",
-      "from": "validate-npm-package-license@3.0.1",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz"
+      "version": "3.0.1"
     },
     "vary": {
-      "version": "1.1.0",
-      "from": "vary@1.1.0",
-      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.0.tgz"
+      "version": "1.1.0"
     },
     "verror": {
-      "version": "1.3.6",
-      "from": "verror@1.3.6",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
+      "version": "1.3.6"
     },
     "vinyl": {
-      "version": "0.5.3",
-      "from": "vinyl@0.5.3",
-      "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz"
+      "version": "0.5.3"
     },
     "vinyl-fs": {
       "version": "0.3.14",
-      "from": "vinyl-fs@0.3.14",
-      "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.3.14.tgz",
       "dependencies": {
         "clone": {
-          "version": "0.2.0",
-          "from": "clone@0.2.0",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
+          "version": "0.2.0"
         },
         "graceful-fs": {
-          "version": "3.0.8",
-          "from": "graceful-fs@3.0.8",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
+          "version": "3.0.8"
         },
         "readable-stream": {
-          "version": "1.0.33",
-          "from": "readable-stream@1.0.33",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz"
+          "version": "1.0.33"
         },
         "strip-bom": {
-          "version": "1.0.0",
-          "from": "strip-bom@1.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz"
+          "version": "1.0.0"
         },
         "through2": {
-          "version": "0.6.5",
-          "from": "through2@0.6.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz"
+          "version": "0.6.5"
         },
         "vinyl": {
-          "version": "0.4.6",
-          "from": "vinyl@0.4.6",
-          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz"
+          "version": "0.4.6"
         }
       }
     },
     "vm-browserify": {
-      "version": "0.0.4",
-      "from": "vm-browserify@0.0.4",
-      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz"
+      "version": "0.0.4"
     },
     "warning": {
-      "version": "2.1.0",
-      "from": "warning@2.1.0",
-      "resolved": "https://registry.npmjs.org/warning/-/warning-2.1.0.tgz"
+      "version": "2.1.0"
     },
     "watchpack": {
       "version": "0.2.9",
-      "from": "watchpack@0.2.9",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-0.2.9.tgz",
       "dependencies": {
         "async": {
-          "version": "0.9.2",
-          "from": "async@0.9.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+          "version": "0.9.2"
         }
       }
     },
     "webpack": {
       "version": "1.12.11",
-      "from": "webpack@1.12.11",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-1.12.11.tgz",
       "dependencies": {
         "esprima": {
-          "version": "2.7.1",
-          "from": "esprima@2.7.1",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.1.tgz"
+          "version": "2.7.1"
         },
         "supports-color": {
-          "version": "3.1.2",
-          "from": "supports-color@3.1.2",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz"
+          "version": "3.1.2"
         }
       }
     },
     "webpack-core": {
       "version": "0.6.8",
-      "from": "webpack-core@0.6.8",
-      "resolved": "https://registry.npmjs.org/webpack-core/-/webpack-core-0.6.8.tgz",
       "dependencies": {
         "source-map": {
-          "version": "0.4.4",
-          "from": "source-map@0.4.4",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz"
+          "version": "0.4.4"
         }
       }
     },
     "webpack-dev-middleware": {
       "version": "1.5.1",
-      "from": "webpack-dev-middleware@1.5.1",
-      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.5.1.tgz",
       "dependencies": {
         "mime": {
-          "version": "1.3.4",
-          "from": "mime@1.3.4",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
+          "version": "1.3.4"
         }
       }
     },
     "webpack-dev-server": {
       "version": "1.14.1",
-      "from": "webpack-dev-server@1.14.1",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.14.1.tgz",
       "dependencies": {
         "supports-color": {
-          "version": "3.1.2",
-          "from": "supports-color@3.1.2",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz"
+          "version": "3.1.2"
         }
       }
     },
     "websocket-driver": {
-      "version": "0.6.4",
-      "from": "websocket-driver@0.6.4",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.4.tgz"
+      "version": "0.6.4"
     },
     "websocket-extensions": {
-      "version": "0.1.1",
-      "from": "websocket-extensions@0.1.1",
-      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.1.tgz"
+      "version": "0.1.1"
     },
     "whatwg-fetch": {
-      "version": "0.9.0",
-      "from": "whatwg-fetch@0.9.0",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-0.9.0.tgz"
+      "version": "0.9.0"
     },
     "window-size": {
-      "version": "0.1.4",
-      "from": "window-size@0.1.4",
-      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz"
+      "version": "0.1.4"
     },
     "wordwrap": {
-      "version": "0.0.2",
-      "from": "wordwrap@0.0.2",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+      "version": "0.0.2"
     },
     "wrappy": {
-      "version": "1.0.1",
-      "from": "wrappy@1.0.1",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+      "version": "1.0.1"
     },
     "write": {
-      "version": "0.2.1",
-      "from": "write@0.2.1",
-      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz"
+      "version": "0.2.1"
     },
     "xml-escape": {
-      "version": "1.0.0",
-      "from": "xml-escape@1.0.0",
-      "resolved": "https://registry.npmjs.org/xml-escape/-/xml-escape-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "xtend": {
-      "version": "4.0.1",
-      "from": "xtend@4.0.1",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+      "version": "4.0.1"
     },
     "y18n": {
-      "version": "3.2.0",
-      "from": "y18n@3.2.0",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.0.tgz"
+      "version": "3.2.0"
     },
     "yargs": {
-      "version": "3.27.0",
-      "from": "yargs@3.27.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.27.0.tgz"
+      "version": "3.27.0"
     }
   }
 }

--- a/gulp/npm-shrinkwrap.json
+++ b/gulp/npm-shrinkwrap.json
@@ -1462,6 +1462,9 @@
     "react-filtered-multiselect": {
       "version": "0.4.2"
     },
+    "react-native-listener": {
+      "version": "1.0.1"
+    },
     "react-onclickout": {
       "version": "2.0.4"
     },

--- a/gulp/npm-shrinkwrap.json
+++ b/gulp/npm-shrinkwrap.json
@@ -4,1477 +4,2412 @@
   "dependencies": {
     "accepts": {
       "version": "1.3.2",
+      "from": "accepts@1.3.2",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.2.tgz",
       "dependencies": {
         "mime-db": {
-          "version": "1.22.0"
+          "version": "1.22.0",
+          "from": "mime-db@1.22.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz"
         },
         "mime-types": {
-          "version": "2.1.10"
+          "version": "2.1.10",
+          "from": "mime-types@2.1.10",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz"
         }
       }
     },
     "acorn": {
-      "version": "1.2.2"
+      "version": "1.2.2",
+      "from": "acorn@1.2.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
     },
     "acorn-to-esprima": {
-      "version": "1.0.7"
+      "version": "1.0.7",
+      "from": "acorn-to-esprima@1.0.7",
+      "resolved": "https://registry.npmjs.org/acorn-to-esprima/-/acorn-to-esprima-1.0.7.tgz"
     },
     "align-text": {
-      "version": "0.1.3"
+      "version": "0.1.3",
+      "from": "align-text@0.1.3",
+      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz"
     },
     "alter": {
-      "version": "0.2.0"
+      "version": "0.2.0",
+      "from": "alter@0.2.0",
+      "resolved": "https://registry.npmjs.org/alter/-/alter-0.2.0.tgz"
     },
     "amdefine": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "amdefine@1.0.0",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
     },
     "ansi-escapes": {
-      "version": "1.1.1"
+      "version": "1.1.1",
+      "from": "ansi-escapes@1.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.1.1.tgz"
     },
     "ansi-regex": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "from": "ansi-regex@2.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
     },
     "ansi-styles": {
-      "version": "2.1.0"
+      "version": "2.1.0",
+      "from": "ansi-styles@2.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
     },
     "anymatch": {
-      "version": "1.3.0"
+      "version": "1.3.0",
+      "from": "anymatch@1.3.0",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz"
     },
     "archy": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "archy@1.0.0",
+      "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz"
     },
     "argparse": {
       "version": "1.0.4",
+      "from": "argparse@1.0.4",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.4.tgz",
       "dependencies": {
         "lodash": {
-          "version": "4.0.0"
+          "version": "4.0.0",
+          "from": "lodash@4.0.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.0.0.tgz"
         }
       }
     },
     "arr-diff": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "from": "arr-diff@2.0.0",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz"
     },
     "arr-flatten": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "from": "arr-flatten@1.0.1",
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz"
     },
     "array-differ": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "array-differ@1.0.0",
+      "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz"
     },
     "array-flatten": {
-      "version": "1.1.1"
+      "version": "1.1.1",
+      "from": "array-flatten@1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz"
     },
     "array-union": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "from": "array-union@1.0.1",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz"
     },
     "array-uniq": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "from": "array-uniq@1.0.2",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
     },
     "array-unique": {
-      "version": "0.2.1"
+      "version": "0.2.1",
+      "from": "array-unique@0.2.1",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
     },
     "arrify": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "from": "arrify@1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
     },
     "asap": {
-      "version": "2.0.3"
+      "version": "2.0.3",
+      "from": "asap@2.0.3",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.3.tgz"
     },
     "asn1": {
-      "version": "0.2.3"
+      "version": "0.2.3",
+      "from": "asn1@0.2.3",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
     },
     "assert": {
-      "version": "1.3.0"
+      "version": "1.3.0",
+      "from": "assert@1.3.0",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz"
     },
     "assert-plus": {
-      "version": "0.1.5"
+      "version": "0.1.5",
+      "from": "assert-plus@0.1.5",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
     },
     "ast-traverse": {
-      "version": "0.1.1"
+      "version": "0.1.1",
+      "from": "ast-traverse@0.1.1",
+      "resolved": "https://registry.npmjs.org/ast-traverse/-/ast-traverse-0.1.1.tgz"
     },
     "ast-types": {
-      "version": "0.8.12"
+      "version": "0.8.12",
+      "from": "ast-types@0.8.12",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.12.tgz"
     },
     "async": {
-      "version": "1.5.2"
+      "version": "1.5.2",
+      "from": "async@1.5.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
     },
     "async-each": {
-      "version": "0.1.6"
+      "version": "0.1.6",
+      "from": "async-each@0.1.6",
+      "resolved": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz"
     },
     "aws-sign2": {
-      "version": "0.6.0"
+      "version": "0.6.0",
+      "from": "aws-sign2@0.6.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
     },
     "babel": {
-      "version": "5.8.34"
+      "version": "5.8.34",
+      "from": "babel@5.8.34",
+      "resolved": "https://registry.npmjs.org/babel/-/babel-5.8.34.tgz"
     },
     "babel-core": {
-      "version": "5.8.34"
+      "version": "5.8.34",
+      "from": "babel-core@5.8.34",
+      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.34.tgz"
     },
     "babel-eslint": {
-      "version": "4.1.6"
+      "version": "4.1.6",
+      "from": "babel-eslint@4.1.6",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-4.1.6.tgz"
     },
     "babel-loader": {
-      "version": "5.4.0"
+      "version": "5.4.0",
+      "from": "babel-loader@5.4.0",
+      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-5.4.0.tgz"
     },
     "babel-plugin-constant-folding": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "from": "babel-plugin-constant-folding@1.0.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-constant-folding/-/babel-plugin-constant-folding-1.0.1.tgz"
     },
     "babel-plugin-dead-code-elimination": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "from": "babel-plugin-dead-code-elimination@1.0.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-dead-code-elimination/-/babel-plugin-dead-code-elimination-1.0.2.tgz"
     },
     "babel-plugin-eval": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "from": "babel-plugin-eval@1.0.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-eval/-/babel-plugin-eval-1.0.1.tgz"
     },
     "babel-plugin-inline-environment-variables": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "from": "babel-plugin-inline-environment-variables@1.0.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-inline-environment-variables/-/babel-plugin-inline-environment-variables-1.0.1.tgz"
     },
     "babel-plugin-jscript": {
-      "version": "1.0.4"
+      "version": "1.0.4",
+      "from": "babel-plugin-jscript@1.0.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jscript/-/babel-plugin-jscript-1.0.4.tgz"
     },
     "babel-plugin-member-expression-literals": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "from": "babel-plugin-member-expression-literals@1.0.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-member-expression-literals/-/babel-plugin-member-expression-literals-1.0.1.tgz"
     },
     "babel-plugin-property-literals": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "from": "babel-plugin-property-literals@1.0.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-property-literals/-/babel-plugin-property-literals-1.0.1.tgz"
     },
     "babel-plugin-proto-to-assign": {
-      "version": "1.0.4"
+      "version": "1.0.4",
+      "from": "babel-plugin-proto-to-assign@1.0.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-proto-to-assign/-/babel-plugin-proto-to-assign-1.0.4.tgz"
     },
     "babel-plugin-react-constant-elements": {
-      "version": "1.0.3"
+      "version": "1.0.3",
+      "from": "babel-plugin-react-constant-elements@1.0.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-react-constant-elements/-/babel-plugin-react-constant-elements-1.0.3.tgz"
     },
     "babel-plugin-react-display-name": {
-      "version": "1.0.3"
+      "version": "1.0.3",
+      "from": "babel-plugin-react-display-name@1.0.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-react-display-name/-/babel-plugin-react-display-name-1.0.3.tgz"
     },
     "babel-plugin-remove-console": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "from": "babel-plugin-remove-console@1.0.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-remove-console/-/babel-plugin-remove-console-1.0.1.tgz"
     },
     "babel-plugin-remove-debugger": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "from": "babel-plugin-remove-debugger@1.0.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-remove-debugger/-/babel-plugin-remove-debugger-1.0.1.tgz"
     },
     "babel-plugin-runtime": {
-      "version": "1.0.7"
+      "version": "1.0.7",
+      "from": "babel-plugin-runtime@1.0.7",
+      "resolved": "https://registry.npmjs.org/babel-plugin-runtime/-/babel-plugin-runtime-1.0.7.tgz"
     },
     "babel-plugin-undeclared-variables-check": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "from": "babel-plugin-undeclared-variables-check@1.0.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-undeclared-variables-check/-/babel-plugin-undeclared-variables-check-1.0.2.tgz"
     },
     "babel-plugin-undefined-to-void": {
-      "version": "1.1.6"
+      "version": "1.1.6",
+      "from": "babel-plugin-undefined-to-void@1.1.6",
+      "resolved": "https://registry.npmjs.org/babel-plugin-undefined-to-void/-/babel-plugin-undefined-to-void-1.1.6.tgz"
     },
     "babel-runtime": {
-      "version": "5.8.34"
+      "version": "5.8.34",
+      "from": "babel-runtime@5.8.34",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz"
     },
     "babylon": {
-      "version": "5.8.34"
+      "version": "5.8.34",
+      "from": "babylon@5.8.34",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.34.tgz"
     },
     "balanced-match": {
-      "version": "0.3.0"
+      "version": "0.3.0",
+      "from": "balanced-match@0.3.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
     },
     "base62": {
-      "version": "0.1.1"
+      "version": "0.1.1",
+      "from": "base62@0.1.1",
+      "resolved": "https://registry.npmjs.org/base62/-/base62-0.1.1.tgz"
     },
     "Base64": {
-      "version": "0.2.1"
+      "version": "0.2.1",
+      "from": "Base64@0.2.1",
+      "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz"
     },
     "base64-js": {
-      "version": "0.0.8"
+      "version": "0.0.8",
+      "from": "base64-js@0.0.8",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz"
     },
     "batch": {
-      "version": "0.5.3"
+      "version": "0.5.3",
+      "from": "batch@0.5.3",
+      "resolved": "https://registry.npmjs.org/batch/-/batch-0.5.3.tgz"
     },
     "beeper": {
-      "version": "1.1.0"
+      "version": "1.1.0",
+      "from": "beeper@1.1.0",
+      "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz"
     },
     "big.js": {
-      "version": "3.1.3"
+      "version": "3.1.3",
+      "from": "big.js@3.1.3",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
     },
     "binary-extensions": {
-      "version": "1.4.0"
+      "version": "1.4.0",
+      "from": "binary-extensions@1.4.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.4.0.tgz"
     },
     "bl": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "from": "bl@1.0.1",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.1.tgz"
     },
     "bluebird": {
-      "version": "2.10.2"
+      "version": "2.10.2",
+      "from": "bluebird@2.10.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz"
     },
     "boom": {
-      "version": "2.10.1"
+      "version": "2.10.1",
+      "from": "boom@2.10.1",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
     },
     "brace-expansion": {
-      "version": "1.1.2"
+      "version": "1.1.2",
+      "from": "brace-expansion@1.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz"
     },
     "braces": {
-      "version": "1.8.3"
+      "version": "1.8.3",
+      "from": "braces@1.8.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.3.tgz"
     },
     "breakable": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "breakable@1.0.0",
+      "resolved": "https://registry.npmjs.org/breakable/-/breakable-1.0.0.tgz"
     },
     "browserify-zlib": {
-      "version": "0.1.4"
+      "version": "0.1.4",
+      "from": "browserify-zlib@0.1.4",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz"
     },
     "buffer": {
       "version": "3.6.0",
+      "from": "buffer@3.6.0",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
       "dependencies": {
         "isarray": {
-          "version": "1.0.0"
+          "version": "1.0.0",
+          "from": "isarray@1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         }
       }
     },
     "builtin-modules": {
-      "version": "1.1.1"
+      "version": "1.1.1",
+      "from": "builtin-modules@1.1.1",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
     },
     "bytes": {
-      "version": "2.2.0"
+      "version": "2.2.0",
+      "from": "bytes@2.2.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.2.0.tgz"
     },
     "calendar-base": {
-      "version": "0.2.1"
+      "version": "0.2.1",
+      "from": "calendar-base@>=0.2.1 <0.3.0",
+      "resolved": "https://registry.npmjs.org/calendar-base/-/calendar-base-0.2.1.tgz"
     },
     "camelcase": {
-      "version": "1.2.1"
+      "version": "1.2.1",
+      "from": "camelcase@1.2.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
     },
     "camelcase-keys": {
       "version": "2.0.0",
+      "from": "camelcase-keys@2.0.0",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.0.0.tgz",
       "dependencies": {
         "camelcase": {
-          "version": "2.0.1"
+          "version": "2.0.1",
+          "from": "camelcase@2.0.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.0.1.tgz"
         }
       }
     },
     "caseless": {
-      "version": "0.11.0"
+      "version": "0.11.0",
+      "from": "caseless@0.11.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
     },
     "center-align": {
-      "version": "0.1.2"
+      "version": "0.1.2",
+      "from": "center-align@0.1.2",
+      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.2.tgz"
     },
     "chalk": {
-      "version": "1.1.1"
+      "version": "1.1.1",
+      "from": "chalk@1.1.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz"
     },
     "chokidar": {
-      "version": "1.4.2"
+      "version": "1.4.2",
+      "from": "chokidar@1.4.2",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.4.2.tgz"
     },
     "classnames": {
-      "version": "2.2.3"
+      "version": "2.2.3",
+      "from": "classnames@2.2.3",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.3.tgz"
     },
     "clean-css": {
       "version": "2.0.8",
+      "from": "clean-css@2.0.8",
+      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-2.0.8.tgz",
       "dependencies": {
         "commander": {
-          "version": "2.0.0"
+          "version": "2.0.0",
+          "from": "commander@2.0.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.0.0.tgz"
         }
       }
     },
     "cli-cursor": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "from": "cli-cursor@1.0.2",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz"
     },
     "cli-width": {
-      "version": "1.1.0"
+      "version": "1.1.0",
+      "from": "cli-width@1.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-1.1.0.tgz"
     },
     "cliui": {
-      "version": "2.1.0"
+      "version": "2.1.0",
+      "from": "cliui@2.1.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz"
     },
     "clone": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "from": "clone@1.0.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
     },
     "clone-stats": {
-      "version": "0.0.1"
+      "version": "0.0.1",
+      "from": "clone-stats@0.0.1",
+      "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
     },
     "code-point-at": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "code-point-at@1.0.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz"
     },
     "combined-stream": {
-      "version": "1.0.5"
+      "version": "1.0.5",
+      "from": "combined-stream@1.0.5",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
     },
     "commander": {
-      "version": "2.9.0"
+      "version": "2.9.0",
+      "from": "commander@2.9.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
     },
     "commoner": {
-      "version": "0.10.4"
+      "version": "0.10.4",
+      "from": "commoner@0.10.4",
+      "resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.4.tgz"
     },
     "compressible": {
-      "version": "2.0.7"
+      "version": "2.0.7",
+      "from": "compressible@2.0.7",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.7.tgz"
     },
     "compression": {
-      "version": "1.6.1"
+      "version": "1.6.1",
+      "from": "compression@1.6.1",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.6.1.tgz"
     },
     "concat-map": {
-      "version": "0.0.1"
+      "version": "0.0.1",
+      "from": "concat-map@0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
     },
     "concat-stream": {
-      "version": "1.5.1"
+      "version": "1.5.1",
+      "from": "concat-stream@1.5.1",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz"
     },
     "connect-history-api-fallback": {
-      "version": "1.1.0"
+      "version": "1.1.0",
+      "from": "connect-history-api-fallback@1.1.0",
+      "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.1.0.tgz"
     },
     "console-browserify": {
       "version": "1.1.0",
+      "from": "console-browserify@1.1.0",
+      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
       "dependencies": {
         "date-now": {
-          "version": "0.1.4"
+          "version": "0.1.4",
+          "from": "date-now@0.1.4",
+          "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
         }
       }
     },
     "constants-browserify": {
-      "version": "0.0.1"
+      "version": "0.0.1",
+      "from": "constants-browserify@0.0.1",
+      "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz"
     },
     "content-disposition": {
-      "version": "0.5.1"
+      "version": "0.5.1",
+      "from": "content-disposition@0.5.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.1.tgz"
     },
     "content-type": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "from": "content-type@1.0.1",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.1.tgz"
     },
     "convert-source-map": {
-      "version": "1.1.3"
+      "version": "1.1.3",
+      "from": "convert-source-map@1.1.3",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz"
     },
     "cookie": {
-      "version": "0.1.5"
+      "version": "0.1.5",
+      "from": "cookie@0.1.5",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.5.tgz"
     },
     "cookie-signature": {
-      "version": "1.0.6"
+      "version": "1.0.6",
+      "from": "cookie-signature@1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
     },
     "core-js": {
-      "version": "1.2.6"
+      "version": "1.2.6",
+      "from": "core-js@1.2.6",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
     },
     "core-util-is": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "from": "core-util-is@1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
     },
     "cryptiles": {
-      "version": "2.0.5"
+      "version": "2.0.5",
+      "from": "cryptiles@2.0.5",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
     },
     "crypto-browserify": {
-      "version": "3.2.8"
+      "version": "3.2.8",
+      "from": "crypto-browserify@3.2.8",
+      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.2.8.tgz"
     },
     "d": {
-      "version": "0.1.1"
+      "version": "0.1.1",
+      "from": "d@0.1.1",
+      "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
     },
     "dashdash": {
       "version": "1.12.2",
+      "from": "dashdash@1.12.2",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.12.2.tgz",
       "dependencies": {
         "assert-plus": {
-          "version": "0.2.0"
+          "version": "0.2.0",
+          "from": "assert-plus@0.2.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
         }
       }
     },
     "dateformat": {
-      "version": "1.0.12"
+      "version": "1.0.12",
+      "from": "dateformat@1.0.12",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz"
     },
     "debug": {
-      "version": "2.2.0"
+      "version": "2.2.0",
+      "from": "debug@2.2.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
     },
     "decamelize": {
-      "version": "1.1.2"
+      "version": "1.1.2",
+      "from": "decamelize@1.1.2",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.2.tgz"
     },
     "deep-equal": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "from": "deep-equal@1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz"
     },
     "deep-is": {
-      "version": "0.1.3"
+      "version": "0.1.3",
+      "from": "deep-is@0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
     },
     "defaults": {
-      "version": "1.0.3"
+      "version": "1.0.3",
+      "from": "defaults@1.0.3",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz"
     },
     "defined": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "defined@1.0.0",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
     },
     "defs": {
-      "version": "1.1.1"
+      "version": "1.1.1",
+      "from": "defs@1.1.1",
+      "resolved": "https://registry.npmjs.org/defs/-/defs-1.1.1.tgz"
     },
     "del": {
       "version": "2.2.0",
+      "from": "del@2.2.0",
+      "resolved": "https://registry.npmjs.org/del/-/del-2.2.0.tgz",
       "dependencies": {
         "object-assign": {
-          "version": "4.0.1"
+          "version": "4.0.1",
+          "from": "object-assign@4.0.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
         }
       }
     },
     "delayed-stream": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "delayed-stream@1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
     },
     "depd": {
-      "version": "1.1.0"
+      "version": "1.1.0",
+      "from": "depd@1.1.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
     },
     "deprecated": {
-      "version": "0.0.1"
+      "version": "0.0.1",
+      "from": "deprecated@0.0.1",
+      "resolved": "https://registry.npmjs.org/deprecated/-/deprecated-0.0.1.tgz"
     },
     "destroy": {
-      "version": "1.0.4"
+      "version": "1.0.4",
+      "from": "destroy@1.0.4",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz"
     },
     "detect-indent": {
-      "version": "3.0.1"
+      "version": "3.0.1",
+      "from": "detect-indent@3.0.1",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz"
     },
     "detective": {
-      "version": "4.3.1"
+      "version": "4.3.1",
+      "from": "detective@4.3.1",
+      "resolved": "https://registry.npmjs.org/detective/-/detective-4.3.1.tgz"
     },
     "doctrine": {
       "version": "0.7.2",
+      "from": "doctrine@0.7.2",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-0.7.2.tgz",
       "dependencies": {
         "esutils": {
-          "version": "1.1.6"
+          "version": "1.1.6",
+          "from": "esutils@1.1.6",
+          "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz"
         }
       }
     },
     "dom-helpers": {
-      "version": "2.4.0"
+      "version": "2.4.0",
+      "from": "dom-helpers@2.4.0",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-2.4.0.tgz"
     },
     "domain-browser": {
-      "version": "1.1.7"
+      "version": "1.1.7",
+      "from": "domain-browser@1.1.7",
+      "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz"
     },
     "duplexer2": {
       "version": "0.0.2",
+      "from": "duplexer2@0.0.2",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
       "dependencies": {
         "readable-stream": {
-          "version": "1.1.13"
+          "version": "1.1.13",
+          "from": "readable-stream@1.1.13",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz"
         }
       }
     },
     "ecc-jsbn": {
-      "version": "0.1.1"
+      "version": "0.1.1",
+      "from": "ecc-jsbn@0.1.1",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
     },
     "ee-first": {
-      "version": "1.1.1"
+      "version": "1.1.1",
+      "from": "ee-first@1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
     },
     "element-class": {
       "version": "0.2.2"
     },
     "end-of-stream": {
-      "version": "0.1.5"
+      "version": "0.1.5",
+      "from": "end-of-stream@0.1.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz"
     },
     "enhanced-resolve": {
       "version": "0.9.1",
+      "from": "enhanced-resolve@0.9.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-0.9.1.tgz",
       "dependencies": {
         "memory-fs": {
-          "version": "0.2.0"
+          "version": "0.2.0",
+          "from": "memory-fs@0.2.0",
+          "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.2.0.tgz"
         }
       }
     },
     "envify": {
-      "version": "3.4.0"
+      "version": "3.4.0",
+      "from": "envify@3.4.0",
+      "resolved": "https://registry.npmjs.org/envify/-/envify-3.4.0.tgz"
     },
     "errno": {
-      "version": "0.1.4"
+      "version": "0.1.4",
+      "from": "errno@0.1.4",
+      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz"
     },
     "error-ex": {
-      "version": "1.3.0"
+      "version": "1.3.0",
+      "from": "error-ex@1.3.0",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz"
     },
     "es5-ext": {
-      "version": "0.10.11"
+      "version": "0.10.11",
+      "from": "es5-ext@0.10.11",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.11.tgz"
     },
     "es6-iterator": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "from": "es6-iterator@2.0.0",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz"
     },
     "es6-map": {
-      "version": "0.1.3"
+      "version": "0.1.3",
+      "from": "es6-map@0.1.3",
+      "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.3.tgz"
     },
     "es6-promise": {
-      "version": "3.0.2"
+      "version": "3.0.2",
+      "from": "es6-promise@3.0.2",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz"
     },
     "es6-set": {
-      "version": "0.1.4"
+      "version": "0.1.4",
+      "from": "es6-set@0.1.4",
+      "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.4.tgz"
     },
     "es6-symbol": {
-      "version": "3.0.2"
+      "version": "3.0.2",
+      "from": "es6-symbol@3.0.2",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.2.tgz"
     },
     "es6-weak-map": {
-      "version": "2.0.1"
+      "version": "2.0.1",
+      "from": "es6-weak-map@2.0.1",
+      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.1.tgz"
     },
     "escape-html": {
-      "version": "1.0.3"
+      "version": "1.0.3",
+      "from": "escape-html@1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
     },
     "escape-string-regexp": {
-      "version": "1.0.4"
+      "version": "1.0.4",
+      "from": "escape-string-regexp@1.0.4",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
     },
     "escope": {
-      "version": "3.3.0"
+      "version": "3.3.0",
+      "from": "escope@3.3.0",
+      "resolved": "https://registry.npmjs.org/escope/-/escope-3.3.0.tgz"
     },
     "eslint": {
       "version": "1.10.3",
+      "from": "eslint@1.10.3",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-1.10.3.tgz",
       "dependencies": {
         "espree": {
-          "version": "2.2.5"
+          "version": "2.2.5",
+          "from": "espree@2.2.5",
+          "resolved": "https://registry.npmjs.org/espree/-/espree-2.2.5.tgz"
         },
         "globals": {
-          "version": "8.18.0"
+          "version": "8.18.0",
+          "from": "globals@8.18.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz"
         },
         "minimatch": {
-          "version": "3.0.0"
+          "version": "3.0.0",
+          "from": "minimatch@3.0.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz"
         },
         "object-assign": {
-          "version": "4.0.1"
+          "version": "4.0.1",
+          "from": "object-assign@4.0.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
         },
         "user-home": {
-          "version": "2.0.0"
+          "version": "2.0.0",
+          "from": "user-home@2.0.0",
+          "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz"
         }
       }
     },
     "eslint-config-airbnb": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "from": "eslint-config-airbnb@1.0.2",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-1.0.2.tgz"
     },
     "eslint-loader": {
       "version": "1.2.1",
+      "from": "eslint-loader@1.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-loader/-/eslint-loader-1.2.1.tgz",
       "dependencies": {
         "object-assign": {
-          "version": "4.0.1"
+          "version": "4.0.1",
+          "from": "object-assign@4.0.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
         }
       }
     },
     "eslint-plugin-babel": {
-      "version": "3.0.0"
+      "version": "3.0.0",
+      "from": "eslint-plugin-babel@3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-babel/-/eslint-plugin-babel-3.0.0.tgz"
     },
     "eslint-plugin-react": {
-      "version": "3.15.0"
+      "version": "3.15.0",
+      "from": "eslint-plugin-react@3.15.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-3.15.0.tgz"
     },
     "esprima-fb": {
-      "version": "15001.1001.0-dev-harmony-fb"
+      "version": "15001.1001.0-dev-harmony-fb",
+      "from": "esprima-fb@15001.1001.0-dev-harmony-fb",
+      "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz"
     },
     "esrecurse": {
       "version": "3.1.1",
+      "from": "esrecurse@3.1.1",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-3.1.1.tgz",
       "dependencies": {
         "estraverse": {
-          "version": "3.1.0"
+          "version": "3.1.0",
+          "from": "estraverse@3.1.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-3.1.0.tgz"
         }
       }
     },
     "estraverse": {
-      "version": "4.1.1"
+      "version": "4.1.1",
+      "from": "estraverse@4.1.1",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz"
     },
     "estraverse-fb": {
-      "version": "1.3.1"
+      "version": "1.3.1",
+      "from": "estraverse-fb@1.3.1",
+      "resolved": "https://registry.npmjs.org/estraverse-fb/-/estraverse-fb-1.3.1.tgz"
     },
     "esutils": {
-      "version": "2.0.2"
+      "version": "2.0.2",
+      "from": "esutils@2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
     },
     "etag": {
-      "version": "1.7.0"
+      "version": "1.7.0",
+      "from": "etag@1.7.0",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz"
     },
     "event-emitter": {
-      "version": "0.3.4"
+      "version": "0.3.4",
+      "from": "event-emitter@0.3.4",
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.4.tgz"
     },
     "eventemitter3": {
-      "version": "1.1.1"
+      "version": "1.1.1",
+      "from": "eventemitter3@1.1.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.1.1.tgz"
     },
     "events": {
-      "version": "1.1.0"
+      "version": "1.1.0",
+      "from": "events@1.1.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.0.tgz"
     },
     "eventsource": {
-      "version": "0.1.6"
+      "version": "0.1.6",
+      "from": "eventsource@0.1.6",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.6.tgz"
     },
     "exit": {
-      "version": "0.1.2"
+      "version": "0.1.2",
+      "from": "exit@0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
     },
     "exit-hook": {
-      "version": "1.1.1"
+      "version": "1.1.1",
+      "from": "exit-hook@1.1.1",
+      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz"
     },
     "expand-brackets": {
-      "version": "0.1.4"
+      "version": "0.1.4",
+      "from": "expand-brackets@0.1.4",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.4.tgz"
     },
     "expand-range": {
-      "version": "1.8.1"
+      "version": "1.8.1",
+      "from": "expand-range@1.8.1",
+      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz"
     },
     "express": {
       "version": "4.13.4",
+      "from": "express@4.13.4",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.13.4.tgz",
       "dependencies": {
         "accepts": {
-          "version": "1.2.13"
+          "version": "1.2.13",
+          "from": "accepts@1.2.13",
+          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.13.tgz"
         },
         "negotiator": {
-          "version": "0.5.3"
+          "version": "0.5.3",
+          "from": "negotiator@0.5.3",
+          "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz"
         },
         "qs": {
-          "version": "4.0.0"
+          "version": "4.0.0",
+          "from": "qs@4.0.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz"
         },
         "vary": {
-          "version": "1.0.1"
+          "version": "1.0.1",
+          "from": "vary@1.0.1",
+          "resolved": "https://registry.npmjs.org/vary/-/vary-1.0.1.tgz"
         }
       }
     },
     "extend": {
-      "version": "2.0.1"
+      "version": "2.0.1",
+      "from": "extend@2.0.1",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-2.0.1.tgz"
     },
     "extglob": {
-      "version": "0.3.2"
+      "version": "0.3.2",
+      "from": "extglob@0.3.2",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz"
     },
     "extsprintf": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "from": "extsprintf@1.0.2",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
     },
     "fancy-log": {
-      "version": "1.1.0"
+      "version": "1.1.0",
+      "from": "fancy-log@1.1.0",
+      "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.1.0.tgz"
     },
     "fast-levenshtein": {
-      "version": "1.0.7"
+      "version": "1.0.7",
+      "from": "fast-levenshtein@1.0.7",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz"
     },
     "faye-websocket": {
-      "version": "0.9.4"
+      "version": "0.9.4",
+      "from": "faye-websocket@0.9.4",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.9.4.tgz"
     },
     "fbjs": {
-      "version": "0.3.2"
+      "version": "0.3.2",
+      "from": "fbjs@0.3.2",
+      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.3.2.tgz"
     },
     "fetch-polyfill": {
-      "version": "0.8.2"
+      "version": "0.8.2",
+      "from": "fetch-polyfill@0.8.2",
+      "resolved": "https://registry.npmjs.org/fetch-polyfill/-/fetch-polyfill-0.8.2.tgz"
     },
     "figures": {
-      "version": "1.4.0"
+      "version": "1.4.0",
+      "from": "figures@1.4.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-1.4.0.tgz"
     },
     "file-entry-cache": {
       "version": "1.2.4",
+      "from": "file-entry-cache@1.2.4",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-1.2.4.tgz",
       "dependencies": {
         "object-assign": {
-          "version": "4.0.1"
+          "version": "4.0.1",
+          "from": "object-assign@4.0.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
         }
       }
     },
     "filename-regex": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "from": "filename-regex@2.0.0",
+      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz"
     },
     "fill-range": {
-      "version": "2.2.3"
+      "version": "2.2.3",
+      "from": "fill-range@2.2.3",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz"
     },
     "finalhandler": {
-      "version": "0.4.1"
+      "version": "0.4.1",
+      "from": "finalhandler@0.4.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.4.1.tgz"
     },
     "find-index": {
-      "version": "0.1.1"
+      "version": "0.1.1",
+      "from": "find-index@0.1.1",
+      "resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz"
     },
     "find-up": {
       "version": "1.1.0",
+      "from": "find-up@1.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.0.tgz",
       "dependencies": {
         "path-exists": {
-          "version": "2.1.0"
+          "version": "2.1.0",
+          "from": "path-exists@2.1.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
         }
       }
     },
     "findup-sync": {
-      "version": "0.3.0"
+      "version": "0.3.0",
+      "from": "findup-sync@0.3.0",
+      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz"
     },
     "first-chunk-stream": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "first-chunk-stream@1.0.0",
+      "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz"
     },
     "flagged-respawn": {
-      "version": "0.3.1"
+      "version": "0.3.1",
+      "from": "flagged-respawn@0.3.1",
+      "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-0.3.1.tgz"
     },
     "flat-cache": {
-      "version": "1.0.10"
+      "version": "1.0.10",
+      "from": "flat-cache@1.0.10",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.0.10.tgz"
     },
     "for-in": {
-      "version": "0.1.4"
+      "version": "0.1.4",
+      "from": "for-in@0.1.4",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz"
     },
     "for-own": {
-      "version": "0.1.3"
+      "version": "0.1.3",
+      "from": "for-own@0.1.3",
+      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz"
     },
     "forever-agent": {
-      "version": "0.6.1"
+      "version": "0.6.1",
+      "from": "forever-agent@0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
     },
     "form-data": {
-      "version": "1.0.0-rc3"
+      "version": "1.0.0-rc3",
+      "from": "form-data@1.0.0-rc3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz"
     },
     "forwarded": {
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "from": "forwarded@0.1.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz"
     },
     "fresh": {
-      "version": "0.3.0"
+      "version": "0.3.0",
+      "from": "fresh@0.3.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz"
     },
     "fs-readdir-recursive": {
-      "version": "0.1.2"
+      "version": "0.1.2",
+      "from": "fs-readdir-recursive@0.1.2",
+      "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-0.1.2.tgz"
     },
     "gaze": {
-      "version": "0.5.2"
+      "version": "0.5.2",
+      "from": "gaze@0.5.2",
+      "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz"
     },
     "generate-function": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "from": "generate-function@2.0.0",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
     },
     "generate-object-property": {
-      "version": "1.2.0"
+      "version": "1.2.0",
+      "from": "generate-object-property@1.2.0",
+      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz"
     },
     "get-stdin": {
-      "version": "4.0.1"
+      "version": "4.0.1",
+      "from": "get-stdin@4.0.1",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
     },
     "glob": {
-      "version": "5.0.15"
+      "version": "5.0.15",
+      "from": "glob@5.0.15",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz"
     },
     "glob-base": {
-      "version": "0.3.0"
+      "version": "0.3.0",
+      "from": "glob-base@0.3.0",
+      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz"
     },
     "glob-parent": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "from": "glob-parent@2.0.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz"
     },
     "glob-stream": {
       "version": "3.1.18",
+      "from": "glob-stream@3.1.18",
+      "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz",
       "dependencies": {
         "glob": {
-          "version": "4.5.3"
+          "version": "4.5.3",
+          "from": "glob@4.5.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz"
         },
         "readable-stream": {
-          "version": "1.0.33"
+          "version": "1.0.33",
+          "from": "readable-stream@1.0.33",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz"
         },
         "through2": {
-          "version": "0.6.5"
+          "version": "0.6.5",
+          "from": "through2@0.6.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz"
         }
       }
     },
     "glob-watcher": {
-      "version": "0.0.6"
+      "version": "0.0.6",
+      "from": "glob-watcher@0.0.6",
+      "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.6.tgz"
     },
     "glob2base": {
-      "version": "0.0.12"
+      "version": "0.0.12",
+      "from": "glob2base@0.0.12",
+      "resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz"
     },
     "globals": {
-      "version": "6.4.1"
+      "version": "6.4.1",
+      "from": "globals@6.4.1",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz"
     },
     "globby": {
       "version": "4.0.0",
+      "from": "globby@4.0.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-4.0.0.tgz",
       "dependencies": {
         "glob": {
-          "version": "6.0.4"
+          "version": "6.0.4",
+          "from": "glob@6.0.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz"
         },
         "object-assign": {
-          "version": "4.0.1"
+          "version": "4.0.1",
+          "from": "object-assign@4.0.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
         }
       }
     },
     "globule": {
       "version": "0.1.0",
+      "from": "globule@0.1.0",
+      "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
       "dependencies": {
         "glob": {
-          "version": "3.1.21"
+          "version": "3.1.21",
+          "from": "glob@3.1.21",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz"
         },
         "graceful-fs": {
-          "version": "1.2.3"
+          "version": "1.2.3",
+          "from": "graceful-fs@1.2.3",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
         },
         "inherits": {
-          "version": "1.0.2"
+          "version": "1.0.2",
+          "from": "inherits@1.0.2",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz"
         },
         "lodash": {
-          "version": "1.0.2"
+          "version": "1.0.2",
+          "from": "lodash@1.0.2",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz"
         },
         "minimatch": {
-          "version": "0.2.14"
+          "version": "0.2.14",
+          "from": "minimatch@0.2.14",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz"
         }
       }
     },
     "glogg": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "glogg@1.0.0",
+      "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz"
     },
     "graceful-fs": {
-      "version": "4.1.2"
+      "version": "4.1.2",
+      "from": "graceful-fs@4.1.2",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
     },
     "graceful-readlink": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "from": "graceful-readlink@1.0.1",
+      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
     },
     "gulp": {
-      "version": "3.9.0"
+      "version": "3.9.0",
+      "from": "gulp@3.9.0",
+      "resolved": "https://registry.npmjs.org/gulp/-/gulp-3.9.0.tgz"
     },
     "gulp-jasmine": {
-      "version": "2.2.1"
+      "version": "2.2.1",
+      "from": "gulp-jasmine@2.2.1",
+      "resolved": "https://registry.npmjs.org/gulp-jasmine/-/gulp-jasmine-2.2.1.tgz"
     },
     "gulp-util": {
-      "version": "3.0.7"
+      "version": "3.0.7",
+      "from": "gulp-util@3.0.7",
+      "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.7.tgz"
     },
     "gulplog": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "gulplog@1.0.0",
+      "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz"
     },
     "handlebars": {
       "version": "4.0.5",
+      "from": "handlebars@4.0.5",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.5.tgz",
       "dependencies": {
         "source-map": {
-          "version": "0.4.4"
+          "version": "0.4.4",
+          "from": "source-map@0.4.4",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz"
         }
       }
     },
     "har-validator": {
-      "version": "2.0.6"
+      "version": "2.0.6",
+      "from": "har-validator@2.0.6",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz"
     },
     "has-ansi": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "from": "has-ansi@2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
     },
     "has-flag": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "has-flag@1.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
     },
     "has-gulplog": {
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "from": "has-gulplog@0.1.0",
+      "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz"
     },
     "hawk": {
-      "version": "3.1.2"
+      "version": "3.1.2",
+      "from": "hawk@3.1.2",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.2.tgz"
     },
     "history": {
-      "version": "1.17.0"
+      "version": "1.17.0",
+      "from": "history@1.17.0",
+      "resolved": "https://registry.npmjs.org/history/-/history-1.17.0.tgz"
     },
     "hoek": {
-      "version": "2.16.3"
+      "version": "2.16.3",
+      "from": "hoek@2.16.3",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
     },
     "home-or-tmp": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "home-or-tmp@1.0.0",
+      "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz"
     },
     "hosted-git-info": {
-      "version": "2.1.4"
+      "version": "2.1.4",
+      "from": "hosted-git-info@2.1.4",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz"
     },
     "http-browserify": {
-      "version": "1.7.0"
+      "version": "1.7.0",
+      "from": "http-browserify@1.7.0",
+      "resolved": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz"
     },
     "http-errors": {
-      "version": "1.3.1"
+      "version": "1.3.1",
+      "from": "http-errors@1.3.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz"
     },
     "http-proxy": {
-      "version": "1.13.2"
+      "version": "1.13.2",
+      "from": "http-proxy@1.13.2",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.13.2.tgz"
     },
     "http-signature": {
-      "version": "1.1.0"
+      "version": "1.1.0",
+      "from": "http-signature@1.1.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.0.tgz"
     },
     "https-browserify": {
-      "version": "0.0.0"
+      "version": "0.0.0",
+      "from": "https-browserify@0.0.0",
+      "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.0.tgz"
     },
     "iconv-lite": {
-      "version": "0.4.13"
+      "version": "0.4.13",
+      "from": "iconv-lite@0.4.13",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
     },
     "ieee754": {
-      "version": "1.1.6"
+      "version": "1.1.6",
+      "from": "ieee754@1.1.6",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.6.tgz"
     },
     "indent-string": {
       "version": "2.1.0",
+      "from": "indent-string@2.1.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
       "dependencies": {
         "repeating": {
-          "version": "2.0.0"
+          "version": "2.0.0",
+          "from": "repeating@2.0.0",
+          "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz"
         }
       }
     },
     "indexof": {
-      "version": "0.0.1"
+      "version": "0.0.1",
+      "from": "indexof@0.0.1",
+      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
     },
     "inflight": {
-      "version": "1.0.4"
+      "version": "1.0.4",
+      "from": "inflight@1.0.4",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz"
     },
     "inherits": {
-      "version": "2.0.1"
+      "version": "2.0.1",
+      "from": "inherits@2.0.1",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
     },
     "inquirer": {
-      "version": "0.11.3"
+      "version": "0.11.3",
+      "from": "inquirer@0.11.3",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.11.3.tgz"
     },
     "interpret": {
-      "version": "0.6.6"
+      "version": "0.6.6",
+      "from": "interpret@0.6.6",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-0.6.6.tgz"
     },
     "invariant": {
-      "version": "2.2.0"
+      "version": "2.2.0",
+      "from": "invariant@2.2.0",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz"
     },
     "invert-kv": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "invert-kv@1.0.0",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
     },
     "ipaddr.js": {
-      "version": "1.0.5"
+      "version": "1.0.5",
+      "from": "ipaddr.js@1.0.5",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.0.5.tgz"
     },
     "is-arrayish": {
-      "version": "0.2.1"
+      "version": "0.2.1",
+      "from": "is-arrayish@0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
     },
     "is-binary-path": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "from": "is-binary-path@1.0.1",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz"
     },
     "is-buffer": {
-      "version": "1.1.1"
+      "version": "1.1.1",
+      "from": "is-buffer@1.1.1",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.1.tgz"
     },
     "is-builtin-module": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "is-builtin-module@1.0.0",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz"
     },
     "is-dotfile": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "from": "is-dotfile@1.0.2",
+      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz"
     },
     "is-equal-shallow": {
-      "version": "0.1.3"
+      "version": "0.1.3",
+      "from": "is-equal-shallow@0.1.3",
+      "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
     },
     "is-extendable": {
-      "version": "0.1.1"
+      "version": "0.1.1",
+      "from": "is-extendable@0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
     },
     "is-extglob": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "is-extglob@1.0.0",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
     },
     "is-finite": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "from": "is-finite@1.0.1",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz"
     },
     "is-fullwidth-code-point": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "is-fullwidth-code-point@1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz"
     },
     "is-glob": {
-      "version": "2.0.1"
+      "version": "2.0.1",
+      "from": "is-glob@2.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
     },
     "is-integer": {
-      "version": "1.0.6"
+      "version": "1.0.6",
+      "from": "is-integer@1.0.6",
+      "resolved": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.6.tgz"
     },
     "is-my-json-valid": {
-      "version": "2.12.4"
+      "version": "2.12.4",
+      "from": "is-my-json-valid@2.12.4",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.4.tgz"
     },
     "is-number": {
       "version": "2.1.0",
+      "from": "is-number@2.1.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
       "dependencies": {
         "kind-of": {
-          "version": "3.0.2"
+          "version": "3.0.2",
+          "from": "kind-of@3.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz"
         }
       }
     },
     "is-path-cwd": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "is-path-cwd@1.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz"
     },
     "is-path-in-cwd": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "is-path-in-cwd@1.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz"
     },
     "is-path-inside": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "is-path-inside@1.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz"
     },
     "is-primitive": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "from": "is-primitive@2.0.0",
+      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
     },
     "is-property": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "from": "is-property@1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
     },
     "is-resolvable": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "is-resolvable@1.0.0",
+      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz"
     },
     "is-typedarray": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "is-typedarray@1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
     },
     "is-utf8": {
-      "version": "0.2.1"
+      "version": "0.2.1",
+      "from": "is-utf8@0.2.1",
+      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
     },
     "isarray": {
-      "version": "0.0.1"
+      "version": "0.0.1",
+      "from": "isarray@0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
     },
     "isobject": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "from": "isobject@2.0.0",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.0.0.tgz"
     },
     "isstream": {
-      "version": "0.1.2"
+      "version": "0.1.2",
+      "from": "isstream@0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
     },
     "jasmine": {
       "version": "2.4.1",
+      "from": "jasmine@2.4.1",
+      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-2.4.1.tgz",
       "dependencies": {
         "glob": {
-          "version": "3.2.11"
+          "version": "3.2.11",
+          "from": "glob@3.2.11",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz"
         },
         "minimatch": {
-          "version": "0.3.0"
+          "version": "0.3.0",
+          "from": "minimatch@0.3.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz"
         }
       }
     },
     "jasmine-core": {
-      "version": "2.4.1"
+      "version": "2.4.1",
+      "from": "jasmine-core@2.4.1",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.4.1.tgz"
     },
     "jasmine-terminal-reporter": {
       "version": "1.0.0",
+      "from": "jasmine-terminal-reporter@1.0.0",
+      "resolved": "https://registry.npmjs.org/jasmine-terminal-reporter/-/jasmine-terminal-reporter-1.0.0.tgz",
       "dependencies": {
         "indent-string": {
-          "version": "1.2.2"
+          "version": "1.2.2",
+          "from": "indent-string@1.2.2",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz"
         }
       }
     },
     "jodid25519": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "from": "jodid25519@1.0.2",
+      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
     },
     "jquery-param": {
-      "version": "0.2.0"
+      "version": "0.2.0",
+      "from": "jquery-param@0.2.0",
+      "resolved": "https://registry.npmjs.org/jquery-param/-/jquery-param-0.2.0.tgz"
     },
     "js-tokens": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "from": "js-tokens@1.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.1.tgz"
     },
     "js-yaml": {
       "version": "3.4.5",
+      "from": "js-yaml@3.4.5",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.4.5.tgz",
       "dependencies": {
         "esprima": {
-          "version": "2.7.1"
+          "version": "2.7.1",
+          "from": "esprima@2.7.1",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.1.tgz"
         }
       }
     },
     "jsbn": {
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "from": "jsbn@0.1.0",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
     },
     "jsesc": {
-      "version": "0.5.0"
+      "version": "0.5.0",
+      "from": "jsesc@0.5.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
     },
     "json-schema": {
-      "version": "0.2.2"
+      "version": "0.2.2",
+      "from": "json-schema@0.2.2",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz"
     },
     "json-stable-stringify": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "json-stable-stringify@1.0.0",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.0.tgz"
     },
     "json-stringify-safe": {
-      "version": "5.0.1"
+      "version": "5.0.1",
+      "from": "json-stringify-safe@5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
     },
     "json3": {
-      "version": "3.3.2"
+      "version": "3.3.2",
+      "from": "json3@3.3.2",
+      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz"
     },
     "json5": {
-      "version": "0.4.0"
+      "version": "0.4.0",
+      "from": "json5@0.4.0",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
     },
     "jsonify": {
-      "version": "0.0.0"
+      "version": "0.0.0",
+      "from": "jsonify@0.0.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
     },
     "jsonpointer": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "from": "jsonpointer@2.0.0",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
     },
     "jsprim": {
-      "version": "1.2.2"
+      "version": "1.2.2",
+      "from": "jsprim@1.2.2",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz"
     },
     "jstransform": {
       "version": "10.1.0",
+      "from": "jstransform@10.1.0",
+      "resolved": "https://registry.npmjs.org/jstransform/-/jstransform-10.1.0.tgz",
       "dependencies": {
         "esprima-fb": {
-          "version": "13001.1001.0-dev-harmony-fb"
+          "version": "13001.1001.0-dev-harmony-fb",
+          "from": "esprima-fb@13001.1001.0-dev-harmony-fb",
+          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-13001.1001.0-dev-harmony-fb.tgz"
         },
         "source-map": {
-          "version": "0.1.31"
+          "version": "0.1.31",
+          "from": "source-map@0.1.31",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.31.tgz"
         }
       }
     },
     "keycode": {
-      "version": "2.1.0"
+      "version": "2.1.0",
+      "from": "keycode@2.1.0",
+      "resolved": "https://registry.npmjs.org/keycode/-/keycode-2.1.0.tgz"
     },
     "kind-of": {
-      "version": "2.0.1"
+      "version": "2.0.1",
+      "from": "kind-of@2.0.1",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz"
     },
     "lazy-cache": {
-      "version": "0.2.7"
+      "version": "0.2.7",
+      "from": "lazy-cache@0.2.7",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz"
     },
     "lcid": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "lcid@1.0.0",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz"
     },
     "left-pad": {
-      "version": "0.0.3"
+      "version": "0.0.3",
+      "from": "left-pad@0.0.3",
+      "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
     },
     "less": {
       "version": "1.6.3",
+      "from": "less@1.6.3",
+      "resolved": "https://registry.npmjs.org/less/-/less-1.6.3.tgz",
       "dependencies": {
         "mkdirp": {
-          "version": "0.3.5"
+          "version": "0.3.5",
+          "from": "mkdirp@0.3.5",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
         },
         "source-map": {
-          "version": "0.1.43"
+          "version": "0.1.43",
+          "from": "source-map@0.1.43",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz"
         }
       }
     },
     "leven": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "from": "leven@1.0.2",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-1.0.2.tgz"
     },
     "levn": {
-      "version": "0.2.5"
+      "version": "0.2.5",
+      "from": "levn@0.2.5",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz"
     },
     "liftoff": {
-      "version": "2.2.0"
+      "version": "2.2.0",
+      "from": "liftoff@2.2.0",
+      "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.2.0.tgz"
     },
     "line-numbers": {
-      "version": "0.2.0"
+      "version": "0.2.0",
+      "from": "line-numbers@0.2.0",
+      "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz"
     },
     "load-json-file": {
-      "version": "1.1.0"
+      "version": "1.1.0",
+      "from": "load-json-file@1.1.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz"
     },
     "loader-utils": {
-      "version": "0.2.12"
+      "version": "0.2.12",
+      "from": "loader-utils@0.2.12",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.12.tgz"
     },
     "lodash": {
-      "version": "3.10.1"
+      "version": "3.10.1",
+      "from": "lodash@3.10.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
     },
     "lodash-compat": {
-      "version": "3.10.1"
+      "version": "3.10.1",
+      "from": "lodash-compat@3.10.1",
+      "resolved": "https://registry.npmjs.org/lodash-compat/-/lodash-compat-3.10.1.tgz"
     },
     "lodash._arraycopy": {
-      "version": "3.0.0"
+      "version": "3.0.0",
+      "from": "lodash._arraycopy@3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz"
     },
     "lodash._arrayeach": {
-      "version": "3.0.0"
+      "version": "3.0.0",
+      "from": "lodash._arrayeach@3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz"
     },
     "lodash._arraymap": {
-      "version": "3.0.0"
+      "version": "3.0.0",
+      "from": "lodash._arraymap@3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._arraymap/-/lodash._arraymap-3.0.0.tgz"
     },
     "lodash._baseassign": {
-      "version": "3.2.0"
+      "version": "3.2.0",
+      "from": "lodash._baseassign@3.2.0",
+      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz"
     },
     "lodash._baseclone": {
-      "version": "3.3.0"
+      "version": "3.3.0",
+      "from": "lodash._baseclone@3.3.0",
+      "resolved": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-3.3.0.tgz"
     },
     "lodash._basecopy": {
-      "version": "3.0.1"
+      "version": "3.0.1",
+      "from": "lodash._basecopy@3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
     },
     "lodash._basedifference": {
-      "version": "3.0.3"
+      "version": "3.0.3",
+      "from": "lodash._basedifference@3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash._basedifference/-/lodash._basedifference-3.0.3.tgz"
     },
     "lodash._baseflatten": {
-      "version": "3.1.4"
+      "version": "3.1.4",
+      "from": "lodash._baseflatten@3.1.4",
+      "resolved": "https://registry.npmjs.org/lodash._baseflatten/-/lodash._baseflatten-3.1.4.tgz"
     },
     "lodash._basefor": {
-      "version": "3.0.3"
+      "version": "3.0.3",
+      "from": "lodash._basefor@3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.3.tgz"
     },
     "lodash._baseindexof": {
-      "version": "3.1.0"
+      "version": "3.1.0",
+      "from": "lodash._baseindexof@3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz"
     },
     "lodash._basetostring": {
-      "version": "3.0.1"
+      "version": "3.0.1",
+      "from": "lodash._basetostring@3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
     },
     "lodash._basevalues": {
-      "version": "3.0.0"
+      "version": "3.0.0",
+      "from": "lodash._basevalues@3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz"
     },
     "lodash._bindcallback": {
-      "version": "3.0.1"
+      "version": "3.0.1",
+      "from": "lodash._bindcallback@3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
     },
     "lodash._cacheindexof": {
-      "version": "3.0.2"
+      "version": "3.0.2",
+      "from": "lodash._cacheindexof@3.0.2",
+      "resolved": "https://registry.npmjs.org/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz"
     },
     "lodash._createassigner": {
-      "version": "3.1.1"
+      "version": "3.1.1",
+      "from": "lodash._createassigner@3.1.1",
+      "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz"
     },
     "lodash._createcache": {
-      "version": "3.1.2"
+      "version": "3.1.2",
+      "from": "lodash._createcache@3.1.2",
+      "resolved": "https://registry.npmjs.org/lodash._createcache/-/lodash._createcache-3.1.2.tgz"
     },
     "lodash._getnative": {
-      "version": "3.9.1"
+      "version": "3.9.1",
+      "from": "lodash._getnative@3.9.1",
+      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
     },
     "lodash._isiterateecall": {
-      "version": "3.0.9"
+      "version": "3.0.9",
+      "from": "lodash._isiterateecall@3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
     },
     "lodash._pickbyarray": {
-      "version": "3.0.2"
+      "version": "3.0.2",
+      "from": "lodash._pickbyarray@3.0.2",
+      "resolved": "https://registry.npmjs.org/lodash._pickbyarray/-/lodash._pickbyarray-3.0.2.tgz"
     },
     "lodash._pickbycallback": {
-      "version": "3.0.0"
+      "version": "3.0.0",
+      "from": "lodash._pickbycallback@3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._pickbycallback/-/lodash._pickbycallback-3.0.0.tgz"
     },
     "lodash._reescape": {
-      "version": "3.0.0"
+      "version": "3.0.0",
+      "from": "lodash._reescape@3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz"
     },
     "lodash._reevaluate": {
-      "version": "3.0.0"
+      "version": "3.0.0",
+      "from": "lodash._reevaluate@3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz"
     },
     "lodash._reinterpolate": {
-      "version": "3.0.0"
+      "version": "3.0.0",
+      "from": "lodash._reinterpolate@3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
     },
     "lodash.assign": {
-      "version": "3.2.0"
+      "version": "3.2.0",
+      "from": "lodash.assign@3.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz"
     },
     "lodash.clonedeep": {
-      "version": "3.0.2"
+      "version": "3.0.2",
+      "from": "lodash.clonedeep@3.0.2",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-3.0.2.tgz"
     },
     "lodash.escape": {
-      "version": "3.1.0"
+      "version": "3.1.0",
+      "from": "lodash.escape@3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.1.0.tgz"
     },
     "lodash.isarguments": {
-      "version": "3.0.5"
+      "version": "3.0.5",
+      "from": "lodash.isarguments@3.0.5",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.5.tgz"
     },
     "lodash.isarray": {
-      "version": "3.0.4"
+      "version": "3.0.4",
+      "from": "lodash.isarray@3.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
     },
     "lodash.isplainobject": {
-      "version": "3.2.0"
+      "version": "3.2.0",
+      "from": "lodash.isplainobject@3.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-3.2.0.tgz"
     },
     "lodash.istypedarray": {
-      "version": "3.0.3"
+      "version": "3.0.3",
+      "from": "lodash.istypedarray@3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.istypedarray/-/lodash.istypedarray-3.0.3.tgz"
     },
     "lodash.keys": {
-      "version": "3.1.2"
+      "version": "3.1.2",
+      "from": "lodash.keys@3.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz"
     },
     "lodash.keysin": {
-      "version": "3.0.8"
+      "version": "3.0.8",
+      "from": "lodash.keysin@3.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz"
     },
     "lodash.merge": {
-      "version": "3.3.2"
+      "version": "3.3.2",
+      "from": "lodash.merge@3.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-3.3.2.tgz"
     },
     "lodash.omit": {
-      "version": "3.1.0"
+      "version": "3.1.0",
+      "from": "lodash.omit@3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-3.1.0.tgz"
     },
     "lodash.pick": {
-      "version": "3.1.0"
+      "version": "3.1.0",
+      "from": "lodash.pick@3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-3.1.0.tgz"
     },
     "lodash.restparam": {
-      "version": "3.6.1"
+      "version": "3.6.1",
+      "from": "lodash.restparam@3.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
     },
     "lodash.template": {
-      "version": "3.6.2"
+      "version": "3.6.2",
+      "from": "lodash.template@3.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz"
     },
     "lodash.templatesettings": {
-      "version": "3.1.1"
+      "version": "3.1.1",
+      "from": "lodash.templatesettings@3.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz"
     },
     "lodash.toplainobject": {
-      "version": "3.0.0"
+      "version": "3.0.0",
+      "from": "lodash.toplainobject@3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.toplainobject/-/lodash.toplainobject-3.0.0.tgz"
     },
     "longest": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "from": "longest@1.0.1",
+      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
     },
     "loose-envify": {
-      "version": "1.1.0"
+      "version": "1.1.0",
+      "from": "loose-envify@1.1.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz"
     },
     "loud-rejection": {
-      "version": "1.2.0"
+      "version": "1.2.0",
+      "from": "loud-rejection@1.2.0",
+      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.2.0.tgz"
     },
     "lru-cache": {
-      "version": "2.7.3"
+      "version": "2.7.3",
+      "from": "lru-cache@2.7.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
     },
     "map-obj": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "from": "map-obj@1.0.1",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
     },
     "media-typer": {
-      "version": "0.3.0"
+      "version": "0.3.0",
+      "from": "media-typer@0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
     },
     "memory-fs": {
-      "version": "0.3.0"
+      "version": "0.3.0",
+      "from": "memory-fs@0.3.0",
+      "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.3.0.tgz"
     },
     "meow": {
       "version": "3.7.0",
+      "from": "meow@3.7.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "dependencies": {
         "object-assign": {
-          "version": "4.0.1"
+          "version": "4.0.1",
+          "from": "object-assign@4.0.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
         }
       }
     },
     "merge-descriptors": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "from": "merge-descriptors@1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz"
     },
     "methods": {
-      "version": "1.1.2"
+      "version": "1.1.2",
+      "from": "methods@1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz"
     },
     "micromatch": {
       "version": "2.3.7",
+      "from": "micromatch@2.3.7",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.7.tgz",
       "dependencies": {
         "kind-of": {
-          "version": "3.0.2"
+          "version": "3.0.2",
+          "from": "kind-of@3.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz"
         }
       }
     },
     "mime": {
-      "version": "1.2.11"
+      "version": "1.2.11",
+      "from": "mime@1.2.11",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
     },
     "mime-db": {
-      "version": "1.21.0"
+      "version": "1.21.0",
+      "from": "mime-db@1.21.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.21.0.tgz"
     },
     "mime-types": {
-      "version": "2.1.9"
+      "version": "2.1.9",
+      "from": "mime-types@2.1.9",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.9.tgz"
     },
     "minimatch": {
-      "version": "2.0.10"
+      "version": "2.0.10",
+      "from": "minimatch@2.0.10",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz"
     },
     "minimist": {
-      "version": "1.2.0"
+      "version": "1.2.0",
+      "from": "minimist@1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
     },
     "mkdirp": {
       "version": "0.5.1",
+      "from": "mkdirp@0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "dependencies": {
         "minimist": {
-          "version": "0.0.8"
+          "version": "0.0.8",
+          "from": "minimist@0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
         }
       }
     },
     "moment": {
-      "version": "2.13.0"
+      "version": "2.13.0",
+      "from": "moment@latest",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.13.0.tgz"
     },
     "ms": {
-      "version": "0.7.1"
+      "version": "0.7.1",
+      "from": "ms@0.7.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
     },
     "multipipe": {
-      "version": "0.1.2"
+      "version": "0.1.2",
+      "from": "multipipe@0.1.2",
+      "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz"
     },
     "mute-stream": {
-      "version": "0.0.5"
+      "version": "0.0.5",
+      "from": "mute-stream@0.0.5",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz"
     },
     "negotiator": {
-      "version": "0.6.0"
+      "version": "0.6.0",
+      "from": "negotiator@0.6.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.0.tgz"
     },
     "node-libs-browser": {
       "version": "0.5.3",
+      "from": "node-libs-browser@0.5.3",
+      "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.5.3.tgz",
       "dependencies": {
         "readable-stream": {
-          "version": "1.1.13"
+          "version": "1.1.13",
+          "from": "readable-stream@1.1.13",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz"
         }
       }
     },
     "node-uuid": {
-      "version": "1.4.7"
+      "version": "1.4.7",
+      "from": "node-uuid@1.4.7",
+      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
     },
     "normalize-package-data": {
-      "version": "2.3.5"
+      "version": "2.3.5",
+      "from": "normalize-package-data@2.3.5",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz"
     },
     "normalize-path": {
-      "version": "2.0.1"
+      "version": "2.0.1",
+      "from": "normalize-path@2.0.1",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz"
     },
     "number-is-nan": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "number-is-nan@1.0.0",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
     },
     "oauth-sign": {
-      "version": "0.8.0"
+      "version": "0.8.0",
+      "from": "oauth-sign@0.8.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
     },
     "object-assign": {
-      "version": "3.0.0"
+      "version": "3.0.0",
+      "from": "object-assign@3.0.0",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
     },
     "object.omit": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "from": "object.omit@2.0.0",
+      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz"
     },
     "on-finished": {
-      "version": "2.3.0"
+      "version": "2.3.0",
+      "from": "on-finished@2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz"
     },
     "on-headers": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "from": "on-headers@1.0.1",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz"
     },
     "once": {
-      "version": "1.3.3"
+      "version": "1.3.3",
+      "from": "once@1.3.3",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz"
     },
     "onetime": {
-      "version": "1.1.0"
+      "version": "1.1.0",
+      "from": "onetime@1.1.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz"
     },
     "optimist": {
       "version": "0.6.1",
+      "from": "optimist@0.6.1",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "dependencies": {
         "minimist": {
-          "version": "0.0.10"
+          "version": "0.0.10",
+          "from": "minimist@0.0.10",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
         }
       }
     },
     "optionator": {
-      "version": "0.6.0"
+      "version": "0.6.0",
+      "from": "optionator@0.6.0",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.6.0.tgz"
     },
     "orchestrator": {
-      "version": "0.3.7"
+      "version": "0.3.7",
+      "from": "orchestrator@0.3.7",
+      "resolved": "https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.7.tgz"
     },
     "ordered-read-streams": {
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "from": "ordered-read-streams@0.1.0",
+      "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz"
     },
     "original": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "original@1.0.0",
+      "resolved": "https://registry.npmjs.org/original/-/original-1.0.0.tgz"
     },
     "os-browserify": {
-      "version": "0.1.2"
+      "version": "0.1.2",
+      "from": "os-browserify@0.1.2",
+      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz"
     },
     "os-homedir": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "from": "os-homedir@1.0.1",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
     },
     "os-locale": {
-      "version": "1.4.0"
+      "version": "1.4.0",
+      "from": "os-locale@1.4.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz"
     },
     "os-tmpdir": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "from": "os-tmpdir@1.0.1",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
     },
     "output-file-sync": {
-      "version": "1.1.1"
+      "version": "1.1.1",
+      "from": "output-file-sync@1.1.1",
+      "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.1.tgz"
     },
     "pako": {
-      "version": "0.2.8"
+      "version": "0.2.8",
+      "from": "pako@0.2.8",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.8.tgz"
     },
     "parse-glob": {
-      "version": "3.0.4"
+      "version": "3.0.4",
+      "from": "parse-glob@3.0.4",
+      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz"
     },
     "parse-json": {
-      "version": "2.2.0"
+      "version": "2.2.0",
+      "from": "parse-json@2.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz"
     },
     "parseurl": {
-      "version": "1.3.1"
+      "version": "1.3.1",
+      "from": "parseurl@1.3.1",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz"
     },
     "path-browserify": {
-      "version": "0.0.0"
+      "version": "0.0.0",
+      "from": "path-browserify@0.0.0",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz"
     },
     "path-exists": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "path-exists@1.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz"
     },
     "path-is-absolute": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "path-is-absolute@1.0.0",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
     },
     "path-is-inside": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "from": "path-is-inside@1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.1.tgz"
     },
     "path-to-regexp": {
-      "version": "0.1.7"
+      "version": "0.1.7",
+      "from": "path-to-regexp@0.1.7",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz"
     },
     "path-type": {
-      "version": "1.1.0"
+      "version": "1.1.0",
+      "from": "path-type@1.1.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz"
     },
     "pbkdf2-compat": {
-      "version": "2.0.1"
+      "version": "2.0.1",
+      "from": "pbkdf2-compat@2.0.1",
+      "resolved": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-2.0.1.tgz"
     },
     "pify": {
-      "version": "2.3.0"
+      "version": "2.3.0",
+      "from": "pify@2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
     },
     "pinkie": {
-      "version": "2.0.1"
+      "version": "2.0.1",
+      "from": "pinkie@2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
     },
     "pinkie-promise": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "from": "pinkie-promise@2.0.0",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz"
     },
     "pluralize": {
-      "version": "1.2.1"
+      "version": "1.2.1",
+      "from": "pluralize@1.2.1",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz"
     },
     "prelude-ls": {
-      "version": "1.1.2"
+      "version": "1.1.2",
+      "from": "prelude-ls@1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
     },
     "preserve": {
-      "version": "0.2.0"
+      "version": "0.2.0",
+      "from": "preserve@0.2.0",
+      "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
     },
     "pretty-hrtime": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "from": "pretty-hrtime@1.0.1",
+      "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.1.tgz"
     },
     "private": {
-      "version": "0.1.6"
+      "version": "0.1.6",
+      "from": "private@0.1.6",
+      "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
     },
     "process": {
-      "version": "0.11.2"
+      "version": "0.11.2",
+      "from": "process@0.11.2",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.2.tgz"
     },
     "process-nextick-args": {
-      "version": "1.0.6"
+      "version": "1.0.6",
+      "from": "process-nextick-args@1.0.6",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
     },
     "promise": {
-      "version": "7.1.1"
+      "version": "7.1.1",
+      "from": "promise@7.1.1",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.1.1.tgz"
     },
     "proxy-addr": {
-      "version": "1.0.10"
+      "version": "1.0.10",
+      "from": "proxy-addr@1.0.10",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.10.tgz"
     },
     "prr": {
-      "version": "0.0.0"
+      "version": "0.0.0",
+      "from": "prr@0.0.0",
+      "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz"
     },
     "punycode": {
-      "version": "1.4.0"
+      "version": "1.4.0",
+      "from": "punycode@1.4.0",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.0.tgz"
     },
     "q": {
-      "version": "1.4.1"
+      "version": "1.4.1",
+      "from": "q@1.4.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
     },
     "qs": {
-      "version": "5.2.0"
+      "version": "5.2.0",
+      "from": "qs@5.2.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz"
     },
     "query-string": {
-      "version": "3.0.0"
+      "version": "3.0.0",
+      "from": "query-string@3.0.0",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-3.0.0.tgz"
     },
     "querystring": {
-      "version": "0.2.0"
+      "version": "0.2.0",
+      "from": "querystring@0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
     },
     "querystring-es3": {
-      "version": "0.2.1"
+      "version": "0.2.1",
+      "from": "querystring-es3@0.2.1",
+      "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz"
     },
     "querystringify": {
-      "version": "0.0.3"
+      "version": "0.0.3",
+      "from": "querystringify@0.0.3",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-0.0.3.tgz"
     },
     "randomatic": {
       "version": "1.1.5",
+      "from": "randomatic@1.1.5",
+      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz",
       "dependencies": {
         "kind-of": {
-          "version": "3.0.2"
+          "version": "3.0.2",
+          "from": "kind-of@3.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz"
         }
       }
     },
     "range-parser": {
-      "version": "1.0.3"
+      "version": "1.0.3",
+      "from": "range-parser@1.0.3",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz"
     },
     "react": {
-      "version": "0.14.3"
+      "version": "0.14.3",
+      "from": "react@0.14.3",
+      "resolved": "https://registry.npmjs.org/react/-/react-0.14.3.tgz"
     },
     "react-bootstrap": {
-      "version": "0.28.2"
+      "version": "0.28.2",
+      "from": "react-bootstrap@0.28.2",
+      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-0.28.2.tgz"
     },
     "react-bootstrap-table": {
       "version": "2.2.0"
     },
     "react-dom": {
-      "version": "0.14.3"
+      "version": "0.14.3",
+      "from": "react-dom@0.14.3",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-0.14.3.tgz"
     },
     "react-filtered-multiselect": {
-      "version": "0.4.2"
+      "version": "0.4.2",
+      "from": "react-filtered-multiselect@0.4.2",
+      "resolved": "https://registry.npmjs.org/react-filtered-multiselect/-/react-filtered-multiselect-0.4.2.tgz"
+    },
+    "react-onclickout": {
+      "version": "2.0.4",
+      "from": "react-onclickout@>=2.0.4 <3.0.0",
+      "resolved": "https://registry.npmjs.org/react-onclickout/-/react-onclickout-2.0.4.tgz"
     },
     "react-onclickout": {
       "version": "2.0.4"
     },
     "react-overlays": {
       "version": "0.5.4",
+      "from": "react-overlays@0.5.4",
+      "resolved": "https://registry.npmjs.org/react-overlays/-/react-overlays-0.5.4.tgz",
       "dependencies": {
         "react-prop-types": {
-          "version": "0.2.2"
+          "version": "0.2.2",
+          "from": "react-prop-types@0.2.2",
+          "resolved": "https://registry.npmjs.org/react-prop-types/-/react-prop-types-0.2.2.tgz"
         }
       }
     },
     "react-prop-types": {
-      "version": "0.3.0"
+      "version": "0.3.0",
+      "from": "react-prop-types@0.3.0",
+      "resolved": "https://registry.npmjs.org/react-prop-types/-/react-prop-types-0.3.0.tgz"
     },
     "react-router": {
-      "version": "1.0.3"
+      "version": "1.0.3",
+      "from": "react-router@1.0.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-1.0.3.tgz"
     },
     "react-sortablejs": {
       "version": "1.0.0"
@@ -1483,167 +2418,269 @@
       "version": "2.6.1"
     },
     "read-json-sync": {
-      "version": "1.1.1"
+      "version": "1.1.1",
+      "from": "read-json-sync@1.1.1",
+      "resolved": "https://registry.npmjs.org/read-json-sync/-/read-json-sync-1.1.1.tgz"
     },
     "read-pkg": {
-      "version": "1.1.0"
+      "version": "1.1.0",
+      "from": "read-pkg@1.1.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz"
     },
     "read-pkg-up": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "from": "read-pkg-up@1.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz"
     },
     "readable-stream": {
-      "version": "2.0.5"
+      "version": "2.0.5",
+      "from": "readable-stream@2.0.5",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz"
     },
     "readdirp": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "from": "readdirp@2.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.0.0.tgz"
     },
     "readline2": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "from": "readline2@1.0.1",
+      "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz"
     },
     "recast": {
-      "version": "0.10.33"
+      "version": "0.10.33",
+      "from": "recast@0.10.33",
+      "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.33.tgz"
     },
     "rechoir": {
-      "version": "0.6.2"
+      "version": "0.6.2",
+      "from": "rechoir@0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz"
     },
     "redent": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "redent@1.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz"
     },
     "regenerate": {
-      "version": "1.2.1"
+      "version": "1.2.1",
+      "from": "regenerate@1.2.1",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.2.1.tgz"
     },
     "regenerator": {
-      "version": "0.8.40"
+      "version": "0.8.40",
+      "from": "regenerator@0.8.40",
+      "resolved": "https://registry.npmjs.org/regenerator/-/regenerator-0.8.40.tgz"
     },
     "regex-cache": {
-      "version": "0.4.2"
+      "version": "0.4.2",
+      "from": "regex-cache@0.4.2",
+      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.2.tgz"
     },
     "regexpu": {
       "version": "1.3.0",
+      "from": "regexpu@1.3.0",
+      "resolved": "https://registry.npmjs.org/regexpu/-/regexpu-1.3.0.tgz",
       "dependencies": {
         "esprima": {
-          "version": "2.7.1"
+          "version": "2.7.1",
+          "from": "esprima@2.7.1",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.1.tgz"
         }
       }
     },
     "regjsgen": {
-      "version": "0.2.0"
+      "version": "0.2.0",
+      "from": "regjsgen@0.2.0",
+      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz"
     },
     "regjsparser": {
-      "version": "0.1.5"
+      "version": "0.1.5",
+      "from": "regjsparser@0.1.5",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz"
     },
     "repeat-element": {
-      "version": "1.1.2"
+      "version": "1.1.2",
+      "from": "repeat-element@1.1.2",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
     },
     "repeat-string": {
-      "version": "1.5.2"
+      "version": "1.5.2",
+      "from": "repeat-string@1.5.2",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
     },
     "repeating": {
-      "version": "1.1.3"
+      "version": "1.1.3",
+      "from": "repeating@1.1.3",
+      "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz"
     },
     "replace-ext": {
-      "version": "0.0.1"
+      "version": "0.0.1",
+      "from": "replace-ext@0.0.1",
+      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
     },
     "request": {
       "version": "2.67.0",
+      "from": "request@2.67.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.67.0.tgz",
       "dependencies": {
         "extend": {
-          "version": "3.0.0"
+          "version": "3.0.0",
+          "from": "extend@3.0.0",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
         }
       }
     },
     "requires-port": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "requires-port@1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz"
     },
     "resolve": {
-      "version": "1.1.6"
+      "version": "1.1.6",
+      "from": "resolve@1.1.6",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz"
     },
     "restore-cursor": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "from": "restore-cursor@1.0.1",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz"
     },
     "right-align": {
-      "version": "0.1.3"
+      "version": "0.1.3",
+      "from": "right-align@0.1.3",
+      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz"
     },
     "rimraf": {
       "version": "2.5.0",
+      "from": "rimraf@2.5.0",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.0.tgz",
       "dependencies": {
         "glob": {
-          "version": "6.0.4"
+          "version": "6.0.4",
+          "from": "glob@6.0.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz"
         }
       }
     },
     "ripemd160": {
-      "version": "0.2.0"
+      "version": "0.2.0",
+      "from": "ripemd160@0.2.0",
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-0.2.0.tgz"
     },
     "run-async": {
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "from": "run-async@0.1.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz"
     },
     "rx-lite": {
-      "version": "3.1.2"
+      "version": "3.1.2",
+      "from": "rx-lite@3.1.2",
+      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz"
     },
     "semver": {
-      "version": "4.3.6"
+      "version": "4.3.6",
+      "from": "semver@4.3.6",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
     },
     "send": {
       "version": "0.13.1",
+      "from": "send@0.13.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.13.1.tgz",
       "dependencies": {
         "mime": {
-          "version": "1.3.4"
+          "version": "1.3.4",
+          "from": "mime@1.3.4",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
         }
       }
     },
     "sequencify": {
-      "version": "0.0.7"
+      "version": "0.0.7",
+      "from": "sequencify@0.0.7",
+      "resolved": "https://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz"
     },
     "serve-index": {
       "version": "1.7.3",
+      "from": "serve-index@1.7.3",
+      "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.7.3.tgz",
       "dependencies": {
         "accepts": {
-          "version": "1.2.13"
+          "version": "1.2.13",
+          "from": "accepts@1.2.13",
+          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.13.tgz"
         },
         "negotiator": {
-          "version": "0.5.3"
+          "version": "0.5.3",
+          "from": "negotiator@0.5.3",
+          "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz"
         }
       }
     },
     "serve-static": {
-      "version": "1.10.2"
+      "version": "1.10.2",
+      "from": "serve-static@1.10.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.10.2.tgz"
     },
     "sha.js": {
-      "version": "2.2.6"
+      "version": "2.2.6",
+      "from": "sha.js@2.2.6",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.2.6.tgz"
     },
     "shebang-regex": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "shebang-regex@1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz"
     },
     "shelljs": {
-      "version": "0.5.3"
+      "version": "0.5.3",
+      "from": "shelljs@0.5.3",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.5.3.tgz"
     },
     "sigmund": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "from": "sigmund@1.0.1",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
     },
     "signal-exit": {
-      "version": "2.1.2"
+      "version": "2.1.2",
+      "from": "signal-exit@2.1.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz"
     },
     "simple-fmt": {
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "from": "simple-fmt@0.1.0",
+      "resolved": "https://registry.npmjs.org/simple-fmt/-/simple-fmt-0.1.0.tgz"
     },
     "simple-is": {
-      "version": "0.2.0"
+      "version": "0.2.0",
+      "from": "simple-is@0.2.0",
+      "resolved": "https://registry.npmjs.org/simple-is/-/simple-is-0.2.0.tgz"
     },
     "slash": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "slash@1.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz"
     },
     "sntp": {
-      "version": "1.0.9"
+      "version": "1.0.9",
+      "from": "sntp@1.0.9",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
     },
     "sockjs": {
-      "version": "0.3.15"
+      "version": "0.3.15",
+      "from": "sockjs@0.3.15",
+      "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.15.tgz"
     },
     "sockjs-client": {
       "version": "1.0.3",
+      "from": "sockjs-client@1.0.3",
+      "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.0.3.tgz",
       "dependencies": {
         "faye-websocket": {
-          "version": "0.7.3"
+          "version": "0.7.3",
+          "from": "faye-websocket@0.7.3",
+          "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.7.3.tgz"
         }
       }
     },
@@ -1651,337 +2688,543 @@
       "version": "1.4.2"
     },
     "source-list-map": {
-      "version": "0.1.5"
+      "version": "0.1.5",
+      "from": "source-list-map@0.1.5",
+      "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.5.tgz"
     },
     "source-map": {
-      "version": "0.5.3"
+      "version": "0.5.3",
+      "from": "source-map@0.5.3",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
     },
     "source-map-support": {
       "version": "0.2.10",
+      "from": "source-map-support@0.2.10",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
       "dependencies": {
         "source-map": {
-          "version": "0.1.32"
+          "version": "0.1.32",
+          "from": "source-map@0.1.32",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz"
         }
       }
     },
     "sparkles": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "sparkles@1.0.0",
+      "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz"
     },
     "spdx-correct": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "from": "spdx-correct@1.0.2",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz"
     },
     "spdx-exceptions": {
-      "version": "1.0.4"
+      "version": "1.0.4",
+      "from": "spdx-exceptions@1.0.4",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz"
     },
     "spdx-expression-parse": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "from": "spdx-expression-parse@1.0.2",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz"
     },
     "spdx-license-ids": {
-      "version": "1.2.0"
+      "version": "1.2.0",
+      "from": "spdx-license-ids@1.2.0",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz"
     },
     "sprintf-js": {
-      "version": "1.0.3"
+      "version": "1.0.3",
+      "from": "sprintf-js@1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
     },
     "sshpk": {
       "version": "1.7.3",
+      "from": "sshpk@1.7.3",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.3.tgz",
       "dependencies": {
         "assert-plus": {
-          "version": "0.2.0"
+          "version": "0.2.0",
+          "from": "assert-plus@0.2.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
         }
       }
     },
     "stable": {
-      "version": "0.1.5"
+      "version": "0.1.5",
+      "from": "stable@0.1.5",
+      "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.5.tgz"
     },
     "statuses": {
-      "version": "1.2.1"
+      "version": "1.2.1",
+      "from": "statuses@1.2.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
     },
     "stream-browserify": {
       "version": "1.0.0",
+      "from": "stream-browserify@1.0.0",
+      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz",
       "dependencies": {
         "readable-stream": {
-          "version": "1.1.13"
+          "version": "1.1.13",
+          "from": "readable-stream@1.1.13",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz"
         }
       }
     },
     "stream-cache": {
-      "version": "0.0.2"
+      "version": "0.0.2",
+      "from": "stream-cache@0.0.2",
+      "resolved": "https://registry.npmjs.org/stream-cache/-/stream-cache-0.0.2.tgz"
     },
     "stream-consume": {
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "from": "stream-consume@0.1.0",
+      "resolved": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.0.tgz"
     },
     "strict-uri-encode": {
-      "version": "1.1.0"
+      "version": "1.1.0",
+      "from": "strict-uri-encode@1.1.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz"
     },
     "string_decoder": {
-      "version": "0.10.31"
+      "version": "0.10.31",
+      "from": "string_decoder@0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
     },
     "string-width": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "from": "string-width@1.0.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.1.tgz"
     },
     "stringmap": {
-      "version": "0.2.2"
+      "version": "0.2.2",
+      "from": "stringmap@0.2.2",
+      "resolved": "https://registry.npmjs.org/stringmap/-/stringmap-0.2.2.tgz"
     },
     "stringset": {
-      "version": "0.2.1"
+      "version": "0.2.1",
+      "from": "stringset@0.2.1",
+      "resolved": "https://registry.npmjs.org/stringset/-/stringset-0.2.1.tgz"
     },
     "stringstream": {
-      "version": "0.0.5"
+      "version": "0.0.5",
+      "from": "stringstream@0.0.5",
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
     },
     "strip-ansi": {
-      "version": "3.0.0"
+      "version": "3.0.0",
+      "from": "strip-ansi@3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz"
     },
     "strip-bom": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "from": "strip-bom@2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz"
     },
     "strip-indent": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "from": "strip-indent@1.0.1",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz"
     },
     "strip-json-comments": {
-      "version": "1.0.4"
+      "version": "1.0.4",
+      "from": "strip-json-comments@1.0.4",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
     },
     "supports-color": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "from": "supports-color@2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
     },
     "tapable": {
-      "version": "0.1.10"
+      "version": "0.1.10",
+      "from": "tapable@0.1.10",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.1.10.tgz"
     },
     "text-table": {
-      "version": "0.2.0"
+      "version": "0.2.0",
+      "from": "text-table@0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
     },
     "through": {
-      "version": "2.3.8"
+      "version": "2.3.8",
+      "from": "through@2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
     },
     "through2": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "from": "through2@2.0.0",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz"
     },
     "tildify": {
-      "version": "1.1.2"
+      "version": "1.1.2",
+      "from": "tildify@1.1.2",
+      "resolved": "https://registry.npmjs.org/tildify/-/tildify-1.1.2.tgz"
     },
     "timers-browserify": {
-      "version": "1.4.2"
+      "version": "1.4.2",
+      "from": "timers-browserify@1.4.2",
+      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz"
     },
     "tinycolor2": {
-      "version": "1.3.0"
+      "version": "1.3.0",
+      "from": "tinycolor2@1.3.0",
+      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.3.0.tgz"
     },
     "to-fast-properties": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "from": "to-fast-properties@1.0.1",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
     },
     "tough-cookie": {
-      "version": "2.2.1"
+      "version": "2.2.1",
+      "from": "tough-cookie@2.2.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz"
     },
     "trim-newlines": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "trim-newlines@1.0.0",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
     },
     "trim-right": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "from": "trim-right@1.0.1",
+      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz"
     },
     "try-resolve": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "from": "try-resolve@1.0.1",
+      "resolved": "https://registry.npmjs.org/try-resolve/-/try-resolve-1.0.1.tgz"
     },
     "tryit": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "from": "tryit@1.0.2",
+      "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.2.tgz"
     },
     "tryor": {
-      "version": "0.1.2"
+      "version": "0.1.2",
+      "from": "tryor@0.1.2",
+      "resolved": "https://registry.npmjs.org/tryor/-/tryor-0.1.2.tgz"
     },
     "tty-browserify": {
-      "version": "0.0.0"
+      "version": "0.0.0",
+      "from": "tty-browserify@0.0.0",
+      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz"
     },
     "tunnel-agent": {
-      "version": "0.4.2"
+      "version": "0.4.2",
+      "from": "tunnel-agent@0.4.2",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
     },
     "tweetnacl": {
-      "version": "0.13.3"
+      "version": "0.13.3",
+      "from": "tweetnacl@0.13.3",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz"
     },
     "type-check": {
-      "version": "0.3.2"
+      "version": "0.3.2",
+      "from": "type-check@0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz"
     },
     "type-is": {
       "version": "1.6.12",
+      "from": "type-is@1.6.12",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.12.tgz",
       "dependencies": {
         "mime-db": {
-          "version": "1.22.0"
+          "version": "1.22.0",
+          "from": "mime-db@1.22.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz"
         },
         "mime-types": {
-          "version": "2.1.10"
+          "version": "2.1.10",
+          "from": "mime-types@2.1.10",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz"
         }
       }
     },
     "typedarray": {
-      "version": "0.0.6"
+      "version": "0.0.6",
+      "from": "typedarray@0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
     },
     "ua-parser-js": {
-      "version": "0.7.10"
+      "version": "0.7.10",
+      "from": "ua-parser-js@0.7.10",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.10.tgz"
     },
     "uglify-js": {
       "version": "2.6.1",
+      "from": "uglify-js@2.6.1",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.1.tgz",
       "dependencies": {
         "async": {
-          "version": "0.2.10"
+          "version": "0.2.10",
+          "from": "async@0.2.10",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
         },
         "window-size": {
-          "version": "0.1.0"
+          "version": "0.1.0",
+          "from": "window-size@0.1.0",
+          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
         },
         "yargs": {
-          "version": "3.10.0"
+          "version": "3.10.0",
+          "from": "yargs@3.10.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz"
         }
       }
     },
     "uglify-to-browserify": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "from": "uglify-to-browserify@1.0.2",
+      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
     },
     "uncontrollable": {
-      "version": "3.2.1"
+      "version": "3.2.1",
+      "from": "uncontrollable@3.2.1",
+      "resolved": "https://registry.npmjs.org/uncontrollable/-/uncontrollable-3.2.1.tgz"
     },
     "unique-stream": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "unique-stream@1.0.0",
+      "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz"
     },
     "unpipe": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "unpipe@1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
     },
     "url": {
       "version": "0.10.3",
+      "from": "url@0.10.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
       "dependencies": {
         "punycode": {
-          "version": "1.3.2"
+          "version": "1.3.2",
+          "from": "punycode@1.3.2",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
         }
       }
     },
     "url-parse": {
-      "version": "1.0.5"
+      "version": "1.0.5",
+      "from": "url-parse@1.0.5",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.0.5.tgz"
     },
     "user-home": {
-      "version": "1.1.1"
+      "version": "1.1.1",
+      "from": "user-home@1.1.1",
+      "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
     },
     "util": {
-      "version": "0.10.3"
+      "version": "0.10.3",
+      "from": "util@0.10.3",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz"
     },
     "util-deprecate": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "from": "util-deprecate@1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
     },
     "utils-merge": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "utils-merge@1.0.0",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
     },
     "v8flags": {
-      "version": "2.0.11"
+      "version": "2.0.11",
+      "from": "v8flags@2.0.11",
+      "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.0.11.tgz"
     },
     "validate-npm-package-license": {
-      "version": "3.0.1"
+      "version": "3.0.1",
+      "from": "validate-npm-package-license@3.0.1",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz"
     },
     "vary": {
-      "version": "1.1.0"
+      "version": "1.1.0",
+      "from": "vary@1.1.0",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.0.tgz"
     },
     "verror": {
-      "version": "1.3.6"
+      "version": "1.3.6",
+      "from": "verror@1.3.6",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
     },
     "vinyl": {
-      "version": "0.5.3"
+      "version": "0.5.3",
+      "from": "vinyl@0.5.3",
+      "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz"
     },
     "vinyl-fs": {
       "version": "0.3.14",
+      "from": "vinyl-fs@0.3.14",
+      "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.3.14.tgz",
       "dependencies": {
         "clone": {
-          "version": "0.2.0"
+          "version": "0.2.0",
+          "from": "clone@0.2.0",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
         },
         "graceful-fs": {
-          "version": "3.0.8"
+          "version": "3.0.8",
+          "from": "graceful-fs@3.0.8",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
         },
         "readable-stream": {
-          "version": "1.0.33"
+          "version": "1.0.33",
+          "from": "readable-stream@1.0.33",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz"
         },
         "strip-bom": {
-          "version": "1.0.0"
+          "version": "1.0.0",
+          "from": "strip-bom@1.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz"
         },
         "through2": {
-          "version": "0.6.5"
+          "version": "0.6.5",
+          "from": "through2@0.6.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz"
         },
         "vinyl": {
-          "version": "0.4.6"
+          "version": "0.4.6",
+          "from": "vinyl@0.4.6",
+          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz"
         }
       }
     },
     "vm-browserify": {
-      "version": "0.0.4"
+      "version": "0.0.4",
+      "from": "vm-browserify@0.0.4",
+      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz"
     },
     "warning": {
-      "version": "2.1.0"
+      "version": "2.1.0",
+      "from": "warning@2.1.0",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-2.1.0.tgz"
     },
     "watchpack": {
       "version": "0.2.9",
+      "from": "watchpack@0.2.9",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-0.2.9.tgz",
       "dependencies": {
         "async": {
-          "version": "0.9.2"
+          "version": "0.9.2",
+          "from": "async@0.9.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
         }
       }
     },
     "webpack": {
       "version": "1.12.11",
+      "from": "webpack@1.12.11",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-1.12.11.tgz",
       "dependencies": {
         "esprima": {
-          "version": "2.7.1"
+          "version": "2.7.1",
+          "from": "esprima@2.7.1",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.1.tgz"
         },
         "supports-color": {
-          "version": "3.1.2"
+          "version": "3.1.2",
+          "from": "supports-color@3.1.2",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz"
         }
       }
     },
     "webpack-core": {
       "version": "0.6.8",
+      "from": "webpack-core@0.6.8",
+      "resolved": "https://registry.npmjs.org/webpack-core/-/webpack-core-0.6.8.tgz",
       "dependencies": {
         "source-map": {
-          "version": "0.4.4"
+          "version": "0.4.4",
+          "from": "source-map@0.4.4",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz"
         }
       }
     },
     "webpack-dev-middleware": {
       "version": "1.5.1",
+      "from": "webpack-dev-middleware@1.5.1",
+      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.5.1.tgz",
       "dependencies": {
         "mime": {
-          "version": "1.3.4"
+          "version": "1.3.4",
+          "from": "mime@1.3.4",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
         }
       }
     },
     "webpack-dev-server": {
       "version": "1.14.1",
+      "from": "webpack-dev-server@1.14.1",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.14.1.tgz",
       "dependencies": {
         "supports-color": {
-          "version": "3.1.2"
+          "version": "3.1.2",
+          "from": "supports-color@3.1.2",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz"
         }
       }
     },
     "websocket-driver": {
-      "version": "0.6.4"
+      "version": "0.6.4",
+      "from": "websocket-driver@0.6.4",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.4.tgz"
     },
     "websocket-extensions": {
-      "version": "0.1.1"
+      "version": "0.1.1",
+      "from": "websocket-extensions@0.1.1",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.1.tgz"
     },
     "whatwg-fetch": {
-      "version": "0.9.0"
+      "version": "0.9.0",
+      "from": "whatwg-fetch@0.9.0",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-0.9.0.tgz"
     },
     "window-size": {
-      "version": "0.1.4"
+      "version": "0.1.4",
+      "from": "window-size@0.1.4",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz"
     },
     "wordwrap": {
-      "version": "0.0.2"
+      "version": "0.0.2",
+      "from": "wordwrap@0.0.2",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
     },
     "wrappy": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "from": "wrappy@1.0.1",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
     },
     "write": {
-      "version": "0.2.1"
+      "version": "0.2.1",
+      "from": "write@0.2.1",
+      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz"
     },
     "xml-escape": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "xml-escape@1.0.0",
+      "resolved": "https://registry.npmjs.org/xml-escape/-/xml-escape-1.0.0.tgz"
     },
     "xtend": {
-      "version": "4.0.1"
+      "version": "4.0.1",
+      "from": "xtend@4.0.1",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
     },
     "y18n": {
-      "version": "3.2.0"
+      "version": "3.2.0",
+      "from": "y18n@3.2.0",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.0.tgz"
     },
     "yargs": {
-      "version": "3.27.0"
+      "version": "3.27.0",
+      "from": "yargs@3.27.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.27.0.tgz"
     }
   }
 }

--- a/gulp/package.json
+++ b/gulp/package.json
@@ -41,6 +41,7 @@
     "react-bootstrap-table": "^2.2.0",
     "react-dom": "^0.14.3",
     "react-filtered-multiselect": "^0.4.2",
+    "react-native-listener": "^1.0.1",
     "react-onclickout": "^2.0.4",
     "react-router": "^1.0.0",
     "react-sortablejs": "^1.0.0",

--- a/gulp/src/reporting/SetUpReport.jsx
+++ b/gulp/src/reporting/SetUpReport.jsx
@@ -1,4 +1,5 @@
 import React, {PropTypes, Component} from 'react';
+import NativeListener from 'react-native-listener';
 import warning from 'warning';
 import {Loading} from 'common/ui/Loading';
 import {scrollUp} from 'common/dom';
@@ -99,6 +100,13 @@ export default class SetUpReport extends Component {
     if (lastComponent === SetUpReport) {
       this.loadData();
     }
+  }
+
+  handleRunReport(e) {
+    e.preventDefault();
+    e.stopPropagation();
+    scrollUp();
+    this.state.reportConfig.run();
   }
 
   async loadData() {
@@ -357,11 +365,9 @@ export default class SetUpReport extends Component {
         <div className="row actions text-center">
           <div className="col-xs-12 col-md-4"></div>
           <div className="col-xs-12 col-md-8">
-            <button
-              className="button primary"
-              onClick={e => {e.preventDefault(); scrollUp(); reportConfig.run();}}>
-              Run Report
-            </button>
+            <NativeListener onClick={e => this.handleRunReport(e)}>
+              <button className="button primary">Run Report</button>
+            </NativeListener>
           </div>
         </div>
       </form>


### PR DESCRIPTION
`stopPropagation()` wasn't working because React doesn't use native events. We use this and `preventDefault()` a few other places, but I'd prefer to fix those on an as-need basis as I'm not entirely sure what other implications are to be had by using this method. 

This is using react-native-listener.

Reference fo this implementation: https://medium.com/@ericclemmons/react-event-preventdefault-78c28c950e46#.lq0ypqvz4

Running a report should now only happen if you click the run button or it's selected and you press enter.