### PR TITLE
Allow the upload of exported csv files [PD-2379]

### DIFF
--- a/automation/forms.py
+++ b/automation/forms.py
@@ -23,7 +23,9 @@ ATS_PARAMETERS = {
 
 
 class SourceCodeFileUpload(forms.Form):
-    source_code_file = forms.FileField(required=True)
+    source_code_file = forms.FileField(
+        required=True,
+        widget=forms.ClearableFileInput(attrs={'accept': '.xls,.xlsx,.csv'}))
     buids = forms.CharField(required=True)
     source_code_parameter = forms.CharField(required=False)
 

--- a/automation/forms.py
+++ b/automation/forms.py
@@ -91,6 +91,8 @@ class SourceCodeFileUpload(forms.Form):
             if isinstance(self.cleaned_data['source_codes'][0], dict):
                 method = add_destination_manipulations
         except IndexError:
+            # There are no entries in this file. Send it anyway - the
+            # method we're sending it to knows what to do.
             pass
         return method(self.cleaned_data['buids'],
                       self.cleaned_data['source_codes'])

--- a/automation/source_codes.py
+++ b/automation/source_codes.py
@@ -1,4 +1,7 @@
+import unicodecsv
 import xlrd
+
+from django.db.models import Q
 
 from redirect.models import DestinationManipulation
 
@@ -19,6 +22,14 @@ def get_book(location):
         book = xlrd.open_workbook(location)
     setattr(book, 'source_code_sheet', book.sheets()[0])
     return book
+
+
+def get_csv(location):
+    if not isinstance(location, (unicode, str)):
+        csv = unicodecsv.reader(location)
+    else:
+        csv = unicodecsv.reader(open(location))
+    return csv
 
 
 def get_values(sheet, source_name, view_source_column=2, source_code_column=1):
@@ -167,6 +178,61 @@ def add_source_codes(buids, codes):
     return stats
 
 
+def add_destination_manipulations(buids, codes):
+    """
+    Adds the provided manipulations to a list of buids.
+
+    Inputs:
+    :buids: List of buids that we're adding these manipulations to
+    :codes: List of dictionaries produced by process_csv
+
+    Outputs:
+    :stats: Dictionary describing the results of this method call; contains the
+        number of added and modified manipulations and the total count
+    """
+    code_dict = {(code['view_source'], code['action_type']): code
+                 for code in codes}
+    if not isinstance(buids, (list, set)):
+        buids = [buids]
+    buids = map(int, buids)
+
+    vs_and_action_type = code_dict.keys()
+
+    existing_options = Q()
+    for item in vs_and_action_type:
+        for buid in buids:
+            existing_options |= Q(buid=buid, view_source=item[0],
+                                  action_type=item[1])
+    all_manipulations = set((buid, item[0], item[1]) for buid in buids
+                            for item in vs_and_action_type)
+    existing = set(DestinationManipulation.objects.filter(
+        existing_options).values_list('buid', 'view_source', 'action_type'))
+
+    new = all_manipulations.difference(existing)
+
+    stats = {
+        'added': len(new),
+        'modified': len(existing),
+        'total': len(all_manipulations)
+    }
+
+    new_list = []
+    for new_info in new:
+        manipulation_info = code_dict[(new_info[1], new_info[2])]
+        manipulation_info['buid'] = new_info[0]
+        new_list.append(DestinationManipulation(**manipulation_info))
+    DestinationManipulation.objects.bulk_create(new_list)
+
+    for existing_info in existing:
+        manipulation_info = code_dict[(existing_info[1], existing_info[2])]
+        manipulation_info['buid'] = existing_info[0]
+        DestinationManipulation.objects.filter(
+            buid=existing_info[0], view_source=existing_info[1],
+            action_type=existing_info[2]).update(**manipulation_info)
+
+    return stats
+
+
 def process_spreadsheet(location, buids, source_name, view_source_column=2,
                         source_code_column=1, add_codes=True):
     """
@@ -192,3 +258,51 @@ def process_spreadsheet(location, buids, source_name, view_source_column=2,
         return add_source_codes(buids, codes)
     else:
         return codes
+
+
+def process_csv(location, buids, add_codes=True):
+    """
+    Grabs a csv file by name or file handle, extracts manipulation
+    values, and optionally adds them to the database.
+
+    Inputs:
+    :location: Location of csv file, as a string or file handle
+    :buids: List of business units
+    :add_codes: Boolean denoting whether we should add these manipulations;
+        Default: True
+
+    Outputs:
+    Summary of operations if add_codes==True
+    Manipulations to be added if add_codes==False
+    """
+    csv = get_csv(location)
+    header = csv.next()
+
+    # The csvs exported from our Django admin include human-readable column
+    # names. We want the actual columns.
+    expected_header = [u'BUID', u'View Source', u'Action Type', u'Action',
+                       u'Value 1', u'Value 2']
+    assert header == expected_header, ('Header mismatch: csv has "%s", '
+                                       'expected "%s"') % (
+        ",".join(set(header).difference(expected_header)),
+        ",".join(set(expected_header).difference(header)))
+    fields = ['buid', 'view_source', 'action_type', 'action',
+              'value_1', 'value_2']
+    codes = [dict(zip(fields, code)) for code in csv]
+    if add_codes:
+        return add_destination_manipulations(buids, codes)
+    else:
+        return codes
+
+
+def process_file(location, buids, source_name, view_source_column=2,
+                 source_code_column=1, add_codes=True):
+    """
+    Naively determines if the file we've been given is a spreadsheet or csv.
+    """
+    try:
+        return process_spreadsheet(location, buids, source_name,
+                                   view_source_column, source_code_column,
+                                   add_codes)
+    except:
+        return process_csv(location, buids, add_codes)

--- a/automation/source_codes.py
+++ b/automation/source_codes.py
@@ -194,13 +194,18 @@ def add_destination_manipulations(buids, codes):
     # This differs from how add_source_codes handles things. I would like to
     # eventually refactor that method to do something similar but that's out
     # of scope for the current task. - TP
-    code_dict = {(code['view_source'], code['action_type']): code
+    code_dict = {(int(code['view_source']), int(code['action_type'])): code
                  for code in codes}
-    if not isinstance(buids, (list, set)):
+
+    # BUIDs are optional; if none are provided, pull them from the csv
+    if not buids:
+        buids = [code['buid'] for code in codes]
+    elif not isinstance(buids, (list, set)):
         buids = [buids]
     buids = map(int, buids)
 
-    vs_and_action_type = code_dict.keys()
+    vs_and_action_type = set((int(vs), int(action_type))
+                             for (vs, action_type) in code_dict.keys())
 
     # Build up the list of possible matching manipulations. This will be used
     # to determine when to update an entry and when to create a new one.

--- a/automation/tests/csv/bad/bad_header.csv
+++ b/automation/tests/csv/bad/bad_header.csv
@@ -1,0 +1,2 @@
+business unit,View Source,Action Type,Action,Value 1,Value 2
+1,1,1,sourcecodetag,?foo=bar,

--- a/automation/tests/csv/bad/no_manipulations.csv
+++ b/automation/tests/csv/bad/no_manipulations.csv
@@ -1,0 +1,1 @@
+BUID,View Source,Action Type,Action,Value 1,Value 2

--- a/automation/tests/csv/good/different_types.csv
+++ b/automation/tests/csv/good/different_types.csv
@@ -1,0 +1,4 @@
+BUID,View Source,Action Type,Action,Value 1,Value 2
+1,1,1,switchlastinstance,/job,/apply
+1,2,1,switchlastthenadd,/job!!!!/apply,?foo=bar
+1,3,1,replacethenadd,old!!!!new,?foo=bar

--- a/automation/tests/csv/good/one_row.csv
+++ b/automation/tests/csv/good/one_row.csv
@@ -1,0 +1,2 @@
+BUID,View Source,Action Type,Action,Value 1,Value 2
+1,1,1,switchlastinstance,/job,/apply

--- a/automation/tests/test_source_codes.py
+++ b/automation/tests/test_source_codes.py
@@ -12,15 +12,16 @@ class SourceCodeUploadTests(MyJobsBase):
         self.user.set_password('secret')
         self.client.login(username=self.user.email,
                           password='secret')
-        self.path = 'automation/tests/spreadsheets/%s/%s.xlsx'
+        self.spreadsheet_path = 'automation/tests/spreadsheets/%s/%s.xlsx'
+        self.csv_path = 'automation/tests/csv/%s/%s.csv'
 
-    def test_good_file_parsing(self):
+    def test_good_spreadsheet_parsing(self):
         files = [
             ('one_row', 1), ('one_row_two_vs', 2), ('one_row_multiple_vs', 3)
         ]
         self.assertEqual(DestinationManipulation.objects.count(), 0)
         for file_name, num_added in files:
-            with open(self.path % ('good', file_name)) as fp:
+            with open(self.spreadsheet_path % ('good', file_name)) as fp:
                 self.client.post(reverse('source_code_upload'),
                                  {'source_code_file': fp,
                                   'buids': [1],
@@ -44,9 +45,57 @@ class SourceCodeUploadTests(MyJobsBase):
                                  {'?src=DE-SC'})
                 DestinationManipulation.objects.all().delete()
 
-    def test_bad_file_parsing(self):
+    def test_good_csv_parsing(self):
+        files = [
+            ('one_row', 1), ('different_types', 3)
+        ]
+
         self.assertEqual(DestinationManipulation.objects.count(), 0)
-        with open(self.path % ('bad', 'invalid_rows')) as fp:
+        for file_name, num_added in files:
+            with open(self.csv_path % ('good', file_name)) as fp:
+                self.client.post(reverse('source_code_upload'),
+                                 {'source_code_file': fp,
+                                  'buids': [1],
+                                  'source_code_parameter': 'src'})
+                self.assertEqual(DestinationManipulation.objects.count(),
+                                 num_added)
+                values = DestinationManipulation.objects.values_list(
+                    'view_source', 'action')
+                self.assertTrue(set([value[0] for value in values]).issubset(
+                    {1, 2, 3}))
+
+                actions = [value[1] for value in values]
+                # We've constructed this csv so that no two actions are the
+                # same - the number of distinct actions should equal the number
+                # of manipulations that we added.
+                self.assertEqual(len(set(actions)), values.count())
+
+                DestinationManipulation.objects.all().delete()
+
+    def test_bad_spreadsheet_parsing(self):
+        self.assertEqual(DestinationManipulation.objects.count(), 0)
+        with open(self.spreadsheet_path % ('bad', 'invalid_rows')) as fp:
+            self.client.post(reverse('source_code_upload'),
+                             {'source_code_file': fp,
+                              'buids': [1],
+                              'source_code_parameter': 'src'})
+
+        self.assertEqual(DestinationManipulation.objects.count(), 0)
+
+    def test_bad_csv_header_parsing(self):
+        self.assertEqual(DestinationManipulation.objects.count(), 0)
+        with self.assertRaises(AssertionError):
+            with open(self.csv_path % ('bad', 'bad_header')) as fp:
+                self.client.post(reverse('source_code_upload'),
+                                 {'source_code_file': fp,
+                                  'buids': [1],
+                                  'source_code_parameter': 'src'})
+
+        self.assertEqual(DestinationManipulation.objects.count(), 0)
+
+    def test_csv_lacking_manipulations(self):
+        self.assertEqual(DestinationManipulation.objects.count(), 0)
+        with open(self.csv_path % ('bad', 'no_manipulations')) as fp:
             self.client.post(reverse('source_code_upload'),
                              {'source_code_file': fp,
                               'buids': [1],
@@ -63,7 +112,7 @@ class SourceCodeUploadTests(MyJobsBase):
         self.assertTrue('Log in' in response.content)
 
     def test_integer_source_codes(self):
-        with open(self.path % ('good', 'digits')) as fp:
+        with open(self.spreadsheet_path % ('good', 'digits')) as fp:
             self.client.post(reverse('source_code_upload'),
                              {'source_code_file': fp,
                               'buids': [1],

--- a/automation/views.py
+++ b/automation/views.py
@@ -13,7 +13,6 @@ def source_code_upload(request):
         form = SourceCodeFileUpload(post, request.FILES)
         if form.is_valid():
             context['stats'] = form.save()
-        print form._errors
     else:
         form = SourceCodeFileUpload()
     context['form'] = form

--- a/automation/views.py
+++ b/automation/views.py
@@ -13,6 +13,7 @@ def source_code_upload(request):
         form = SourceCodeFileUpload(post, request.FILES)
         if form.is_valid():
             context['stats'] = form.save()
+        print form._errors
     else:
         form = SourceCodeFileUpload()
     context['form'] = form


### PR DESCRIPTION
Testing:

- Head to the DestinationManipulation admin
- Search for something
- Select some rows If you select duplicate (view_source, action_type) pairs, undefined things will happen on reimport.
- In the dropdown, select "Save selected as CSV" and hit "Go"
- Modify if you wish.
- Head to /ajax/source-codes locally and fill out everything.
    - "Buids" is comma-separated. These do not have to match the buids in the spreadsheet - if they don't match, the values in the spreadsheet will be copied to the provided buids. If not provided, we update rows based on the buids from the csv.
- Submit and verify that stuff happened in the DestinationManipulation admin