### PR TITLE
[PD-2433] Updated method for grabbing partners from OFCCP.

### DIFF
--- a/mypartners/helpers.py
+++ b/mypartners/helpers.py
@@ -311,7 +311,7 @@ def find_partner_from_email(partner_list, email):
     return None
 
 
-def get_library_partners(url, params=None):
+def get_library_partners(url, params=None, headers=None):
     """
     Returns a generator that yields `CompliancePartner` objects, which can then
     be added to the PartnerLibrary table in the database. At the moment, this
@@ -331,7 +331,8 @@ def get_library_partners(url, params=None):
         tree = html.parse(url)
     else:
         params = params or {}
-        response = requests.post(url, params=params)
+        headers = headers or {}
+        response = requests.post(url, params=params, headers=headers)
         tree = html.fromstring(response.text)
 
     # convert column headers to valid Python identifiers, and rename duplicates

--- a/tasks.py
+++ b/tasks.py
@@ -54,24 +54,6 @@ sys.path.insert(0, os.path.join(BASE_DIR))
 sys.path.insert(0, os.path.join(BASE_DIR, '../'))
 os.environ['DJANGO_SETTINGS_MODULE'] = 'settings'
 FEED_FILE_PREFIX = "dseo_feed_"
-PARTNER_LIBRARY_SOURCES = {
-    # https://ofccp.dol-esa.gov/errd/index.html
-    'Employment Referral Resource Directory': {
-        'url': 'https://ofccp.dol-esa.gov/errd/directoryexcel.jsp',
-        'headers': {
-            'Accept-Encoding': 'gzip, deflate, br',
-            'Cookie': 'JSESSIONID=0000Rd90S0bik8ueBPRLXaoKFvy:18sto47c3'
-        }
-    },
-    #  http://www.dol-esa.gov/errd/Resources.503VEVRAA.html
-    'Disability and Veterans Community Resources Directory': {
-        'url': 'https://ofccp.dol-esa.gov/errd/resourceexcel.jsp',
-        'headers': {
-            'Accept-Encoding': 'gzip, deflate, br',
-            'Cookie': 'JSESSIONID=0000Rd90S0bik8ueBPRLXaoKFvy:18sto47c3'
-        }
-    }
-}
 
 @task(name='tasks.create_jira_ticket')
 def create_jira_ticket(summary, description, **kwargs):
@@ -203,6 +185,38 @@ def send_search_digest(self, search):
             raise send_search_digest.retry(arg=[search], exc=e)
 
 
+PARTNER_LIBRARY_SOURCES = {
+    'Employment Referral Resource Directory': {
+        'search_url': 'https://ofccp.dol-esa.gov/errd/directory.jsp',
+        'download_url': 'https://ofccp.dol-esa.gov/errd/directoryexcel.jsp',
+        'params': {
+            'reg': 'ALL',
+            'stat': 'None',
+            'name': '',
+            'city': '',
+            'sht': 'None',
+            'lst': 'None',
+            'sortorder': 'asc'
+        }
+    },
+    'Disability and Veterans Community Resources Directory': {
+        'search_url': 'https://ofccp.dol-esa.gov/errd/resourcequery.jsp',
+        'download_url': 'https://ofccp.dol-esa.gov/errd/resourceexcel.jsp',
+        'params': {
+            'returnformat': 'html',
+            'formname': 'searchfrm',
+            'reg': 'ALL',
+            'stat': 'None',
+            'name': '',
+            'city': '',
+            'sht': 'None',
+            'lst': 'None',
+            'sortorder': 'asc'
+        }
+    }
+}
+
+
 @task(name='tasks.update_partner_library', ignore_result=True,
       default_retry_delay=180, max_retries=2)
 def update_partner_library():
@@ -212,9 +226,9 @@ def update_partner_library():
         print "Parsing data for PartnerLibrary information..."
 
         added = skipped = 0
-        for partner in get_library_partners(data['url'],
-                                            data.get('params'),
-                                            data.get('headers')):
+        for partner in get_library_partners(data['search_url'],
+                                            data['download_url'],
+                                            data.get('params')):
             # the second join + split take care of extra internal whitespace
             fullname = " ".join(" ".join([partner.first_name,
                                           partner.middle_name,

--- a/tasks.py
+++ b/tasks.py
@@ -55,22 +55,20 @@ sys.path.insert(0, os.path.join(BASE_DIR, '../'))
 os.environ['DJANGO_SETTINGS_MODULE'] = 'settings'
 FEED_FILE_PREFIX = "dseo_feed_"
 PARTNER_LIBRARY_SOURCES = {
-    # http://www.dol-esa.gov/errd/index.html
+    # https://ofccp.dol-esa.gov/errd/index.html
     'Employment Referral Resource Directory': {
-        'url': 'http://www.dol-esa.gov/errd/getexcel.jsp?op=1',
-        'params': {
-            'sel': 'ALL',
-            'subreg': 'Download'
+        'url': 'https://ofccp.dol-esa.gov/errd/directoryexcel.jsp',
+        'headers': {
+            'Accept-Encoding': 'gzip, deflate, br',
+            'Cookie': 'JSESSIONID=0000Rd90S0bik8ueBPRLXaoKFvy:18sto47c3'
         }
     },
     #  http://www.dol-esa.gov/errd/Resources.503VEVRAA.html
     'Disability and Veterans Community Resources Directory': {
-        'url': 'http://www.dol-esa.gov/errd/resourcequery.jsp',
-        'params': {
-            'returnformat': 'excel',
-            'formname': 'downloadreg',
-            'reg': 'ALL',
-            'subreg': 'Download'
+        'url': 'https://ofccp.dol-esa.gov/errd/resourceexcel.jsp',
+        'headers': {
+            'Accept-Encoding': 'gzip, deflate, br',
+            'Cookie': 'JSESSIONID=0000Rd90S0bik8ueBPRLXaoKFvy:18sto47c3'
         }
     }
 }
@@ -214,7 +212,9 @@ def update_partner_library():
         print "Parsing data for PartnerLibrary information..."
 
         added = skipped = 0
-        for partner in get_library_partners(data['url'], data['params']):
+        for partner in get_library_partners(data['url'],
+                                            data.get('params'),
+                                            data.get('headers')):
             # the second join + split take care of extra internal whitespace
             fullname = " ".join(" ".join([partner.first_name,
                                           partner.middle_name,
@@ -1132,4 +1132,4 @@ def requeue_failures(hours=8):
 def clean_import_records(days=31):
     days_ago = datetime.now() - timedelta(days=days)
     ImportRecord.objects.filter(date__lt=days_ago).delete()
-    
+

--- a/templates/mypartners/partner_library.html
+++ b/templates/mypartners/partner_library.html
@@ -15,8 +15,8 @@
         <div id="ofccp-referral-directory" class="span12">
             <small>
                 <i>
-                    The partner(s) listed here are from the <a href="http://www.dol-esa.gov/errd/index.html" target="_blank" style="text-decoration: underline">Employment Referral Resource Directory</a>,
-                    the <a href="http://www.dol-esa.gov/errd/Resources.503VEVRAA.html" target="_blank" style="text-decoration: underline">Disability and Veterans Community Resource Directory</a>, and other sources.
+                    The partner(s) listed here are from the <a href="https://ofccp.dol-esa.gov/errd/index.html" target="_blank" style="text-decoration: underline">Employment Referral Resource Directory</a>,
+                    the <a href="https://ofccp.dol-esa.gov/errd/Resources.503VEVRAA.html" target="_blank" style="text-decoration: underline">Disability and Veterans Community Resource Directory</a>, and other sources.
                 </i>
             </small>
         </div>


### PR DESCRIPTION
- urls mentioned at the top of the Partner Library are updated
- HTTP calls made to OFCCP have been updated with proper headers to comply with new way pages are being served

To test, you can run the ./manage.py update_partner_library command. Before this PR, you'd get some failed HTTP requests. Now you should see something about successfully importing/skipping partners and contacts.
