### PR TITLE
[PD-2405] Add Empty List Handling to Reporting

### DIFF
--- a/myreports/datasources/comm_records.py
+++ b/myreports/datasources/comm_records.py
@@ -314,8 +314,8 @@ class CommRecordsFilter(DataSourceFilter):
         if self.communication_type:
             qs = qs.filter(contact_type__in=self.communication_type)
 
-        list_empty = True
-        if self.tags:
+        if self.tags is not None:
+            list_empty = True
             or_qs = []
             for tag_ors in self.tags:
                 if tag_ors:

--- a/myreports/datasources/contacts.py
+++ b/myreports/datasources/contacts.py
@@ -240,7 +240,7 @@ class ContactsFilter(DataSourceFilter):
                 qs = qs.filter(or_q)
             if len(self.tags) == 0:
                 # if an empty tags list was received, return only untagged items
-                qs.filter(tags=None)
+                qs = qs.filter(tags=None)
 
         if self.partner is not None:
             qs = qs.filter(partner__pk__in=self.partner)

--- a/myreports/datasources/contacts.py
+++ b/myreports/datasources/contacts.py
@@ -230,15 +230,18 @@ class ContactsFilter(DataSourceFilter):
         qs = filter_date_range(self.date, 'last_action_time', qs)
 
         if self.tags is not None:
+            list_empty = True
             or_qs = []
             for tag_ors in self.tags:
-                or_qs.append(
-                    reduce(
-                        __or__,
-                        map(lambda t: Q(tags__name__iexact=t), tag_ors)))
+                if tag_ors:
+                    list_empty = False
+                    or_qs.append(
+                        reduce(
+                            __or__,
+                            map(lambda t: Q(tags__name__iexact=t), tag_ors)))
             for or_q in or_qs:
                 qs = qs.filter(or_q)
-            if len(self.tags) == 0:
+            if list_empty:
                 # if an empty tags list was received, return only untagged items
                 qs = qs.filter(tags=None)
 

