### PR TITLE
[PD-2442] Send Activation from console

### DIFF
--- a/registration/templatetags/password_reset_tags.py
+++ b/registration/templatetags/password_reset_tags.py
@@ -21,9 +21,9 @@ def get_current_seosite(attr=None, str_func=None):
     # return the capitalized domain for a site
     >>> {% get_current_seosite 'domain' 'capitalize' %}
     'My.jobs'
-    """
 
-    seosite = getattr(settings, 'Site', SeoSite.objects.filter(
+    """
+    seosite = getattr(settings, 'SITE', SeoSite.objects.filter(
         domain='secure.my.jobs').first() or 'secure.my.jobs')
 
     if attr:

--- a/registration/templatetags/password_reset_tags.py
+++ b/registration/templatetags/password_reset_tags.py
@@ -23,12 +23,12 @@ def get_current_seosite(attr=None, str_func=None):
     'My.jobs'
     """
 
-    seosite = getattr(settings, 'SITE') or SeoSite.objects.get(
-        domain="secure.my.jobs")
+    seosite = getattr(settings, 'Site', SeoSite.objects.filter(
+        domain='secure.my.jobs').first() or 'secure.my.jobs')
 
     if attr:
         # the attribute may not always be a string, so we convert it to one
-        obj = unicode(getattr(seosite, attr))
+        obj = unicode(getattr(seosite, attr, seosite))
         if str_func:
             return getattr(obj, str_func)()
 

--- a/registration/tests/test_models.py
+++ b/registration/tests/test_models.py
@@ -155,6 +155,22 @@ class RegistrationModelTests(MyJobsBase):
         profile = ActivationProfile.objects.get(user=new_user)
         self.failIf(ActivationProfile.objects.activate_user(profile.activation_key))
 
+    def test_manually_send_activation(self):
+        """
+        Atttempting to send an activation email outside of a view shouldn't
+        result in an exception.
+
+        """
+        # when running in console, settings.SITE isn't set
+        del settings.SITE
+
+        user = UserFactory(email='activation@test.com')
+        activation = ActivationProfile(user=user)
+        activation.send_activation_email()
+
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertIn('activated', mail.outbox[0].body)
+
     def test_activation_nonexistent_key(self):
         """
         Attempting to activate with a non-existent key (i.e., one not


### PR DESCRIPTION
This is #2362, but done right. Still feel slightly icky about it, but it doesn't seem to break a gang of tests like my last PR did. 

Basically:
- `getattr`, when not passed a third argument, will raise an exception when the attribute in question doesn't exist. The third argument will be returned as a default.
- If secure.my.jobs doesn't exist as an SeoSite (eg, while testing), then an exception is thrown
- as I'm using a string for a default value in that case (rather than making a database call on the fly), `getattr` would fail on line 31, so I made it return the seosite (a string by this point) as the default arugment

Example invocations:

The call `get_current_seosite(attr='domain', str_func='title')`:
- on www.myjobs would return the equivalent of SeoSite.objects.get(domain='www.my.jobs').domain.title().
- on the command line would return the equivalent of `SeoSite.objects.get(domain='secure.my.jobs').domain.title()`
- on the command line in a dev environment without a microsite for secure.my.jobs* would return the equivalent of `"secure.my.jobs".title()`
