### PR TITLE
[PD-2434] Partner Library Source

### DIFF
--- a/mypartners/admin.py
+++ b/mypartners/admin.py
@@ -3,7 +3,8 @@ from django.contrib import admin
 from django_extensions.admin import ForeignKeyAutocompleteAdmin
 
 from mypartners.models import (Partner, Contact, CommonEmailDomain,
-                               OutreachEmailDomain, OutreachEmailAddress)
+                               OutreachEmailDomain, OutreachEmailAddress,
+                               PartnerLibrarySource)
 
 
 def format_company_name(company):
@@ -43,3 +44,4 @@ admin.site.register(CommonEmailDomain)
 # TODO: Remove this once NUO Module is live
 admin.site.register(OutreachEmailAddress)
 admin.site.register(OutreachEmailDomain, OutreachEmailDomainAdmin)
+admin.site.register(PartnerLibrarySource)

--- a/mypartners/admin.py
+++ b/mypartners/admin.py
@@ -38,10 +38,26 @@ class OutreachEmailDomainAdmin(ForeignKeyAutocompleteAdmin):
         js = ('django_extensions/js/jquery-1.7.2.min.js', )
 
 
+class PartnerLibrarySourceAdmin(admin.ModelAdmin):
+    def get_readonly_fields(self, request, obj=None):
+        # developers can edit everything
+        fields = []
+
+        # staff can edit search_url and name
+        if not request.user.email.endswith('apps.directemployers.org'):
+            fields += ['download_url', 'params']
+
+        # everyone else is restricted to read-only access
+        if not request.user.email.endswith('directemployers.org'):
+            fields += ['name', 'search_url', 'params']
+
+        return fields
+
+
 admin.site.register(Partner)
 admin.site.register(Contact)
 admin.site.register(CommonEmailDomain)
 # TODO: Remove this once NUO Module is live
 admin.site.register(OutreachEmailAddress)
 admin.site.register(OutreachEmailDomain, OutreachEmailDomainAdmin)
-admin.site.register(PartnerLibrarySource)
+admin.site.register(PartnerLibrarySource, PartnerLibrarySourceAdmin)

--- a/mypartners/helpers.py
+++ b/mypartners/helpers.py
@@ -311,7 +311,7 @@ def find_partner_from_email(partner_list, email):
     return None
 
 