--- a/myreports/datasources/contacts.py
+++ b/myreports/datasources/contacts.py
@@ -229,7 +229,7 @@ class ContactsFilter(DataSourceFilter):
         """
         qs = filter_date_range(self.date, 'last_action_time', qs)
 
-        if self.tags:
+        if self.tags is not None:
             or_qs = []
             for tag_ors in self.tags:
                 or_qs.append(
@@ -238,8 +238,11 @@ class ContactsFilter(DataSourceFilter):
                         map(lambda t: Q(tags__name__iexact=t), tag_ors)))
             for or_q in or_qs:
                 qs = qs.filter(or_q)
+            if len(self.tags) == 0:
+                # if an empty tags list was received, return only untagged items
+                qs.filter(tags=None)
 
-        if self.partner:
+        if self.partner is not None:
             qs = qs.filter(partner__pk__in=self.partner)
 
         if self.locations is not None:

--- a/myreports/tests/test_comm_records_datasource.py
+++ b/myreports/tests/test_comm_records_datasource.py
@@ -197,7 +197,10 @@ class TestCommRecordsDataSource(MyJobsBase):
         self.assertEqual(expected, subjects)
 
     def test_filter_by_tags(self):
-        """Show only commrec with correct tags."""
+        """
+        Show only commrec with correct tags.
+
+        """
         ds = CommRecordsDataSource()
         recs = ds.run_unaggregated(
             self.company,
@@ -205,6 +208,21 @@ class TestCommRecordsDataSource(MyJobsBase):
             [])
         subjects = {r['subject'] for r in recs}
         expected = {self.record_1.subject, self.record_2.subject}
+        self.assertEqual(expected, subjects)
+
+    def test_filter_by_tags_empty_list(self):
+        """
+        When tags receives an empty list, only return untagged commrecs.
+
+        """
+        self.record_1.tags.clear()
+        ds = CommRecordsDataSource()
+        recs = ds.run_unaggregated(
+            self.company,
+            CommRecordsFilter(tags=[[]]),
+            [])
+        subjects = {r['subject'] for r in recs}
+        expected = {self.record_1.subject}
         self.assertEqual(expected, subjects)
 
     def test_filter_by_tags_or(self):
@@ -245,12 +263,17 @@ class TestCommRecordsDataSource(MyJobsBase):
         self.assertEqual(expected, subjects)
 
     def test_filter_by_empty_things(self):
-        """Empty filters should not filter, just like missing filters."""
+        """
+        Empty filters should not filter, just like missing filters.
+
+        """
         ds = CommRecordsDataSource()
         recs = ds.run_unaggregated(
             self.company,
             CommRecordsFilter(
-                locations={'city': '', 'state': ''}),
+                locations={'city': '', 'state': ''},
+                contact=None,
+                partner=None),
             [])
         subjects = {r['subject'] for r in recs}
         expected = {
@@ -272,7 +295,10 @@ class TestCommRecordsDataSource(MyJobsBase):
         self.assertEqual(expected, subjects)
 
     def test_filter_by_partner(self):
-        """Check partner filter works at all."""
+        """
+        Check partner filter works at all.
+
+        """
         ds = CommRecordsDataSource()
         recs = ds.run_unaggregated(
             self.company,
@@ -282,8 +308,24 @@ class TestCommRecordsDataSource(MyJobsBase):
         expected = {self.record_1.subject, self.record_2.subject}
         self.assertEqual(expected, subjects)
 
+    def test_filter_by_partner_empty_list(self):
+        """
+        Verify that sending an empty list for partner returns no results.
+
+        """
+        ds = CommRecordsDataSource()
+        recs = ds.run_unaggregated(
+            self.company,
+            CommRecordsFilter(partner=[]),
+            [])
+
+        self.assertEqual(len(recs), 0)
+
     def test_filter_by_contact(self):
-        """Check partner filter works at all."""
+        """
+        Check partner filter works at all.
+
+        """
         ds = CommRecordsDataSource()
         recs = ds.run_unaggregated(
             self.company,
@@ -293,8 +335,24 @@ class TestCommRecordsDataSource(MyJobsBase):
         expected = {self.record_3.subject}
         self.assertEqual(expected, subjects)
 
+    def test_filter_by_contact_empty_list(self):
+        """
+        Check partner filter returns no result if given an empty list
+
+        """
+        ds = CommRecordsDataSource()
+        recs = ds.run_unaggregated(
+            self.company,
+            CommRecordsFilter(contact=[]),
+            [])
+
+        self.assertEqual(len(recs), 0)
+
     def test_help_city(self):
-        """Check city help works and ignores current city filter."""
+        """
+        Check city help works and ignores current city filter.
+
+        """
         ds = CommRecordsDataSource()
         recs = ds.help_city(
             self.company,
@@ -304,7 +362,10 @@ class TestCommRecordsDataSource(MyJobsBase):
         self.assertEqual({'Los Angeles'}, actual)
 
     def test_help_state(self):
-        """Check state help works and ignores current state filter."""
+        """
+        Check state help works and ignores current state filter.
+
+        """
         ds = CommRecordsDataSource()
         recs = ds.help_state(
             self.company,
@@ -314,20 +375,29 @@ class TestCommRecordsDataSource(MyJobsBase):
         self.assertEqual({'IL', 'IN'}, actual)
 
     def test_help_tags(self):
-        """Check tags help works at all."""
+        """
+        Check tags help works at all.
+
+        """
         ds = CommRecordsDataSource()
         recs = ds.help_tags(self.company, CommRecordsFilter(), "E")
         actual = {r['value'] for r in recs}
         self.assertEqual({'east', 'west'}, actual)
 
     def test_help_tags_colors(self):
-        """Tags should have colors"""
+        """
+        Tags should have colors
+
+        """
         ds = CommRecordsDataSource()
         recs = ds.help_tags(self.company, CommRecordsFilter(), "east")
         self.assertEqual("aaaaaa", recs[0]['hexColor'])
 
     def test_help_communication_types(self):
-        """Check communication_types help works at all."""
+        """
+        Check communication_types help works at all.
+
+        """
         ds = CommRecordsDataSource()
         recs = ds.help_communication_type(
             self.company, CommRecordsFilter(), "ph")
@@ -336,7 +406,10 @@ class TestCommRecordsDataSource(MyJobsBase):
         self.assertEqual(expected, actual)
 
     def test_help_partner(self):
-        """Check partner help works at all."""
+        """
+        Check partner help works at all.
+
+        """
         ds = CommRecordsDataSource()
         recs = ds.help_partner(self.company, CommRecordsFilter(), "A")
         self.assertEqual(
@@ -344,7 +417,10 @@ class TestCommRecordsDataSource(MyJobsBase):
             recs)
 
     def test_help_contact(self):
-        """Check contact help works at all."""
+        """
+        Check contact help works at all.
+
+        """
         ds = CommRecordsDataSource()
         recs = ds.help_contact(self.company, CommRecordsFilter(), "U")
         self.assertEqual(
@@ -352,7 +428,10 @@ class TestCommRecordsDataSource(MyJobsBase):
             recs)
 
     def test_order(self):
-        """Check ordering results works at all."""
+        """
+        Check ordering results works at all.
+
+        """
         ds = CommRecordsDataSource()
         recs = ds.run_unaggregated(
             self.company,
@@ -409,7 +488,10 @@ class TestCommRecordsDataSource(MyJobsBase):
         self.assertEqual(expected, adorned_filter)
 
     def test_default_filter(self):
-        """should produce a populated filter object."""
+        """
+        should produce a populated filter object.
+
+        """
         ds = CommRecordsDataSource()
         default_filter = ds.get_default_filter(None, self.company)
         self.assertEquals(
@@ -425,13 +507,19 @@ class TestCommRecordsDataSource(MyJobsBase):
 
 class TestCommRecordsFilterCloning(TestCase):
     def test_clone_without_empty(self):
-        """Cloning empty filters shouldn't crash."""
+        """
+        Cloning empty filters shouldn't crash.
+
+        """
         filter = CommRecordsFilter()
         self.assertEqual(CommRecordsFilter(), filter.clone_without_city())
         self.assertEqual(CommRecordsFilter(), filter.clone_without_state())
 
     def test_clone_without_full(self):
