### PR TITLE
[PD-2399] Reset Report on Run

### DIFF
--- a/gulp/src/reporting/SetUpReport.jsx
+++ b/gulp/src/reporting/SetUpReport.jsx
@@ -103,6 +103,15 @@ export default class SetUpReport extends Component {
     }
   }
 
+  handleRunReport(e) {
+    e.preventDefault();
+
+    this.state.reportConfig.run();
+    this.props.history.pushState(null, '/');
+
+    scrollUp();
+  }
+
   async loadData() {
     const {
       intention: reportingType,
@@ -340,7 +349,7 @@ export default class SetUpReport extends Component {
           <div className="col-xs-12 col-md-8">
             <button
               className="button primary"
-              onClick={ e => {e.preventDefault(); scrollUp(); reportConfig.run();}}>
+              onClick={ e => this.handleRunReport(e)}>
               Run Report
             </button>
           </div>

--- a/myreports/datasources/comm_records.py
+++ b/myreports/datasources/comm_records.py
@@ -100,7 +100,7 @@ class CommRecordsDataSource(DataSource):
             Location.objects
             .filter(contacts__contactrecord__in=comm_records_qs)
             .filter(state__icontains=partial))
-        state_qs = locations_qs.values('state').distinct().order_by('state')
+        state_qs = locations_qs.values('state').order_by('state').distinct()
         return [{
             'value': c['state'],
             'display': states[c['state']]

--- a/myreports/datasources/contacts.py
+++ b/myreports/datasources/contacts.py
@@ -11,6 +11,8 @@ from mypartners.models import Contact, Location, Tag, Partner, Status
 
 from universal.helpers import dict_identity, extract_value
 
+from postajob.location_data import states
+
 from django.db.models import Q
 
 
@@ -58,8 +60,11 @@ class ContactsDataSource(DataSource):
             Location.objects
             .filter(contacts__in=contacts_qs)
             .filter(state__icontains=partial))
-        state_qs = locations_qs.values('state').distinct()
-        return [{'value': s['state'], 'display': s['state']} for s in state_qs]
+        state_qs = locations_qs.values('state').order_by('state').distinct()
+        return [{
+            'value': s['state'],
+            'display': states[s['state']]
+        } for s in state_qs if s['state']]
 
     def help_tags(self, company, filter_spec, partial):
         """Get help for the tags field."""

--- a/myreports/datasources/partners.py
+++ b/myreports/datasources/partners.py
@@ -4,6 +4,8 @@ from datetime import datetime
 
 from mypartners.models import Contact, Partner, Status, Location, Tag
 
+from postajob.location_data import states
+
 from myreports.datasources.util import (
     dispatch_help_by_field_name, dispatch_run_by_data_type,
     filter_date_range, extract_tags)
@@ -151,8 +153,11 @@ class PartnersDataSource(DataSource):
             Location.objects
             .filter(contacts__partner__in=partners_qs)
             .filter(state__icontains=partial))
-        state_qs = locations_qs.values('state').distinct()
-        return [{'value': c['state'], 'display': c['state']} for c in state_qs]
+        state_qs = locations_qs.values('state').order_by('state').distinct()
+        return [{
+            'value': c['state'],
+            'display': states[c['state']]
+        } for c in state_qs if c['state']]
 
     def help_tags(self, company, filter_spec, partial):
         """Get help for the tags field."""


### PR DESCRIPTION
When running a report, you should now see that, after scrolling up (which happens automatically), the report filters have been reset. In addition, the state filter in contact and partners should show full state names instead of abbreviations.