### PR TITLE
[PD-2398 PD-2392] Unbroke old reporting and removed beta from another spot.

### DIFF
--- a/gulp/src/reporting/DynamicReportApp.jsx
+++ b/gulp/src/reporting/DynamicReportApp.jsx
@@ -62,7 +62,7 @@ export class DynamicReportApp extends Component {
           <div className="col-sm-12">
             <div className="breadcrumbs">
               <span>
-                Dynamic Reporting (beta)
+                Dynamic Reporting
               </span>
             </div>
           </div>

--- a/gulp/src/reporting/DynamicReportApp.jsx
+++ b/gulp/src/reporting/DynamicReportApp.jsx
@@ -62,7 +62,7 @@ export class DynamicReportApp extends Component {
           <div className="col-sm-12">
             <div className="breadcrumbs">
               <span>
-                Dynamic Reporting
+                Dynamic Reporting (beta)
               </span>
             </div>
           </div>

--- a/myreports/urls.py
+++ b/myreports/urls.py
@@ -3,7 +3,7 @@ from myreports.views import ReportView
 
 urlpatterns = patterns(
     'myreports.views',
-    url(r'^view/overview/$', 'overview', name='overview'),
+    url(r'^view/overview$', 'overview', name='overview'),
     url(r'^view/archive$', 'report_archive', name='report_archive'),
     url(r'view/(?P<app>\w+)/(?P<model>\w+)$', ReportView.as_view(),
         name='reports'),

--- a/templates/myreports/includes/report_overview.html
+++ b/templates/myreports/includes/report_overview.html
@@ -2,7 +2,7 @@
     <div class="span12">
         <h1 class="bottom-bordered">
             <a href="{% url 'overview' %}">{{ company.name }}</a>
-            <small>Reports (beta)</small>
+            <small>Reports</small>
         </h1>
     </div>
 </div>


### PR DESCRIPTION
Apparently that trailing slash breaks the export screen for classic reporting? This also removes a place where beta was noted in dynamic reporting.