### PR TITLE
PD-2445 Minor style change to fix UL padding in menus and text.

### DIFF
--- a/static/custom.css
+++ b/static/custom.css
@@ -100,6 +100,10 @@ textarea{
 }
 
 /*Lists*/
+ul {
+    margin: 0 0 0 20px;
+}
+
 li {
     color: #000;
 }
@@ -3495,10 +3499,6 @@ fieldset:nth-child(n+2) {
     display: inline-block;
 }
 
-.row .col-md-8 ul {
-    margin: 0;
-}
-
 .row .col-md-8 ul li label {
     font-weight: normal;
 }
@@ -3737,10 +3737,6 @@ legend.fieldset-border {
 /* Export Page Styles */
 #export-page #record-count {
   text-align: center;
-}
-
-#export-page ul {
-    margin: 0 0 0 20px;
 }
 
 #export-page ul li {


### PR DESCRIPTION
Whoever merges this gets their choice of Chicken Tortilla or Steak Burger variety soup from Progresso.  Progresso® - Because it's Still Edible.

# Notes
Per [this ticket](https://directemployersfoundation.atlassian.net/browse/PD-2445), there was a weird margin on the left side of Select menus.  I've fixed that without causing weird list action elsewhere.