-def get_library_partners(url, params=None):
+def get_library_partners(url, params=None, headers=None):
     """
     Returns a generator that yields `CompliancePartner` objects, which can then
     be added to the PartnerLibrary table in the database. At the moment, this
@@ -331,7 +331,8 @@ def get_library_partners(url, params=None):
         tree = html.parse(url)
     else:
         params = params or {}
-        response = requests.post(url, params=params)
+        headers = headers or {}
+        response = requests.post(url, params=params, headers=headers)
         tree = html.fromstring(response.text)
 
     # convert column headers to valid Python identifiers, and rename duplicates

--- a/mypartners/migrations/0032_auto__add_partnerlibrarysource.py
+++ b/mypartners/migrations/0032_auto__add_partnerlibrarysource.py
@@ -1,20 +1,28 @@
 # -*- coding: utf-8 -*-
 from south.utils import datetime_utils as datetime
 from south.db import db
-from south.v2 import DataMigration
+from south.v2 import SchemaMigration
 from django.db import models
 
-class Migration(DataMigration):
+
+class Migration(SchemaMigration):
 
     def forwards(self, orm):
-        "Write your forwards methods here."
+        # Adding model 'PartnerLibrarySource'
+        db.create_table(u'mypartners_partnerlibrarysource', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('name', self.gf('django.db.models.fields.CharField')(max_length=255)),
+            ('search_url', self.gf('django.db.models.fields.URLField')(max_length=200, blank=True)),
+            ('download_url', self.gf('django.db.models.fields.URLField')(max_length=200, blank=True)),
+            ('params', self.gf('django.db.models.fields.TextField')(blank=True)),
+        ))
+        db.send_create_signal(u'mypartners', ['PartnerLibrarySource'])
 
-        # update tags
-        orm.Tag.objects.filter(name='OFCCP Library').update(
-            name='Employment Referral Resource Directory')
 
     def backwards(self, orm):
-        "Write your backwards methods here."
+        # Deleting model 'PartnerLibrarySource'
+        db.delete_table(u'mypartners_partnerlibrarysource')
+
 
     models = {
         u'auth.group': {
@@ -36,6 +44,26 @@ class Migration(DataMigration):
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
             'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
             'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'myjobs.activity': {
+            'Meta': {'object_name': 'Activity'},
+            'app_access': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['myjobs.AppAccess']"}),
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '150'}),
+            'display_name': ('django.db.models.fields.CharField', [], {'max_length': '50', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '50'})
+        },
+        u'myjobs.appaccess': {
+            'Meta': {'object_name': 'AppAccess'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '50'})
+        },
+        u'myjobs.role': {
+            'Meta': {'unique_together': "(('company', 'name'),)", 'object_name': 'Role'},
+            'activities': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['myjobs.Activity']", 'symmetrical': 'False'}),
+            'company': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['seo.Company']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
         },
         u'myjobs.user': {
             'Meta': {'object_name': 'User'},
@@ -60,20 +88,30 @@ class Migration(DataMigration):
             'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
             'password_change': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
             'profile_completion': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'roles': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['myjobs.Role']", 'symmetrical': 'False'}),
             'source': ('django.db.models.fields.CharField', [], {'default': "'https://secure.my.jobs'", 'max_length': '255'}),
             'timezone': ('django.db.models.fields.CharField', [], {'default': "'America/New_York'", 'max_length': '255'}),
             'user_guid': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '100', 'db_index': 'True'}),
             'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"})
         },
+        u'mypartners.commonemaildomain': {
+            'Meta': {'ordering': "['domain']", 'object_name': 'CommonEmailDomain'},
+            'domain': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '200'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
         u'mypartners.contact': {
             'Meta': {'object_name': 'Contact'},
+            'approval_status': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['mypartners.Status']", 'unique': 'True', 'null': 'True'}),
+            'archived_on': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
             'email': ('django.db.models.fields.EmailField', [], {'max_length': '255', 'blank': 'True'}),
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_action_time': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'blank': 'True'}),
+            'library': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['mypartners.PartnerLibrary']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
             'locations': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'contacts'", 'symmetrical': 'False', 'to': u"orm['mypartners.Location']"}),
             'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
-            'notes': ('django.db.models.fields.TextField', [], {'max_length': '1000', 'blank': 'True'}),
-            'partner': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['mypartners.Partner']"}),
-            'phone': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'notes': ('django.db.models.fields.TextField', [], {'default': "''", 'max_length': '1000', 'blank': 'True'}),
+            'partner': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['mypartners.Partner']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
+            'phone': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '30', 'blank': 'True'}),
             'tags': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['mypartners.Tag']", 'null': 'True', 'symmetrical': 'False'}),
             'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['myjobs.User']", 'null': 'True', 'on_delete': 'models.SET_NULL', 'blank': 'True'})
         },
@@ -84,31 +122,37 @@ class Migration(DataMigration):
             'change_message': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
             'contact_identifier': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
             'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']", 'null': 'True', 'blank': 'True'}),
+            'delta': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'impersonator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'impersonator'", 'null': 'True', 'on_delete': 'models.SET_NULL', 'to': u"orm['myjobs.User']"}),
             'object_id': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
             'object_repr': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
             'partner': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['mypartners.Partner']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
+            'successful': ('django.db.models.fields.NullBooleanField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
             'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['myjobs.User']", 'null': 'True', 'on_delete': 'models.SET_NULL'})
         },
         u'mypartners.contactrecord': {
             'Meta': {'object_name': 'ContactRecord'},
+            'approval_status': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['mypartners.Status']", 'unique': 'True', 'null': 'True'}),
+            'archived_on': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
+            'contact': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['mypartners.Contact']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
             'contact_email': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
-            'contact_name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
-            'contact_phone': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'contact_phone': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '30', 'blank': 'True'}),
             'contact_type': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
             'created_by': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['myjobs.User']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
-            'created_on': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'created_on': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
             'date_time': ('django.db.models.fields.DateTimeField', [], {'blank': 'True'}),
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
-            'job_applications': ('django.db.models.fields.CharField', [], {'max_length': '6', 'blank': 'True'}),
-            'job_hires': ('django.db.models.fields.CharField', [], {'max_length': '6', 'blank': 'True'}),
-            'job_id': ('django.db.models.fields.CharField', [], {'max_length': '40', 'blank': 'True'}),
-            'job_interviews': ('django.db.models.fields.CharField', [], {'max_length': '6', 'blank': 'True'}),
+            'job_applications': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '6', 'blank': 'True'}),
+            'job_hires': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '6', 'blank': 'True'}),
+            'job_id': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '40', 'blank': 'True'}),
+            'job_interviews': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '6', 'blank': 'True'}),
+            'last_action_time': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'blank': 'True'}),
             'length': ('django.db.models.fields.TimeField', [], {'null': 'True', 'blank': 'True'}),
-            'location': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
-            'notes': ('django.db.models.fields.TextField', [], {'max_length': '1000', 'blank': 'True'}),
-            'partner': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['mypartners.Partner']"}),
-            'subject': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'location': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '255', 'blank': 'True'}),
+            'notes': ('django.db.models.fields.TextField', [], {'default': "''", 'max_length': '1000', 'blank': 'True'}),
+            'partner': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['mypartners.Partner']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
+            'subject': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '255', 'blank': 'True'}),
             'tags': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['mypartners.Tag']", 'null': 'True', 'symmetrical': 'False'})
         },
         u'mypartners.location': {
@@ -116,18 +160,51 @@ class Migration(DataMigration):
             'address_line_one': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
             'address_line_two': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
             'city': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
-            'country_code': ('django.db.models.fields.CharField', [], {'max_length': '3'}),
+            'country_code': ('django.db.models.fields.CharField', [], {'default': "'USA'", 'max_length': '3'}),
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
             'label': ('django.db.models.fields.CharField', [], {'max_length': '60', 'blank': 'True'}),
             'postal_code': ('django.db.models.fields.CharField', [], {'max_length': '12', 'blank': 'True'}),
             'state': ('django.db.models.fields.CharField', [], {'max_length': '200'})
         },
+        u'mypartners.outreachemailaddress': {
+            'Meta': {'object_name': 'OutreachEmailAddress'},
+            'company': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['seo.Company']"}),
+            'email': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        u'mypartners.outreachemaildomain': {
+            'Meta': {'ordering': "['company', 'domain']", 'unique_together': "(('company', 'domain'),)", 'object_name': 'OutreachEmailDomain'},
+            'company': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['seo.Company']"}),
+            'domain': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        u'mypartners.outreachrecord': {
+            'Meta': {'object_name': 'OutreachRecord'},
+            'communication_records': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['mypartners.ContactRecord']", 'symmetrical': 'False'}),
+            'contacts': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['mypartners.Contact']", 'symmetrical': 'False'}),
+            'current_workflow_state': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['mypartners.OutreachWorkflowState']"}),
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'email_body': ('django.db.models.fields.TextField', [], {}),
+            'from_email': ('django.db.models.fields.EmailField', [], {'max_length': '255'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'outreach_email': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['mypartners.OutreachEmailAddress']"}),
+            'partners': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['mypartners.Partner']", 'symmetrical': 'False'})
+        },
+        u'mypartners.outreachworkflowstate': {
+            'Meta': {'object_name': 'OutreachWorkflowState'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'state': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
         u'mypartners.partner': {
             'Meta': {'object_name': 'Partner'},
+            'approval_status': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['mypartners.Status']", 'unique': 'True', 'null': 'True'}),
+            'archived_on': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
+            'data_source': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_action_time': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'blank': 'True'}),
             'library': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['mypartners.PartnerLibrary']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
             'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
-            'owner': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['seo.Company']"}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['seo.Company']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
             'primary_contact': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'primary_contact'", 'null': 'True', 'on_delete': 'models.SET_NULL', 'to': u"orm['mypartners.Contact']"}),
             'tags': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['mypartners.Tag']", 'null': 'True', 'symmetrical': 'False'}),
             'uri': ('django.db.models.fields.URLField', [], {'max_length': '200', 'blank': 'True'})
@@ -158,17 +235,32 @@ class Migration(DataMigration):
             'uri': ('django.db.models.fields.URLField', [], {'max_length': '200', 'blank': 'True'}),
             'zip_code': ('django.db.models.fields.CharField', [], {'max_length': '12', 'blank': 'True'})
         },
+        u'mypartners.partnerlibrarysource': {
+            'Meta': {'object_name': 'PartnerLibrarySource'},
+            'download_url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'params': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'search_url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'blank': 'True'})
+        },
         u'mypartners.prmattachment': {
             'Meta': {'object_name': 'PRMAttachment'},
             'attachment': ('django.db.models.fields.files.FileField', [], {'max_length': '767', 'null': 'True', 'blank': 'True'}),
             'contact_record': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['mypartners.ContactRecord']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
         },
+        u'mypartners.status': {
+            'Meta': {'object_name': 'Status'},
+            'approved_by': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['myjobs.User']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
+            'code': ('django.db.models.fields.PositiveSmallIntegerField', [], {'default': '1'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_modified': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'blank': 'True'})
+        },
         u'mypartners.tag': {
             'Meta': {'unique_together': "(('name', 'company'),)", 'object_name': 'Tag'},
             'company': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['seo.Company']"}),
             'created_by': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['myjobs.User']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
-            'created_on': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'created_on': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
             'hex_color': ('django.db.models.fields.CharField', [], {'default': "'d4d4d4'", 'max_length': '6', 'blank': 'True'}),
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
             'name': ('django.db.models.fields.CharField', [], {'max_length': '255'})
@@ -212,12 +304,14 @@ class Migration(DataMigration):
             'enable_markdown': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
             'federal_contractor': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
             'id': ('django.db.models.fields.IntegerField', [], {'max_length': '10', 'primary_key': 'True'}),
+            'ignore_includeinindex': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'site_packages': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['postajob.SitePackage']", 'null': 'True', 'blank': 'True'}),
             'title': ('django.db.models.fields.CharField', [], {'max_length': '500', 'null': 'True', 'blank': 'True'}),
             'title_slug': ('django.db.models.fields.SlugField', [], {'max_length': '500', 'null': 'True', 'blank': 'True'})
         },
         u'seo.company': {
             'Meta': {'ordering': "['name']", 'unique_together': "(('name', 'user_created'),)", 'object_name': 'Company'},
-            'admins': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['myjobs.User']", 'through': u"orm['seo.CompanyUser']", 'symmetrical': 'False'}),
+            'app_access': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['myjobs.AppAccess']", 'symmetrical': 'False', 'blank': 'True'}),
             'canonical_microsite': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
             'company_slug': ('django.db.models.fields.SlugField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
             'digital_strategies_customer': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
@@ -230,18 +324,10 @@ class Migration(DataMigration):
             'name': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
             'og_img': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
             'posting_access': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
-            'prm_access': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'prm_saved_search_sites': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['seo.SeoSite']", 'null': 'True', 'blank': 'True'}),
             'product_access': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
             'site_package': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['postajob.SitePackage']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
             'user_created': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
-        },
-        u'seo.companyuser': {
-            'Meta': {'unique_together': "(('user', 'company'),)", 'object_name': 'CompanyUser', 'db_table': "'mydashboard_companyuser'"},
-            'company': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['seo.Company']"}),
-            'date_added': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
-            'group': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
-            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
-            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['myjobs.User']"})
         },
         u'seo.configuration': {
             'Meta': {'object_name': 'Configuration'},
@@ -256,9 +342,18 @@ class Migration(DataMigration):
             'browse_country_order': ('django.db.models.fields.IntegerField', [], {'default': '3'}),
             'browse_country_show': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
             'browse_country_text': ('django.db.models.fields.CharField', [], {'default': "'Country'", 'max_length': '50'}),
-            'browse_facet_order': ('django.db.models.fields.IntegerField', [], {'default': '2'}),
+            'browse_facet_order': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'browse_facet_order_2': ('django.db.models.fields.IntegerField', [], {'default': '2'}),
+            'browse_facet_order_3': ('django.db.models.fields.IntegerField', [], {'default': '3'}),
+            'browse_facet_order_4': ('django.db.models.fields.IntegerField', [], {'default': '4'}),
             'browse_facet_show': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'browse_facet_show_2': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'browse_facet_show_3': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'browse_facet_show_4': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
             'browse_facet_text': ('django.db.models.fields.CharField', [], {'default': "'Job Profiles'", 'max_length': '50'}),
+            'browse_facet_text_2': ('django.db.models.fields.CharField', [], {'default': "'Job Profiles'", 'max_length': '50'}),
+            'browse_facet_text_3': ('django.db.models.fields.CharField', [], {'default': "'Job Profiles'", 'max_length': '50'}),
+            'browse_facet_text_4': ('django.db.models.fields.CharField', [], {'default': "'Job Profiles'", 'max_length': '50'}),
             'browse_moc_order': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
             'browse_moc_show': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
             'browse_moc_text': ('django.db.models.fields.CharField', [], {'default': "'Military Titles'", 'max_length': '50'}),
@@ -272,6 +367,7 @@ class Migration(DataMigration):
             'defaultBlurb': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
             'defaultBlurbTitle': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
             'directemployers_link': ('django.db.models.fields.URLField', [], {'default': "'http://directemployers.org'", 'max_length': '200'}),
+            'doc_type': ('django.db.models.fields.CharField', [], {'default': '\'<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">\'', 'max_length': '255'}),
             'facet_tag': ('django.db.models.fields.CharField', [], {'default': "'new-jobs'", 'max_length': '50'}),
             'fontColor': ('django.db.models.fields.CharField', [], {'default': "'666666'", 'max_length': '6'}),
             'footer': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
@@ -279,8 +375,12 @@ class Migration(DataMigration):
             'header': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
             'home_page_template': ('django.db.models.fields.CharField', [], {'default': "'home_page/home_page_listing.html'", 'max_length': '200'}),
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'language_code': ('django.db.models.fields.CharField', [], {'default': "'en'", 'max_length': '16'}),
             'location_tag': ('django.db.models.fields.CharField', [], {'default': "'jobs'", 'max_length': '50'}),
             'meta': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'moc_helptext': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'moc_label': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'moc_placeholder': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
             'moc_tag': ('django.db.models.fields.CharField', [], {'default': "'vet-jobs'", 'max_length': '50'}),
             'num_filter_items_to_show': ('django.db.models.fields.IntegerField', [], {'default': '10'}),
             'num_job_items_to_show': ('django.db.models.fields.IntegerField', [], {'default': '15'}),
@@ -296,7 +396,14 @@ class Migration(DataMigration):
             'status': ('django.db.models.fields.IntegerField', [], {'default': '1', 'null': 'True', 'db_index': 'True', 'blank': 'True'}),
             'title': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True'}),
             'title_tag': ('django.db.models.fields.CharField', [], {'default': "'jobs-in'", 'max_length': '50'}),
+            'use_secure_blocks': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
             'view_all_jobs_detail': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'what_helptext': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'what_label': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'what_placeholder': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'where_helptext': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'where_label': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'where_placeholder': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
             'wide_footer': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
             'wide_header': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'})
         },
@@ -353,10 +460,11 @@ class Migration(DataMigration):
             'google_analytics_campaigns': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['seo.GoogleAnalyticsCampaign']", 'null': 'True', 'blank': 'True'}),
             'group': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.Group']", 'null': 'True'}),
             'microsite_carousel': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['social_links.MicrositeCarousel']", 'null': 'True', 'on_delete': 'models.SET_NULL', 'blank': 'True'}),
+            'parent_site': ('seo.models.NonChainedForeignKey', [], {'blank': 'True', 'related_name': "'child_sites'", 'null': 'True', 'on_delete': 'models.SET_NULL', 'to': u"orm['seo.SeoSite']"}),
             'postajob_filter_type': ('django.db.models.fields.CharField', [], {'default': "'this site only'", 'max_length': '255'}),
             'site_description': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '200', 'blank': 'True'}),
             'site_heading': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '200', 'blank': 'True'}),
-            'site_package': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['postajob.SitePackage']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
+            'site_package': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['postajob.SitePackage']", 'null': 'True', 'on_delete': 'models.SET_NULL', 'blank': 'True'}),
             u'site_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['sites.Site']", 'unique': 'True', 'primary_key': 'True'}),
             'site_tags': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['seo.SiteTag']", 'null': 'True', 'blank': 'True'}),
             'site_title': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '200', 'blank': 'True'}),
@@ -367,6 +475,7 @@ class Migration(DataMigration):
             'Meta': {'object_name': 'SeoSiteFacet'},
             'boolean_operation': ('django.db.models.fields.CharField', [], {'default': "'or'", 'max_length': '3', 'db_index': 'True'}),
             'customfacet': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['seo.CustomFacet']"}),
+            'facet_group': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
             'facet_type': ('django.db.models.fields.CharField', [], {'default': "'STD'", 'max_length': '4', 'db_index': 'True'}),
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
             'seosite': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['seo.SeoSite']"})
@@ -408,4 +517,3 @@ class Migration(DataMigration):
     }
 
     complete_apps = ['mypartners']
-    symmetrical = True

--- a/mypartners/migrations/0033_library_sources.py
+++ b/mypartners/migrations/0033_library_sources.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import json
 from south.utils import datetime_utils as datetime
 from south.db import db
 from south.v2 import DataMigration
@@ -7,11 +8,38 @@ from django.db import models
 class Migration(DataMigration):
 
     def forwards(self, orm):
-        "Write your forwards methods here."
-
-        # update tags
-        orm.Tag.objects.filter(name='OFCCP Library').update(
-            name='Employment Referral Resource Directory')
+        orm.PartnerLibrarySource.objects.bulk_create([
+            orm.PartnerLibrarySource(
+                name='Employment Referral Resource Directory',
+                search_url='https://ofccp.dol-esa.gov/errd/directory.jsp',
+                download_url='https://ofccp.dol-esa.gov/errd/directoryexcel.jsp',
+                params=json.dumps({
+                    'reg': 'ALL',
+                    'stat': 'None',
+                    'name': '',
+                    'city': '',
+                    'sht': 'None',
+                    'lst': 'None',
+                    'sortorder': 'asc'
+                })
+            ),
+            orm.PartnerLibrarySource(
+                name='Disability and Veterans Community Resources Directory',
+                search_url='https://ofccp.dol-esa.gov/errd/resourcequery.jsp',
+                download_url='https://ofccp.dol-esa.gov/errd/resourceexcel.jsp',
+                params=json.dumps({
+                    'returnformat': 'html',
+                    'formname': 'searchfrm',
+                    'reg': 'ALL',
+                    'stat': 'None',
+                    'name': '',
+                    'city': '',
+                    'sht': 'None',
+                    'lst': 'None',
+                    'sortorder': 'asc'
+                })
+            )
+        ])
 
     def backwards(self, orm):
         "Write your backwards methods here."
@@ -37,6 +65,26 @@ class Migration(DataMigration):
             'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
             'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
         },
+        u'myjobs.activity': {
+            'Meta': {'object_name': 'Activity'},
+            'app_access': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['myjobs.AppAccess']"}),
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '150'}),
+            'display_name': ('django.db.models.fields.CharField', [], {'max_length': '50', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '50'})
+        },
+        u'myjobs.appaccess': {
+            'Meta': {'object_name': 'AppAccess'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '50'})
+        },
+        u'myjobs.role': {
+            'Meta': {'unique_together': "(('company', 'name'),)", 'object_name': 'Role'},
+            'activities': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['myjobs.Activity']", 'symmetrical': 'False'}),
+            'company': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['seo.Company']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
         u'myjobs.user': {
             'Meta': {'object_name': 'User'},
             'date_joined': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
@@ -60,20 +108,30 @@ class Migration(DataMigration):
             'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
             'password_change': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
             'profile_completion': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'roles': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['myjobs.Role']", 'symmetrical': 'False'}),
             'source': ('django.db.models.fields.CharField', [], {'default': "'https://secure.my.jobs'", 'max_length': '255'}),
             'timezone': ('django.db.models.fields.CharField', [], {'default': "'America/New_York'", 'max_length': '255'}),
             'user_guid': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '100', 'db_index': 'True'}),
             'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"})
         },
+        u'mypartners.commonemaildomain': {
+            'Meta': {'ordering': "['domain']", 'object_name': 'CommonEmailDomain'},
+            'domain': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '200'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
         u'mypartners.contact': {
             'Meta': {'object_name': 'Contact'},
+            'approval_status': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['mypartners.Status']", 'unique': 'True', 'null': 'True'}),
+            'archived_on': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
             'email': ('django.db.models.fields.EmailField', [], {'max_length': '255', 'blank': 'True'}),
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_action_time': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'blank': 'True'}),
+            'library': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['mypartners.PartnerLibrary']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
             'locations': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'contacts'", 'symmetrical': 'False', 'to': u"orm['mypartners.Location']"}),
             'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
-            'notes': ('django.db.models.fields.TextField', [], {'max_length': '1000', 'blank': 'True'}),
-            'partner': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['mypartners.Partner']"}),
-            'phone': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'notes': ('django.db.models.fields.TextField', [], {'default': "''", 'max_length': '1000', 'blank': 'True'}),
+            'partner': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['mypartners.Partner']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
+            'phone': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '30', 'blank': 'True'}),
             'tags': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['mypartners.Tag']", 'null': 'True', 'symmetrical': 'False'}),
             'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['myjobs.User']", 'null': 'True', 'on_delete': 'models.SET_NULL', 'blank': 'True'})
         },
@@ -84,31 +142,37 @@ class Migration(DataMigration):
             'change_message': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
             'contact_identifier': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
             'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']", 'null': 'True', 'blank': 'True'}),
+            'delta': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'impersonator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'impersonator'", 'null': 'True', 'on_delete': 'models.SET_NULL', 'to': u"orm['myjobs.User']"}),
             'object_id': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
             'object_repr': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
             'partner': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['mypartners.Partner']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
+            'successful': ('django.db.models.fields.NullBooleanField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
             'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['myjobs.User']", 'null': 'True', 'on_delete': 'models.SET_NULL'})
         },
         u'mypartners.contactrecord': {
             'Meta': {'object_name': 'ContactRecord'},
+            'approval_status': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['mypartners.Status']", 'unique': 'True', 'null': 'True'}),
+            'archived_on': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
+            'contact': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['mypartners.Contact']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
             'contact_email': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
-            'contact_name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
-            'contact_phone': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'contact_phone': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '30', 'blank': 'True'}),
             'contact_type': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
             'created_by': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['myjobs.User']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
-            'created_on': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'created_on': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
             'date_time': ('django.db.models.fields.DateTimeField', [], {'blank': 'True'}),
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
-            'job_applications': ('django.db.models.fields.CharField', [], {'max_length': '6', 'blank': 'True'}),
-            'job_hires': ('django.db.models.fields.CharField', [], {'max_length': '6', 'blank': 'True'}),
-            'job_id': ('django.db.models.fields.CharField', [], {'max_length': '40', 'blank': 'True'}),
-            'job_interviews': ('django.db.models.fields.CharField', [], {'max_length': '6', 'blank': 'True'}),
+            'job_applications': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '6', 'blank': 'True'}),
+            'job_hires': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '6', 'blank': 'True'}),
+            'job_id': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '40', 'blank': 'True'}),
+            'job_interviews': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '6', 'blank': 'True'}),
+            'last_action_time': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'blank': 'True'}),
             'length': ('django.db.models.fields.TimeField', [], {'null': 'True', 'blank': 'True'}),
-            'location': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
-            'notes': ('django.db.models.fields.TextField', [], {'max_length': '1000', 'blank': 'True'}),
-            'partner': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['mypartners.Partner']"}),
-            'subject': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'location': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '255', 'blank': 'True'}),
+            'notes': ('django.db.models.fields.TextField', [], {'default': "''", 'max_length': '1000', 'blank': 'True'}),
+            'partner': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['mypartners.Partner']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
+            'subject': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '255', 'blank': 'True'}),
             'tags': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['mypartners.Tag']", 'null': 'True', 'symmetrical': 'False'})
         },
         u'mypartners.location': {
@@ -116,18 +180,51 @@ class Migration(DataMigration):
             'address_line_one': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
             'address_line_two': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
             'city': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
-            'country_code': ('django.db.models.fields.CharField', [], {'max_length': '3'}),
+            'country_code': ('django.db.models.fields.CharField', [], {'default': "'USA'", 'max_length': '3'}),
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
             'label': ('django.db.models.fields.CharField', [], {'max_length': '60', 'blank': 'True'}),
             'postal_code': ('django.db.models.fields.CharField', [], {'max_length': '12', 'blank': 'True'}),
             'state': ('django.db.models.fields.CharField', [], {'max_length': '200'})
         },
+        u'mypartners.outreachemailaddress': {
+            'Meta': {'object_name': 'OutreachEmailAddress'},
+            'company': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['seo.Company']"}),
+            'email': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        u'mypartners.outreachemaildomain': {
+            'Meta': {'ordering': "['company', 'domain']", 'unique_together': "(('company', 'domain'),)", 'object_name': 'OutreachEmailDomain'},
+            'company': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['seo.Company']"}),
+            'domain': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        u'mypartners.outreachrecord': {
+            'Meta': {'object_name': 'OutreachRecord'},
+            'communication_records': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['mypartners.ContactRecord']", 'symmetrical': 'False'}),
+            'contacts': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['mypartners.Contact']", 'symmetrical': 'False'}),
+            'current_workflow_state': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['mypartners.OutreachWorkflowState']"}),
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'email_body': ('django.db.models.fields.TextField', [], {}),
+            'from_email': ('django.db.models.fields.EmailField', [], {'max_length': '255'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'outreach_email': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['mypartners.OutreachEmailAddress']"}),
+            'partners': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['mypartners.Partner']", 'symmetrical': 'False'})
+        },
+        u'mypartners.outreachworkflowstate': {
+            'Meta': {'object_name': 'OutreachWorkflowState'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'state': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
         u'mypartners.partner': {
             'Meta': {'object_name': 'Partner'},
+            'approval_status': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['mypartners.Status']", 'unique': 'True', 'null': 'True'}),
+            'archived_on': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
+            'data_source': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_action_time': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'blank': 'True'}),
             'library': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['mypartners.PartnerLibrary']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
             'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
-            'owner': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['seo.Company']"}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['seo.Company']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
             'primary_contact': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'primary_contact'", 'null': 'True', 'on_delete': 'models.SET_NULL', 'to': u"orm['mypartners.Contact']"}),
             'tags': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['mypartners.Tag']", 'null': 'True', 'symmetrical': 'False'}),
             'uri': ('django.db.models.fields.URLField', [], {'max_length': '200', 'blank': 'True'})
@@ -158,17 +255,32 @@ class Migration(DataMigration):
             'uri': ('django.db.models.fields.URLField', [], {'max_length': '200', 'blank': 'True'}),
             'zip_code': ('django.db.models.fields.CharField', [], {'max_length': '12', 'blank': 'True'})
         },
+        u'mypartners.partnerlibrarysource': {
+            'Meta': {'object_name': 'PartnerLibrarySource'},
+            'download_url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'params': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'search_url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'blank': 'True'})
+        },
         u'mypartners.prmattachment': {
             'Meta': {'object_name': 'PRMAttachment'},
             'attachment': ('django.db.models.fields.files.FileField', [], {'max_length': '767', 'null': 'True', 'blank': 'True'}),
             'contact_record': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['mypartners.ContactRecord']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
         },
+        u'mypartners.status': {
+            'Meta': {'object_name': 'Status'},
+            'approved_by': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['myjobs.User']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
+            'code': ('django.db.models.fields.PositiveSmallIntegerField', [], {'default': '1'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_modified': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'blank': 'True'})
+        },
         u'mypartners.tag': {
             'Meta': {'unique_together': "(('name', 'company'),)", 'object_name': 'Tag'},
             'company': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['seo.Company']"}),
             'created_by': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['myjobs.User']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
-            'created_on': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'created_on': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
             'hex_color': ('django.db.models.fields.CharField', [], {'default': "'d4d4d4'", 'max_length': '6', 'blank': 'True'}),
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
             'name': ('django.db.models.fields.CharField', [], {'max_length': '255'})
@@ -212,12 +324,14 @@ class Migration(DataMigration):
             'enable_markdown': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
             'federal_contractor': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
             'id': ('django.db.models.fields.IntegerField', [], {'max_length': '10', 'primary_key': 'True'}),
+            'ignore_includeinindex': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'site_packages': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['postajob.SitePackage']", 'null': 'True', 'blank': 'True'}),
             'title': ('django.db.models.fields.CharField', [], {'max_length': '500', 'null': 'True', 'blank': 'True'}),
             'title_slug': ('django.db.models.fields.SlugField', [], {'max_length': '500', 'null': 'True', 'blank': 'True'})
         },
         u'seo.company': {
             'Meta': {'ordering': "['name']", 'unique_together': "(('name', 'user_created'),)", 'object_name': 'Company'},
-            'admins': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['myjobs.User']", 'through': u"orm['seo.CompanyUser']", 'symmetrical': 'False'}),
+            'app_access': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['myjobs.AppAccess']", 'symmetrical': 'False', 'blank': 'True'}),
             'canonical_microsite': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
             'company_slug': ('django.db.models.fields.SlugField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
             'digital_strategies_customer': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
@@ -230,18 +344,10 @@ class Migration(DataMigration):
             'name': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
             'og_img': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
             'posting_access': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
-            'prm_access': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'prm_saved_search_sites': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['seo.SeoSite']", 'null': 'True', 'blank': 'True'}),
             'product_access': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
             'site_package': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['postajob.SitePackage']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
             'user_created': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
-        },
-        u'seo.companyuser': {
-            'Meta': {'unique_together': "(('user', 'company'),)", 'object_name': 'CompanyUser', 'db_table': "'mydashboard_companyuser'"},
-            'company': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['seo.Company']"}),
-            'date_added': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
-            'group': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
-            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
-            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['myjobs.User']"})
         },
         u'seo.configuration': {
             'Meta': {'object_name': 'Configuration'},
@@ -256,9 +362,18 @@ class Migration(DataMigration):
             'browse_country_order': ('django.db.models.fields.IntegerField', [], {'default': '3'}),
             'browse_country_show': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
             'browse_country_text': ('django.db.models.fields.CharField', [], {'default': "'Country'", 'max_length': '50'}),
-            'browse_facet_order': ('django.db.models.fields.IntegerField', [], {'default': '2'}),
+            'browse_facet_order': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'browse_facet_order_2': ('django.db.models.fields.IntegerField', [], {'default': '2'}),
+            'browse_facet_order_3': ('django.db.models.fields.IntegerField', [], {'default': '3'}),
+            'browse_facet_order_4': ('django.db.models.fields.IntegerField', [], {'default': '4'}),
             'browse_facet_show': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'browse_facet_show_2': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'browse_facet_show_3': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'browse_facet_show_4': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
             'browse_facet_text': ('django.db.models.fields.CharField', [], {'default': "'Job Profiles'", 'max_length': '50'}),
+            'browse_facet_text_2': ('django.db.models.fields.CharField', [], {'default': "'Job Profiles'", 'max_length': '50'}),
+            'browse_facet_text_3': ('django.db.models.fields.CharField', [], {'default': "'Job Profiles'", 'max_length': '50'}),
+            'browse_facet_text_4': ('django.db.models.fields.CharField', [], {'default': "'Job Profiles'", 'max_length': '50'}),
             'browse_moc_order': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
             'browse_moc_show': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
             'browse_moc_text': ('django.db.models.fields.CharField', [], {'default': "'Military Titles'", 'max_length': '50'}),
@@ -272,6 +387,7 @@ class Migration(DataMigration):
             'defaultBlurb': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
             'defaultBlurbTitle': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
             'directemployers_link': ('django.db.models.fields.URLField', [], {'default': "'http://directemployers.org'", 'max_length': '200'}),
+            'doc_type': ('django.db.models.fields.CharField', [], {'default': '\'<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">\'', 'max_length': '255'}),
             'facet_tag': ('django.db.models.fields.CharField', [], {'default': "'new-jobs'", 'max_length': '50'}),
             'fontColor': ('django.db.models.fields.CharField', [], {'default': "'666666'", 'max_length': '6'}),
             'footer': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
@@ -279,8 +395,12 @@ class Migration(DataMigration):
             'header': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
             'home_page_template': ('django.db.models.fields.CharField', [], {'default': "'home_page/home_page_listing.html'", 'max_length': '200'}),
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'language_code': ('django.db.models.fields.CharField', [], {'default': "'en'", 'max_length': '16'}),
             'location_tag': ('django.db.models.fields.CharField', [], {'default': "'jobs'", 'max_length': '50'}),
             'meta': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'moc_helptext': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'moc_label': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'moc_placeholder': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
             'moc_tag': ('django.db.models.fields.CharField', [], {'default': "'vet-jobs'", 'max_length': '50'}),
             'num_filter_items_to_show': ('django.db.models.fields.IntegerField', [], {'default': '10'}),
             'num_job_items_to_show': ('django.db.models.fields.IntegerField', [], {'default': '15'}),
@@ -296,7 +416,14 @@ class Migration(DataMigration):
             'status': ('django.db.models.fields.IntegerField', [], {'default': '1', 'null': 'True', 'db_index': 'True', 'blank': 'True'}),
             'title': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True'}),
             'title_tag': ('django.db.models.fields.CharField', [], {'default': "'jobs-in'", 'max_length': '50'}),
+            'use_secure_blocks': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
             'view_all_jobs_detail': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'what_helptext': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'what_label': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'what_placeholder': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'where_helptext': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'where_label': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'where_placeholder': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
             'wide_footer': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
             'wide_header': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'})
         },
@@ -353,10 +480,11 @@ class Migration(DataMigration):
             'google_analytics_campaigns': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['seo.GoogleAnalyticsCampaign']", 'null': 'True', 'blank': 'True'}),
             'group': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.Group']", 'null': 'True'}),
             'microsite_carousel': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['social_links.MicrositeCarousel']", 'null': 'True', 'on_delete': 'models.SET_NULL', 'blank': 'True'}),
+            'parent_site': ('seo.models.NonChainedForeignKey', [], {'blank': 'True', 'related_name': "'child_sites'", 'null': 'True', 'on_delete': 'models.SET_NULL', 'to': u"orm['seo.SeoSite']"}),
             'postajob_filter_type': ('django.db.models.fields.CharField', [], {'default': "'this site only'", 'max_length': '255'}),
             'site_description': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '200', 'blank': 'True'}),
             'site_heading': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '200', 'blank': 'True'}),
-            'site_package': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['postajob.SitePackage']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
+            'site_package': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['postajob.SitePackage']", 'null': 'True', 'on_delete': 'models.SET_NULL', 'blank': 'True'}),
             u'site_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['sites.Site']", 'unique': 'True', 'primary_key': 'True'}),
             'site_tags': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['seo.SiteTag']", 'null': 'True', 'blank': 'True'}),
             'site_title': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '200', 'blank': 'True'}),
@@ -367,6 +495,7 @@ class Migration(DataMigration):
             'Meta': {'object_name': 'SeoSiteFacet'},
             'boolean_operation': ('django.db.models.fields.CharField', [], {'default': "'or'", 'max_length': '3', 'db_index': 'True'}),
             'customfacet': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['seo.CustomFacet']"}),
+            'facet_group': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
             'facet_type': ('django.db.models.fields.CharField', [], {'default': "'STD'", 'max_length': '4', 'db_index': 'True'}),
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
             'seosite': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['seo.SeoSite']"})

--- a/mypartners/migrations/0033_library_sources.py
+++ b/mypartners/migrations/0033_library_sources.py
@@ -42,7 +42,7 @@ class Migration(DataMigration):
         ])
 
     def backwards(self, orm):
-        "Write your backwards methods here."
+        orm.PartnerLibrarySource.objects.all().delete()
 
     models = {
         u'auth.group': {

--- a/mypartners/models.py
+++ b/mypartners/models.py
@@ -442,6 +442,17 @@ def save_partner(sender, instance, **kwargs):
         instance.approval_status = Status.objects.create()
 
 
+class PartnerLibrarySource(models.Model):
+    name = models.CharField(max_length=255)
+    search_url = models.URLField(blank=True)
+    download_url = models.URLField(blank=True)
+    # json serialized dictionary of parameters
+    params = models.TextField(blank=True)
+
+    def __unicode__(self):
+        return self.name
+
+
 class PartnerLibrary(models.Model):
     """
     Partners curated from the Office of Federal Contract Compliance

