### PR TITLE
Stop grabbing the entire redirect count [PD-2444]

### DIFF
--- a/automation/forms.py
+++ b/automation/forms.py
@@ -56,8 +56,10 @@ class SourceCodeFileUpload(forms.Form):
             # Checks for jobs belonging to the buids provided and
             # auto-determines an acceptable parameter based on the job. If
             # this fails, a parameter must be provided in the form
-            test_job = Redirect.objects.filter(
-                buid__in=buids, expired_date__isnull=True).first()
+            jobs = Redirect.objects.filter(
+                buid__in=buids, expired_date__isnull=True)
+            jobs.query.clear_ordering(True)
+            test_job = jobs.first()
             if test_job:
                 for url_part, key in ATS_PARAMETERS.items():
                     if url_part in test_job.url:

--- a/automation/forms.py
+++ b/automation/forms.py
@@ -56,10 +56,9 @@ class SourceCodeFileUpload(forms.Form):
             # Checks for jobs belonging to the buids provided and
             # auto-determines an acceptable parameter based on the job. If
             # this fails, a parameter must be provided in the form
-            test_job = Redirect.objects.filter(buid__in=buids,
-                                               expired_date__isnull=True)
-            if test_job.count():
-                test_job = test_job[0]
+            test_job = Redirect.objects.filter(
+                buid__in=buids, expired_date__isnull=True).first()
+            if test_job:
                 for url_part, key in ATS_PARAMETERS.items():
                     if url_part in test_job.url:
                         source_code_parameter = key


### PR DESCRIPTION
This generates the following SQL if I search for buids 1 and 2

```
SELECT `redirect_redirect`.`guid`, `redirect_redirect`.`buid`, `redirect_redirect`.`uid`, `redirect_redirect`.`url`, `redirect_redirect`.`new_date`, `redirect_redirect`.`expired_date`, `redirect_redirect`.`job_location`, `redirect_redirect`.`job_title`, `redirect_redirect`.`company_name` 
FROM `redirect_redirect`
WHERE `redirect_redirect`.`buid` IN (1, 2)
ORDER BY `redirect_redirect`.`guid` ASC LIMIT 1
```