### PR TITLE
Fix IE8 Reporting Bugs

### DIFF
--- a/gulp/npm-shrinkwrap.json
+++ b/gulp/npm-shrinkwrap.json
@@ -453,6 +453,34 @@
     "error-ex": {
       "version": "1.3.0"
     },
+    "es3ify": {
+      "version": "0.2.2",
+      "dependencies": {
+        "base62": {
+          "version": "1.1.1"
+        },
+        "esprima": {
+          "version": "2.7.2"
+        },
+        "jstransform": {
+          "version": "11.0.3",
+          "dependencies": {
+            "esprima-fb": {
+              "version": "15001.1.0-dev-harmony-fb"
+            }
+          }
+        },
+        "object-assign": {
+          "version": "2.1.1"
+        },
+        "source-map": {
+          "version": "0.4.4"
+        }
+      }
+    },
+    "es3ify-loader": {
+      "version": "0.2.0"
+    },
     "es5-ext": {
       "version": "0.10.11"
     },

--- a/gulp/package.json
+++ b/gulp/package.json
@@ -21,6 +21,7 @@
     "babel-runtime": "^5.8.25",
     "calendar-base": "^0.2.1",
     "classnames": "^2.2.1",
+    "es3ify-loader": "^0.2.0",
     "es6-promise": "^3.0.2",
     "eslint": "^1.10.2",
     "eslint-config-airbnb": "^1.0.0",

--- a/gulp/src/common/ui/ClickOutCompat.jsx
+++ b/gulp/src/common/ui/ClickOutCompat.jsx
@@ -1,17 +1,21 @@
 import React, {PropTypes} from 'react';
 import ClickOutHandler from 'react-onclickout';
+import {isIE8} from 'common/dom';
 
 export default function ClickOutCompat(props) {
   const {children, onClickOut} = props;
 
-  if (window.addEventListener) {
+  if (!isIE8) {
     return (
       <ClickOutHandler onClickOut={(...args) => onClickOut(...args)}>
         {children}
       </ClickOutHandler>
     );
   }
-  return children;
+  // ClickOutHandler does this. Do the same here so css selectors still work.
+  return Array.isArray(children) ?
+      <div>{children}</div> :
+      React.Children.only(children);
 }
 
 ClickOutCompat.propTypes = {

--- a/gulp/src/common/ui/DateField.jsx
+++ b/gulp/src/common/ui/DateField.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import TextField from './TextField';
 import CalendarPanel from './CalendarPanel';
-import ClickOutHandler from 'react-onclickout';
+import ClickOutCompat from 'common/ui/ClickOutCompat';
 import moment from 'moment';
 
 /**
@@ -201,7 +201,7 @@ class DateField extends React.Component {
     }
 
     return (
-      <ClickOutHandler onClickOut={e => this.closeCalendar(e, this)}>
+      <ClickOutCompat onClickOut={e => this.closeCalendar(e, this)}>
         <div>
           <TextField
             id={name}
@@ -219,7 +219,7 @@ class DateField extends React.Component {
         </div>
         {errorComponent}
         {calendar}
-      </ClickOutHandler>
+      </ClickOutCompat>
     );
   }
 }

--- a/gulp/src/reporting/ReportList.jsx
+++ b/gulp/src/reporting/ReportList.jsx
@@ -7,15 +7,18 @@ export class ReportList extends Component {
   constructor() {
     super();
     this.state = {
-      isMenuActive: false,
       currentlyActive: '',
       reportsRefreshing: [],
     };
   }
 
-  toggleMenu(e) {
-    const {isMenuActive} = this.state;
-    this.setState({isMenuActive: !isMenuActive, currentlyActive: e.target.parentNode.parentNode.id});
+  clickMenu(e) {
+    const {currentlyActive: oldActiveId} = this.state;
+    const activeId = e.target.parentNode.parentNode.id;
+
+    // Hide if they clicked the same one. Important for IE8.
+    const currentlyActive = oldActiveId === activeId ? '' : activeId;
+    this.setState({currentlyActive});
   }
 
   handleRefreshReport(report) {
@@ -75,7 +78,7 @@ export class ReportList extends Component {
   }
 
   closeAllPopups() {
-    this.setState({isMenuActive: false, currentlyActive: ''});
+    this.setState({currentlyActive: ''});
   }
 
   render() {
@@ -115,11 +118,15 @@ export class ReportList extends Component {
           )}
           key={r.id}
           id={numberedID}>
-          {options.length > 0 ? <PopMenu options={options}
-                                         isMenuActive={isThisMenuActive}
-                                         toggleMenu={(e) => this.toggleMenu(e)}
-                                         closeAllPopups={(e) => this.closeAllPopups(e)} /> : ''}
-          {(r.isRunning || this.state.reportsRefreshing.indexOf(r.id) > -1) ? <span className="report-loader"></span> : ''}
+          {options.length > 0 ?
+            <PopMenu options={options}
+              isMenuActive={isThisMenuActive}
+              toggleMenu={(e) => this.clickMenu(e)}
+              closeAllPopups={(e) => this.closeAllPopups(e)} />
+              : ''}
+          {(r.isRunning || this.state.reportsRefreshing.indexOf(r.id) > -1) ?
+            <span className="report-loader"></span>
+            : ''}
           <span className="menu-text">{r.name}</span>
         </li>
       );

--- a/gulp/webpack.config.js
+++ b/gulp/webpack.config.js
@@ -38,6 +38,13 @@ module.exports = {
         loader: 'eslint-loader',
       },
     ],
+    // ie8 catchall. Some imported react components need this.
+    postLoaders: [
+      {
+        test: /\.js$/,
+        loaders: ['es3ify'],
+      },
+    ],
   },
   plugins: [
     // React is smaller, faster, and silent in this mode.


### PR DESCRIPTION
Fixes:

* Components importing React Sortable wouldn't load on ie8 at all, at least under dev server.
* ClickOutCompat was needed and not being used in DateField.
* ReportList context menu couldn't be closed on ie8.