--- a/mypartners/models.py
+++ b/mypartners/models.py
@@ -444,10 +444,17 @@ def save_partner(sender, instance, **kwargs):
 
 class PartnerLibrarySource(models.Model):
     name = models.CharField(max_length=255)
-    search_url = models.URLField(blank=True)
-    download_url = models.URLField(blank=True)
+    search_url = models.URLField(
+        blank=True,
+        help_text="The URL to the user-facing search page for this source.")
+    download_url = models.URLField(
+        blank=True,
+        help_text="The URL used to download this source.")
     # json serialized dictionary of parameters
-    params = models.TextField(blank=True)
+    params = models.TextField(
+        blank=True,
+        help_text="POST data used when downloading this source, serialized "
+                  "as JSON.")
 
     def __unicode__(self):
         return self.name

--- a/mypartners/tests/test_views.py
+++ b/mypartners/tests/test_views.py
@@ -22,8 +22,6 @@ from django.utils.timezone import utc
 from myprofile.tests.factories import SecondaryEmailFactory
 from seo.models import SeoSite
 
-from tasks import PARTNER_LIBRARY_SOURCES
-
 from myjobs.tests.setup import MyJobsBase
 from myjobs.tests.test_views import TestClient
 from myjobs.tests.factories import UserFactory, RoleFactory

