### PR TITLE
[PD-2442] passed default as a third argument instead of using an or expression.

### DIFF
--- a/registration/templatetags/password_reset_tags.py
+++ b/registration/templatetags/password_reset_tags.py
@@ -21,8 +21,8 @@ def get_current_seosite(attr=None, str_func=None):
     # return the capitalized domain for a site
     >>> {% get_current_seosite 'domain' 'capitalize' %}
     'My.jobs'
-    """
 
+    """
     seosite = getattr(settings, 'SITE', SeoSite.objects.get(
         domain="secure.my.jobs"))
 

--- a/registration/templatetags/password_reset_tags.py
+++ b/registration/templatetags/password_reset_tags.py
@@ -23,8 +23,8 @@ def get_current_seosite(attr=None, str_func=None):
     'My.jobs'
     """
 
-    seosite = getattr(settings, 'SITE') or SeoSite.objects.get(
-        domain="secure.my.jobs")
+    seosite = getattr(settings, 'SITE', SeoSite.objects.get(
+        domain="secure.my.jobs"))
 
     if attr:
         # the attribute may not always be a string, so we convert it to one


### PR DESCRIPTION
# Description

The template we use for the password reset email uses this template tag, which in turn tries to access settings.SITE, which is only set by multihost middleware. Thus, if you're attempting to run ActivationProfile.send_activation_email() outside of a view, settings.SITE will never be defined. As we seem to be attempting to fallback on "secure.my.jobs", I took advantage of getattr's third argument, which effectivley does what the or expression was originally doing. Difference is that without the third argument, if an attribute can't be found, getattr raises an exception.

# Testing
```
$ ./manage.py shell
> from myjobs.models import *
> from registration.models import *
u = User.objects.get(email='youremailhere')
ap = ActivationProfile(user=u)
ap.send_activation_email()
```

You might get an SMPT exception locally since this is attempting to send an email, but you should NOT get an exception related to settings.SITE, which you will if you attempt similar on production, quality-control, or staging.