### PR TITLE
Made some options of dev server configurable.

### DIFF
--- a/dk2/dev/Dockerfile
+++ b/dk2/dev/Dockerfile
@@ -33,3 +33,5 @@ run ln -s /var/log /log
 
 volume /MyJobs
 volume /deployment
+
+env DEVSERVER_HTTPS=1

--- a/gulp/package.json
+++ b/gulp/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "clean-shrinkwrap": "babel-node clean-shrinkwrap.js",
-    "devserver": "webpack-dev-server -d --progress"
+    "devserver": "webpack-dev-server -d --progress --config=webpack.dev.config.js --inline"
   },
   "author": "DirectEmployers Association",
   "license": "(GPL-2.0 OR GPL-3.0 OR MIT)",

--- a/gulp/package.json
+++ b/gulp/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "clean-shrinkwrap": "babel-node clean-shrinkwrap.js",
-    "devserver": "webpack-dev-server -d --progress --config=webpack.dev.config.js --host=0.0.0.0 --https --inline"
+    "devserver": "webpack-dev-server -d --progress"
   },
   "author": "DirectEmployers Association",
   "license": "(GPL-2.0 OR GPL-3.0 OR MIT)",

--- a/gulp/webpack.config.js
+++ b/gulp/webpack.config.js
@@ -3,10 +3,6 @@ var path = require('path');
 
 module.exports = {
   devServer: {
-    hot: true,
-    progress: true,
-    inline: true,
-    stats: 'errors-only',
     host: process.env.DEVSERVER_HOST || "0.0.0.0",
     port: process.env.DEVSERVER_PORT || "8080",
     config: "webpack.dev.config.js",

--- a/gulp/webpack.config.js
+++ b/gulp/webpack.config.js
@@ -2,6 +2,16 @@ var webpack = require('webpack');
 var path = require('path');
 
 module.exports = {
+  devServer: {
+    hot: true,
+    progress: true,
+    inline: true,
+    stats: 'errors-only',
+    host: process.env.DEVSERVER_HOST || "0.0.0.0",
+    port: process.env.DEVSERVER_PORT || "8080",
+    config: "webpack.dev.config.js",
+    https: process.env.DEVSERVER_HTTPS ? true : false,
+  },
   entry: {
     reporting: './src/reporting/main',
     manageusers: './src/manageusers/main',


### PR DESCRIPTION
- HTTPS is no longer assumed to be enabled by default unless you're using docker
- you can enable it by doing DEVSERVER_HTTPS=1 npm run devserver*
- you can explicitly disable by doing DEVSERVER_HTTPS= npm run devserver
- port and host are configurable, defaulting to 0.0.0.0:8080

* technically, any truthy value works. 