-        """Cloning should remove certain fields."""
+        """
+        Cloning should remove certain fields.
+
+        """
         filter = CommRecordsFilter(
                 tags=['C'],
                 locations={'city': 'A', 'state': 'B'})

--- a/myreports/tests/test_contacts_datasource.py
+++ b/myreports/tests/test_contacts_datasource.py
@@ -343,7 +343,7 @@ class TestContactsDataSource(MyJobsBase):
         recs = ds.run_unaggregated(
             self.company,
             ContactsFilter(
-                tags=[],
+                tags=[[]],
                 locations={'city': '', 'state': ''}),
             [])
         names = {r['name'] for r in recs}

--- a/myreports/tests/test_contacts_datasource.py
+++ b/myreports/tests/test_contacts_datasource.py
@@ -83,6 +83,24 @@ class TestContactsDataSource(MyJobsBase):
                 state="CA"))
         self.sue.tags.add(self.west_tag)
 
+        self.billy_user = UserFactory(email="billy@user.com")
+        self.billy = ContactFactory(
+            partner=self.partner_b,
+            name='Billy Tagless',
+            user=self.sue_user,
+            email="billy@user.com",
+            last_action_time='2015-09-30 13:23')
+        self.sue.locations.add(
+            LocationFactory.create(
+                address_line_one="456",
+                city="La Croix",
+                state="CO"))
+        self.sue.locations.add(
+            LocationFactory.create(
+                address_line_one="789",
+                city="La Croix",
+                state="Co"))
+
         # Poision data. Should never show up.
         self.archived_partner_user = (
             UserFactory(email="archived_partner@user.com"))
@@ -206,7 +224,7 @@ class TestContactsDataSource(MyJobsBase):
                 date=[datetime(2015, 9, 1), datetime(2015, 9, 30)]),
             [])
         names = {r['name'] for r in recs}
-        expected = {self.sue.name}
+        expected = {self.sue.name, self.billy.name}
         self.assertEqual(expected, names)
 
     def test_filter_by_date_before(self):
@@ -218,7 +236,7 @@ class TestContactsDataSource(MyJobsBase):
                 date=[None, datetime(2015, 9, 30)]),
             [])
         names = {r['name'] for r in recs}
