### PR TITLE
[PD-2402] Miscellaneous topbar fixes.

### DIFF
--- a/myjobs/templatetags/common_tags.py
+++ b/myjobs/templatetags/common_tags.py
@@ -6,6 +6,7 @@ from django.conf import settings
 from django.core.urlresolvers import reverse
 
 from myjobs import version
+from myjobs.models import MissingAppLevelAccess
 from myjobs.helpers import get_completion, make_fake_gravatar
 from seo.models import Company
 from universal.helpers import get_company
@@ -314,7 +315,12 @@ def get_menus(context):
         ]
     } if user.roles.exists() else {}
 
-    if employer_menu and user.can(company, "read partner", check_access=False):
+    try:
+        can_read_partner = user.can(company, "read partner")
+    except MissingAppLevelAccess:
+        can_read_partner = False
+
+    if employer_menu and can_read_partner:
         employer_menu["submenus"] += [
             {
                 "id": "partner-tab",
@@ -334,7 +340,12 @@ def get_menus(context):
             "label": "Reports",
         })
 
-    if employer_menu and user.can(company, "read role", check_access=False):
+    try:
+        can_read_role = user.can(company, "read role")
+    except MissingAppLevelAccess:
+        can_read_role = False
+
+    if employer_menu and can_read_role:
         employer_menu["submenus"].append(
             {
                 "id": "manage-users-tab",

--- a/myjobs/tests/test_decorators.py
+++ b/myjobs/tests/test_decorators.py
@@ -8,7 +8,7 @@ from myjobs.tests.setup import MyJobsBase
 from myjobs.tests.factories import (AppAccessFactory, UserFactory,
                                     ActivityFactory, RoleFactory)
 from myjobs.decorators import requires
-from myjobs.models import MissingActivity, MissingAppAccess
+from myjobs.models import MissingActivity, MissingAppLevelAccess
 from seo.tests.factories import CompanyFactory, CompanyUserFactory
 
 
@@ -53,7 +53,7 @@ class DecoratorTests(MyJobsBase):
         """
 
         self.company.app_access.clear()
-        with self.assertRaises(MissingAppAccess) as cm:
+        with self.assertRaises(MissingAppLevelAccess) as cm:
             response = requires(self.activity.name)(dummy_view)(self.request)
 
         self.assertEqual(
@@ -64,8 +64,8 @@ class DecoratorTests(MyJobsBase):
     def test_access_callback(self):
         """
         When app access is sufficient and a callback is supplied, the response
-        of that callback should be returned rather than a `MissingAppAccess`
-        response.
+        of that callback should be returned rather than a
+        `MissingAppLevelAccess` response.
         """
 
         self.company.app_access.clear()

--- a/myjobs/tests/test_decorators.py
+++ b/myjobs/tests/test_decorators.py
@@ -7,7 +7,8 @@ from django.http import HttpResponse, Http404
 from myjobs.tests.setup import MyJobsBase
 from myjobs.tests.factories import (AppAccessFactory, UserFactory,
                                     ActivityFactory, RoleFactory)
-from myjobs.decorators import requires, MissingActivity
+from myjobs.decorators import requires
+from myjobs.models import MissingActivity, MissingAppAccess
 from seo.tests.factories import CompanyFactory, CompanyUserFactory
 
 
@@ -52,7 +53,7 @@ class DecoratorTests(MyJobsBase):
         """
 
         self.company.app_access.clear()
-        with self.assertRaises(Http404) as cm:
+        with self.assertRaises(MissingAppAccess) as cm:
             response = requires(self.activity.name)(dummy_view)(self.request)
 
         self.assertEqual(

--- a/static/custom.css
+++ b/static/custom.css
@@ -4995,7 +4995,8 @@ a.btn.pull-right {
     font-size: 2em !important;
   }
   .topbar-new #nav ul#pop-menu li.sub-nav-item a,
-  .topbar-new #nav ul#pop-menu li.nav-item a {
+  .topbar-new #nav ul#pop-menu li.nav-item a,
+  .topbar-new #nav ul#pop-menu li#mobile-company-select a {
     height: 45px;
   }
 }

--- a/static/custom.css
+++ b/static/custom.css
@@ -4994,8 +4994,9 @@ a.btn.pull-right {
     height: 33px !important;
     font-size: 2em !important;
   }
-  .topbar-new #nav ul#pop-menu li a {
-    height: 45px !important;
+  .topbar-new #nav ul#pop-menu li.sub-nav-item a,
+  .topbar-new #nav ul#pop-menu li.nav-item a {
+    height: 45px;
   }
 }
 @media(min-width:992px){

--- a/static/topbar.js
+++ b/static/topbar.js
@@ -26,14 +26,6 @@ $(window).ready(function() {
         }
     });
 
-    $("#pop-menu").mouseleave(function(){
-        $("#back-btn-li").addClass("no-show");
-        $(".nav-item").removeClass("no-show");
-        $(".sub-nav-item").addClass("no-show");
-
-        $("#nav").removeClass("active");
-    });
-
     $(".nav-item").click(function(e) {
       $("#mobile-company-select").removeClass("no-show");
       $("#back-btn-li").removeClass("no-show");


### PR DESCRIPTION
# Changes
- the back arrow on the top bar for react apps is now full height like it is in non-react apps
- mouse exiting the window doesn't cause the mobile menu to automatically close anymore
- PRM and Reporting don't show up in the Employer menu if the current company doesn't have app-level access
- Reintroduced MissingAppLevelAccess to better test when that kind of response is getting. Operationally, it's just Http404, but determining that such is the case should be easier to do now when inspecting newrelic if something happens in production.

# Before:
![2016-05-17-112815_956x1056_scrot](https://cloud.githubusercontent.com/assets/93686/15328559/486c3ed6-1c23-11e6-8930-186ad00ebfbe.png)

# After
![2016-05-17-112851_956x1056_scrot](https://cloud.githubusercontent.com/assets/93686/15328565/4e108180-1c23-11e6-81f6-a38b927d1208.png)