--- a/mypartners/views.py
+++ b/mypartners/views.py
@@ -43,7 +43,8 @@ from mypartners.forms import (PartnerForm, ContactForm,
 from mypartners.models import (Partner, Contact, ContactRecord,
                                PRMAttachment, ContactLogEntry, Tag,
                                CONTACT_TYPE_CHOICES, ADDITION, DELETION,
-                               Location, OutreachEmailAddress, OutreachRecord)
+                               Location, OutreachEmailAddress, OutreachRecord,
+                               PartnerLibrarySource)
 from mypartners.helpers import (prm_worthy, add_extra_params,
                                 add_extra_params_to_jobs, log_change,
                                 contact_record_val_to_str, retrieve_fields,
@@ -115,7 +116,8 @@ def partner_library(request):
     ctx = {
         'company': company,
         'view_name': 'PRM',
-        'partners': paginator
+        'partners': paginator,
+        'sources': PartnerLibrarySource.objects.values('search_url', 'name')
     }
 
     return render_to_response('mypartners/partner_library.html', ctx,

--- a/tasks.py
+++ b/tasks.py
@@ -31,7 +31,7 @@ from myjobs.helpers import log_to_jira
 from mymessages.models import Message
 from mysearches.models import (SavedSearch, SavedSearchDigest, SavedSearchLog,
                                DOM_CHOICES, DOW_CHOICES)
-from mypartners.models import PartnerLibrary
+from mypartners.models import PartnerLibrary, PartnerLibrarySource
 from mypartners.helpers import get_library_partners
 import import_jobs
 from import_jobs.models import ImportRecord
@@ -185,50 +185,18 @@ def send_search_digest(self, search):
             raise send_search_digest.retry(arg=[search], exc=e)
 
 
-PARTNER_LIBRARY_SOURCES = {
-    'Employment Referral Resource Directory': {
-        'search_url': 'https://ofccp.dol-esa.gov/errd/directory.jsp',
-        'download_url': 'https://ofccp.dol-esa.gov/errd/directoryexcel.jsp',
-        'params': {
-            'reg': 'ALL',
-            'stat': 'None',
-            'name': '',
-            'city': '',
-            'sht': 'None',
-            'lst': 'None',
-            'sortorder': 'asc'
-        }
-    },
-    'Disability and Veterans Community Resources Directory': {
-        'search_url': 'https://ofccp.dol-esa.gov/errd/resourcequery.jsp',
-        'download_url': 'https://ofccp.dol-esa.gov/errd/resourceexcel.jsp',
-        'params': {
-            'returnformat': 'html',
-            'formname': 'searchfrm',
-            'reg': 'ALL',
-            'stat': 'None',
-            'name': '',
-            'city': '',
-            'sht': 'None',
-            'lst': 'None',
-            'sortorder': 'asc'
-        }
-    }
-}
-
-
 @task(name='tasks.update_partner_library', ignore_result=True,
       default_retry_delay=180, max_retries=2)
 def update_partner_library():
 
-    for source, data in PARTNER_LIBRARY_SOURCES.items():
+    for source in PartnerLibrarySource.objects.all():
         print "Connecting to %s...." % source
         print "Parsing data for PartnerLibrary information..."
 
         added = skipped = 0
-        for partner in get_library_partners(data['search_url'],
-                                            data['download_url'],
-                                            data.get('params')):
+        for partner in get_library_partners(source.search_url,
+                                            source.download_url,
+                                            json.loads(source.params)):
             # the second join + split take care of extra internal whitespace
             fullname = " ".join(" ".join([partner.first_name,
                                           partner.middle_name,
@@ -238,13 +206,13 @@ def update_partner_library():
 
             for email in emails:
                 # disambiguate records by source, contact name, and address
-                if not PartnerLibrary.objects.filter(data_source=source,
+                if not PartnerLibrary.objects.filter(data_source=source.name,
                                                      contact_name=fullname,
                                                      st=partner.st,
                                                      city=partner.city,
                                                      email=email).exists():
                     PartnerLibrary.objects.create(
-                        data_source=source,
+                        data_source=source.name,
                         name=partner.organization_name,
                         uri=partner.website,
                         region=partner.region,

--- a/tasks.py
+++ b/tasks.py
@@ -54,24 +54,6 @@ sys.path.insert(0, os.path.join(BASE_DIR))
 sys.path.insert(0, os.path.join(BASE_DIR, '../'))
 os.environ['DJANGO_SETTINGS_MODULE'] = 'settings'
 FEED_FILE_PREFIX = "dseo_feed_"
-PARTNER_LIBRARY_SOURCES = {
-    # https://ofccp.dol-esa.gov/errd/index.html
-    'Employment Referral Resource Directory': {
-        'url': 'https://ofccp.dol-esa.gov/errd/directoryexcel.jsp',
-        'headers': {
-            'Accept-Encoding': 'gzip, deflate, br',
-            'Cookie': 'JSESSIONID=0000Rd90S0bik8ueBPRLXaoKFvy:18sto47c3'
-        }
-    },
-    #  http://www.dol-esa.gov/errd/Resources.503VEVRAA.html
-    'Disability and Veterans Community Resources Directory': {
-        'url': 'https://ofccp.dol-esa.gov/errd/resourceexcel.jsp',
-        'headers': {
-            'Accept-Encoding': 'gzip, deflate, br',
-            'Cookie': 'JSESSIONID=0000Rd90S0bik8ueBPRLXaoKFvy:18sto47c3'
-        }
-    }
-}
 
 @task(name='tasks.create_jira_ticket')
 def create_jira_ticket(summary, description, **kwargs):
@@ -203,6 +185,38 @@ def send_search_digest(self, search):
             raise send_search_digest.retry(arg=[search], exc=e)
 
 
+PARTNER_LIBRARY_SOURCES = {
+    'Employment Referral Resource Directory': {
+        'search_url': 'https://ofccp.dol-esa.gov/errd/directory.jsp',
+        'download_url': 'https://ofccp.dol-esa.gov/errd/directoryexcel.jsp',
+        'params': {
+            'reg': 'ALL',
+            'stat': 'None',
+            'name': '',
+            'city': '',
+            'sht': 'None',
+            'lst': 'None',
+            'sortorder': 'asc'
+        }
+    },
+    'Disability and Veterans Community Resources Directory': {
+        'search_url': 'https://ofccp.dol-esa.gov/errd/resourcequery.jsp',
+        'download_url': 'https://ofccp.dol-esa.gov/errd/resourceexcel.jsp',
+        'params': {
+            'returnformat': 'html',
+            'formname': 'searchfrm',
+            'reg': 'ALL',
+            'stat': 'None',
+            'name': '',
+            'city': '',
+            'sht': 'None',
+            'lst': 'None',
+            'sortorder': 'asc'
+        }
+    }
+}
+
+
 @task(name='tasks.update_partner_library', ignore_result=True,
       default_retry_delay=180, max_retries=2)
 def update_partner_library():
@@ -212,9 +226,9 @@ def update_partner_library():
         print "Parsing data for PartnerLibrary information..."
 
         added = skipped = 0
-        for partner in get_library_partners(data['url'],
-                                            data.get('params'),
-                                            data.get('headers')):
+        for partner in get_library_partners(data['search_url'],
+                                            data['download_url'],
+                                            data.get('params')):
             # the second join + split take care of extra internal whitespace
             fullname = " ".join(" ".join([partner.first_name,
                                           partner.middle_name,

--- a/tasks.py
+++ b/tasks.py
@@ -55,22 +55,20 @@ sys.path.insert(0, os.path.join(BASE_DIR, '../'))
 os.environ['DJANGO_SETTINGS_MODULE'] = 'settings'
 FEED_FILE_PREFIX = "dseo_feed_"
 PARTNER_LIBRARY_SOURCES = {
-    # http://www.dol-esa.gov/errd/index.html
+    # https://ofccp.dol-esa.gov/errd/index.html
     'Employment Referral Resource Directory': {
-        'url': 'http://www.dol-esa.gov/errd/getexcel.jsp?op=1',
-        'params': {
-            'sel': 'ALL',
-            'subreg': 'Download'
+        'url': 'https://ofccp.dol-esa.gov/errd/directoryexcel.jsp',
+        'headers': {
+            'Accept-Encoding': 'gzip, deflate, br',
+            'Cookie': 'JSESSIONID=0000Rd90S0bik8ueBPRLXaoKFvy:18sto47c3'
         }
     },
     #  http://www.dol-esa.gov/errd/Resources.503VEVRAA.html
     'Disability and Veterans Community Resources Directory': {
-        'url': 'http://www.dol-esa.gov/errd/resourcequery.jsp',
-        'params': {
-            'returnformat': 'excel',
-            'formname': 'downloadreg',
-            'reg': 'ALL',
-            'subreg': 'Download'
+        'url': 'https://ofccp.dol-esa.gov/errd/resourceexcel.jsp',
+        'headers': {
+            'Accept-Encoding': 'gzip, deflate, br',
+            'Cookie': 'JSESSIONID=0000Rd90S0bik8ueBPRLXaoKFvy:18sto47c3'
         }
     }
 }
@@ -214,7 +212,9 @@ def update_partner_library():
         print "Parsing data for PartnerLibrary information..."
 
         added = skipped = 0
-        for partner in get_library_partners(data['url'], data['params']):
+        for partner in get_library_partners(data['url'],
+                                            data.get('params'),
+                                            data.get('headers')):
             # the second join + split take care of extra internal whitespace
             fullname = " ".join(" ".join([partner.first_name,
                                           partner.middle_name,
@@ -1132,4 +1132,4 @@ def requeue_failures(hours=8):
 def clean_import_records(days=31):
     days_ago = datetime.now() - timedelta(days=days)
     ImportRecord.objects.filter(date__lt=days_ago).delete()
-    
+

--- a/templates/mypartners/partner_library.html
+++ b/templates/mypartners/partner_library.html
@@ -13,12 +13,15 @@
     {% include "mypartners/includes/prm_header.html" with page_title="Partner Library" back_to="Back to Partner Relationship Manager" back_to_url="prm" %}
     <div class="row">
         <div id="ofccp-referral-directory" class="span12">
-            <small>
-                <i>
-                    The partner(s) listed here are from the <a href="https://ofccp.dol-esa.gov/errd/index.html" target="_blank" style="text-decoration: underline">Employment Referral Resource Directory</a>,
-                    the <a href="https://ofccp.dol-esa.gov/errd/Resources.503VEVRAA.html" target="_blank" style="text-decoration: underline">Disability and Veterans Community Resource Directory</a>, and other sources.
-                </i>
-            </small>
+            <div><small><i>
+                {% if sources %}
+                    The partner(s) listed here are from
+                    {% for source in sources %}
+                        the <a href="{{ source.search_url }}" target="_blank" style="text-decoration: underline">{{ source.name }}</a>,
+                    {% endfor %}
+                     and other sources.
+                {% endif %}
+            </i></small></div>
         </div>
     </div>
     <div class="row">

--- a/templates/mypartners/partner_library.html
+++ b/templates/mypartners/partner_library.html
@@ -15,8 +15,8 @@
         <div id="ofccp-referral-directory" class="span12">
             <small>
                 <i>
-                    The partner(s) listed here are from the <a href="http://www.dol-esa.gov/errd/index.html" target="_blank" style="text-decoration: underline">Employment Referral Resource Directory</a>,
-                    the <a href="http://www.dol-esa.gov/errd/Resources.503VEVRAA.html" target="_blank" style="text-decoration: underline">Disability and Veterans Community Resource Directory</a>, and other sources.
+                    The partner(s) listed here are from the <a href="https://ofccp.dol-esa.gov/errd/index.html" target="_blank" style="text-decoration: underline">Employment Referral Resource Directory</a>,
+                    the <a href="https://ofccp.dol-esa.gov/errd/Resources.503VEVRAA.html" target="_blank" style="text-decoration: underline">Disability and Veterans Community Resource Directory</a>, and other sources.
                 </i>
             </small>
         </div>


### PR DESCRIPTION
This ~~just just~~mostly moves partner library sources from the server to the database. Now updates should have a much faster turn around and not require hotfixes. 

*update:* This also exposes the source to the django admin, which has different edit permissions based on your email address (I think roles may be cleaner, but that's outside of scope for this):
- developers (@apps.directemployers.org) can edit anything
- staff (@directemployers.org) can edit the search url and name
- everyone else is read only

I also made the links on the Partner Library depend on these database values rather than being hard-coded in the template.

# Testing
After running migrations for mypartners, `./manage.py update_partner_library` should function as it did before. Additionally, you should see a new "Partner LIbrary Sources" section in the django admin.

Bonus points if you verify that the text at the top of /prm/view/partner-library/ changes properly based on PartnerLibrarySource entries. search_url will change the href, name will change the displayed text, and adding removing sources will change the number of items enumerated.

Even More bonus points if you verify that changing your user's email address to something that doesn't have directemployers.org or apps.directemployers.org changes what you can do in the django admin.