### PR TITLE
Improve Docker Documentation

### DIFF
--- a/doc/source/developers/docker/use.rst
+++ b/doc/source/developers/docker/use.rst
@@ -138,7 +138,7 @@ Keep trying until ``docker ps`` shows no running machines.
 Load Data into MySQL and Solr
 =============================
 
-``dk background`` At this point possibly only MySql and the reveser proxy will 
+``dk background`` At this point possibly only MySql and the reverse proxy will 
 stay running.
 
 ``dk maint mysql:5.5`` Start an interactive container based on MySQL

--- a/doc/source/developers/docker/use.rst
+++ b/doc/source/developers/docker/use.rst
@@ -75,6 +75,10 @@ First Time (Linux)
 
 Install docker from your distro.
 
+Make sure your user is added to the docker group.  
+
+docker should be shown when you run ``groups``
+
 Know your local ip address. We'll call it $myip from now on.
 
 Terminal Setup (OSX)
@@ -106,8 +110,6 @@ Build the Development Image
 
 Rerun this any time we change requirements.txt.
 
-``(cd dk2/dev && ln -s ../../requirements.txt .)`` Need this symlink.
-
 ``dk rebuilddev`` Also takes a long time. [If it hits a glitch run this command again]
 
 Build the Background Containers
@@ -136,7 +138,8 @@ Keep trying until ``docker ps`` shows no running machines.
 Load Data into MySQL and Solr
 =============================
 
-``dk background`` At this point possibly only MySql will stay running.
+``dk background`` At this point possibly only MySql and the reveser proxy will 
+stay running.
 
 ``dk maint mysql:5.5`` Start an interactive container based on MySQL
 


### PR DESCRIPTION
During my installation we discovered that you need to add your user account to the `docker` group. 

It was also my experience that the symlink breaks things, as the `dk rebuilddev` command copies the settings already.

Finally, the reverse proxy stayed up before I setup MySQL and Solr, so I documented that.