-        expected = {self.sue.name}
+        expected = {self.sue.name, self.billy.name}
         self.assertEqual(expected, names)
 
     def test_filter_by_date_after(self):
@@ -304,9 +322,8 @@ class TestContactsDataSource(MyJobsBase):
                 partner=[],
                 locations={'city': '', 'state': ''}),
             [])
-        names = {r['name'] for r in recs}
-        expected = {self.john.name, self.sue.name}
-        self.assertEqual(expected, names)
+
+        self.assertEqual(len(recs), 0)
 
     def test_filter_with_empty_tag_list(self):
         """
@@ -323,7 +340,7 @@ class TestContactsDataSource(MyJobsBase):
                 locations={'city': '', 'state': ''}),
             [])
         names = {r['name'] for r in recs}
-        expected = {self.john.name, self.sue.name}
+        expected = {self.billy.name}
         self.assertEqual(expected, names)
 
     def test_filter_by_state(self):

--- a/myreports/tests/test_contacts_datasource.py
+++ b/myreports/tests/test_contacts_datasource.py
@@ -83,24 +83,6 @@ class TestContactsDataSource(MyJobsBase):
                 state="CA"))
         self.sue.tags.add(self.west_tag)
 
-        self.billy_user = UserFactory(email="billy@user.com")
-        self.billy = ContactFactory(
-            partner=self.partner_b,
-            name='Billy Tagless',
-            user=self.sue_user,
-            email="billy@user.com",
-            last_action_time='2015-09-30 13:23')
-        self.sue.locations.add(
-            LocationFactory.create(
-                address_line_one="456",
-                city="La Croix",
-                state="CO"))
-        self.sue.locations.add(
-            LocationFactory.create(
-                address_line_one="789",
-                city="La Croix",
-                state="Co"))
-
         # Poision data. Should never show up.
         self.archived_partner_user = (
             UserFactory(email="archived_partner@user.com"))
@@ -208,7 +190,10 @@ class TestContactsDataSource(MyJobsBase):
         self.archived_contact.archive()
 
     def test_run_unfiltered(self):
-        """Make sure we only get data for this user."""
+        """
+        Make sure we only get data for this user.
+
+        """
         ds = ContactsDataSource()
         recs = ds.run_unaggregated(self.company, ContactsFilter(), [])
         names = {r['name'] for r in recs}
@@ -216,7 +201,10 @@ class TestContactsDataSource(MyJobsBase):
         self.assertEqual(expected, names)
 
     def test_filter_by_date_range(self):
-        """Should show only contact with last_action_time in range."""
+        """
+        Should show only contact with last_action_time in range.
+
+        """
         ds = ContactsDataSource()
         recs = ds.run_unaggregated(
             self.company,
@@ -224,11 +212,14 @@ class TestContactsDataSource(MyJobsBase):
                 date=[datetime(2015, 9, 1), datetime(2015, 9, 30)]),
             [])
         names = {r['name'] for r in recs}
-        expected = {self.sue.name, self.billy.name}
+        expected = {self.sue.name}
         self.assertEqual(expected, names)
 
     def test_filter_by_date_before(self):
-        """Should show only contact with last_action_time before date."""
+        """
+        Should show only contact with last_action_time before date.
+
+        """
         ds = ContactsDataSource()
         recs = ds.run_unaggregated(
             self.company,
@@ -236,11 +227,14 @@ class TestContactsDataSource(MyJobsBase):
                 date=[None, datetime(2015, 9, 30)]),
             [])
         names = {r['name'] for r in recs}
-        expected = {self.sue.name, self.billy.name}
+        expected = {self.sue.name}
         self.assertEqual(expected, names)
 
     def test_filter_by_date_after(self):
-        """Should show only contact with last_action_time after date."""
+        """
+        Should show only contact with last_action_time after date.
+
+        """
         ds = ContactsDataSource()
         recs = ds.run_unaggregated(
             self.company,
@@ -252,7 +246,10 @@ class TestContactsDataSource(MyJobsBase):
         self.assertEqual(expected, names)
 
     def test_filter_by_tags(self):
-        """Should show only contact with correct tags."""
+        """
+        Should show only contact with correct tags.
+
+        """
         ds = ContactsDataSource()
         recs = ds.run_unaggregated(
             self.company,
@@ -263,7 +260,10 @@ class TestContactsDataSource(MyJobsBase):
         self.assertEqual(expected, names)
 
     def test_filter_by_tags_or(self):
-        """Show only contact with correct tags in 'or' configuration."""
+        """
+        Show only contact with correct tags in 'or' configuration.
+
+        """
         ds = ContactsDataSource()
         recs = ds.run_unaggregated(
             self.company,
@@ -274,7 +274,10 @@ class TestContactsDataSource(MyJobsBase):
         self.assertEqual(expected, names)
 
     def test_filter_by_tags_and(self):
-        """Show only contact with correct tags in 'and' configuration."""
+        """
+        Show only contact with correct tags in 'and' configuration.
+
+        """
         ds = ContactsDataSource()
         recs = ds.run_unaggregated(
             self.company,
@@ -295,7 +298,10 @@ class TestContactsDataSource(MyJobsBase):
         self.assertEqual(expected, names)
 
     def test_filter_by_empty_things(self):
-        """None filters should not filter, just like missing filters."""
+        """
+        None filters should not filter, just like missing filters.
+
+        """
         ds = ContactsDataSource()
         recs = ds.run_unaggregated(
             self.company,
@@ -332,6 +338,7 @@ class TestContactsDataSource(MyJobsBase):
         selected no tags to filter by.
 
         """
