### PR TITLE
[PD-2448] Allow user deletion

### DIFF
--- a/myjobs/models.py
+++ b/myjobs/models.py
@@ -381,6 +381,17 @@ class User(AbstractBaseUser, PermissionsMixin):
         super(User, self).save(force_insert, force_update, using,
                                update_fields)
 
+    def delete(self, *args, **kwargs):
+        # importing the models directly would probably cause a circular import
+        Contact = self.contact_set.model
+        ContactRecord = self.contactrecord_set.model
+        # clear archived relationships
+        Contact.all_objects.filter(user=self).update(user=None)
+        ContactRecord.all_objects.filter(user=self).update(user=None)
+
+        return super(Contact, self).delete(*args, **kwargs)
+
+
     def get_activities(self, company):
         """Returns a list of activity names associated with this user."""
 

--- a/myjobs/models.py
+++ b/myjobs/models.py
@@ -387,9 +387,10 @@ class User(AbstractBaseUser, PermissionsMixin):
         ContactRecord = self.contactrecord_set.model
         # clear archived relationships
         Contact.all_objects.filter(user=self).update(user=None)
-        ContactRecord.all_objects.filter(user=self).update(user=None)
+        ContactRecord.all_objects.filter(
+            created_by=self).update(created_by=None)
 
-        return super(Contact, self).delete(*args, **kwargs)
+        return super(User, self).delete(*args, **kwargs)
 
 
     def get_activities(self, company):

--- a/myjobs/tests/test_views.py
+++ b/myjobs/tests/test_views.py
@@ -18,6 +18,7 @@ from myjobs.models import (User, EmailLog, FAQ, CompanyAccessRequest,
                            SecondPartyAccessRequest)
 from myjobs.tests.factories import (UserFactory, RoleFactory, ActivityFactory,
                                     AppAccessFactory)
+from mypartners.tests.factories import ContactFactory
 from myjobs.tests.setup import MyJobsBase, TestClient
 from mymessages.models import Message
 from mymessages.tests.factories import MessageInfoFactory
@@ -249,6 +250,17 @@ class MyJobsViewsTests(MyJobsBase):
         Going to the delete_account view removes a user and their data
         completely
         """
+        self.assertEqual(User.objects.count(), 2)
+        self.client.get(reverse('delete_account'), follow=True)
+        self.assertEqual(User.objects.count(), 1)
+
+    def test_delete_with_archived_contacts(self):
+        """
+        Deleted a user when an archived contact still refers to the should be
+        possible.
+        """
+        contact = ContactFactory(user=self.user)
+        contact.archive()
         self.assertEqual(User.objects.count(), 2)
         self.client.get(reverse('delete_account'), follow=True)
         self.assertEqual(User.objects.count(), 1)

--- a/myjobs/views.py
+++ b/myjobs/views.py
@@ -36,6 +36,7 @@ from myjobs.models import (Ticket, User, FAQ, CustomHomepage, Role, Activity,
 from myprofile.forms import (InitialNameForm, InitialEducationForm,
                              InitialAddressForm, InitialPhoneForm,
                              InitialWorkForm)
+from mypartners.models import Contact, ContactRecord
 from myprofile.models import ProfileUnits, Name
 from registration.forms import RegistrationForm, CustomAuthForm
 from registration.models import Invitation
@@ -374,6 +375,11 @@ def edit_account(request):
 @user_passes_test(User.objects.not_disabled)
 def delete_account(request):
     email = request.user.email
+
+    # clear archived relationships
+    Contact.all_objects.filter(user=request.user).update(user=None)
+    ContactRecord.all_objects.filter(user=request.user).update(user=None)
+
     request.user.delete()
 
     template = '%s/delete-account-confirmation.html' % settings.PROJECT

--- a/myjobs/views.py
+++ b/myjobs/views.py
@@ -36,7 +36,6 @@ from myjobs.models import (Ticket, User, FAQ, CustomHomepage, Role, Activity,
 from myprofile.forms import (InitialNameForm, InitialEducationForm,
                              InitialAddressForm, InitialPhoneForm,
                              InitialWorkForm)
-from mypartners.models import Contact, ContactRecord
 from myprofile.models import ProfileUnits, Name
 from registration.forms import RegistrationForm, CustomAuthForm
 from registration.models import Invitation
@@ -375,11 +374,6 @@ def edit_account(request):
 @user_passes_test(User.objects.not_disabled)
 def delete_account(request):
     email = request.user.email
-
-    # clear archived relationships
-    Contact.all_objects.filter(user=request.user).update(user=None)
-    ContactRecord.all_objects.filter(user=request.user).update(user=None)
-
     request.user.delete()
 
     template = '%s/delete-account-confirmation.html' % settings.PROJECT


### PR DESCRIPTION
If you create a contact related to a user and then "delete" that contact, you can then not delete the user. The reason is that we actually archive the contact instead of deleting it, so when User.delete is searching for related fields, it ignores archived contacts, and thus doesn't work since there are still contacts technically referring to it. This ticket sets those relationships to null manually so that delete will work as expected.