+        self.sue.tags.clear()
         ds = ContactsDataSource()
         recs = ds.run_unaggregated(
             self.company,
@@ -340,7 +347,7 @@ class TestContactsDataSource(MyJobsBase):
                 locations={'city': '', 'state': ''}),
             [])
         names = {r['name'] for r in recs}
-        expected = {self.billy.name}
+        expected = {self.sue.name}
         self.assertEqual(expected, names)
 
     def test_filter_by_state(self):

--- a/myreports/tests/test_contacts_datasource.py
+++ b/myreports/tests/test_contacts_datasource.py
@@ -277,12 +277,48 @@ class TestContactsDataSource(MyJobsBase):
         self.assertEqual(expected, names)
 
     def test_filter_by_empty_things(self):
-        """Empty filters should not filter, just like missing filters."""
+        """None filters should not filter, just like missing filters."""
+        ds = ContactsDataSource()
+        recs = ds.run_unaggregated(
+            self.company,
+            ContactsFilter(
+                partner=None,
+                tags=None,
+                locations={'city': '', 'state': ''}),
+            [])
+        names = {r['name'] for r in recs}
+        expected = {self.john.name, self.sue.name}
+        self.assertEqual(expected, names)
+
+    def test_filter_with_empty_partner_list(self):
+        """
+        Empty partner list should cause no results to return
+        This indicates that the member selected to filter by partner,
+        but selected no partners
+
+        """
         ds = ContactsDataSource()
         recs = ds.run_unaggregated(
             self.company,
             ContactsFilter(
                 partner=[],
+                locations={'city': '', 'state': ''}),
+            [])
+        names = {r['name'] for r in recs}
+        expected = {self.john.name, self.sue.name}
+        self.assertEqual(expected, names)
+
+    def test_filter_with_empty_tag_list(self):
+        """
+        Empty tag list should cause only items without tags to return.
+        This indicates that the member selected to filter by tags, but
+        selected no tags to filter by.
+
+        """
+        ds = ContactsDataSource()
+        recs = ds.run_unaggregated(
+            self.company,
+            ContactsFilter(
                 tags=[],
                 locations={'city': '', 'state': ''}),
             [])


### PR DESCRIPTION
## Overview

I have modified the filter_query_set function of both the communication records handler and the contacts handler. The following logic applies to both.

If one of the following fields receives an empty list, return no results:
contact, partner

If the tags object receives an empty list, return all untagged items of that category

If either of these receives a None, or the parameter is not passed in, do not filter on that field.

## Testing

I have also modified/added tests to properly "poke" these scenarios. Without a UI, this is kind of hard to hand test. 