### PR TITLE
Fix counts of referral and communication records in reporting  pd 2388

### DIFF
--- a/mypartners/models.py
+++ b/mypartners/models.py
@@ -589,20 +589,20 @@ class ContactRecordQuerySet(SearchParameterQuerySet):
         """
 
         all_contacts = self.values(
-            'partner__name', 'partner', 'contact__name',
+            'partner__name', 'partner', 'contact__name', 'contact__id',
             'contact_email').distinct().order_by('partner__name')
 
         records = dict(self.exclude(contact_type='job').values_list(
-            'contact__name').annotate(
-                records=models.Count('contact__name')).distinct())
+            'contact__id').annotate(
+                records=models.Count('contact__id')).distinct())
 
         referrals = dict(self.filter(contact_type='job').values_list(
-            'contact__name').annotate(
-                referrals=models.Count('contact__name')).distinct())
+            'contact__id').annotate(
+                referrals=models.Count('contact__id')).distinct())
 
         for contact in all_contacts:
-            contact['referrals'] = referrals.get(contact['contact__name'], 0)
-            contact['records'] = records.get(contact['contact__name'], 0)
+            contact['referrals'] = referrals.get(contact['contact__id'], 0)
+            contact['records'] = records.get(contact['contact__id'], 0)
 
         return sorted(all_contacts, key=lambda c: c['records'], reverse=True)
 

--- a/mypartners/models.py
+++ b/mypartners/models.py
@@ -581,7 +581,6 @@ class ContactRecordQuerySet(SearchParameterQuerySet):
     @staticmethod
     def _dict_from_values(values, key_fields, value_field):
         """
-        Sorts a single value from values into a dictionary keyed by key_fields.
         Used to match distinct items between querysets based on multiple field 
         values.
 
@@ -595,7 +594,7 @@ class ContactRecordQuerySet(SearchParameterQuerySet):
         """
         dictionary = {}
         for item in values:
-            key = ''.join([str(item[field]) for field in key_fields])
+            key = '-'.join([str(item[field]) for field in key_fields])
             dictionary[key] = item[value_field]
         return dictionary
 
@@ -628,7 +627,7 @@ class ContactRecordQuerySet(SearchParameterQuerySet):
         referrals = self._dict_from_values(referral_qs, distinct_fields,
                                            'referral_count')
         for contact in all_contacts:
-            key = ''.join([str(contact[field]) for field in distinct_fields])
+            key = '-'.join([str(contact[field]) for field in distinct_fields])
             contact['referrals'] = referrals.get(key, 0)
             contact['records'] = records.get(key, 0)
         return sorted(all_contacts, key=lambda c: c['records'], reverse=True)

--- a/mypartners/models.py
+++ b/mypartners/models.py
@@ -587,12 +587,11 @@ class ContactRecordQuerySet(SearchParameterQuerySet):
 
         Inputs:
             :values: An iterable of dictionaries such as queryset.values()
-                     [{field_name: value}]
+                     [{field1: value}, {field2: value}]
             :key_fields: An ordered iterable of field names whose values will be
                          used to form a unique key
             :value_field: The field from values stored in the returned 
                           dictionary
-
         """
         dictionary = {}
         for item in values:
@@ -613,7 +612,7 @@ class ContactRecordQuerySet(SearchParameterQuerySet):
         all_contacts = self.values('partner__name', 'partner',  'contact__name',
                 'contact', 'contact_email').distinct().order_by('partner__name')
 
-        # Fields required to identify distinct instances. Names are redundant.
+        # Fields to identify distinct instances for grouping. Names are redundant.
         distinct_fields = ('partner', 'contact', 'contact_email')
         record_qs = (self.exclude(contact_type='job').values(
                          *distinct_fields).annotate(

--- a/mypartners/models.py
+++ b/mypartners/models.py
@@ -582,7 +582,7 @@ class ContactRecordQuerySet(SearchParameterQuerySet):
     def _dict_from_values(values, key_fields, value_field):
         """
         Sorts a single value from values into a dictionary keyed by key_fields.
-        Used to match distinct items between querysets based multiple field 
+        Used to match distinct items between querysets based on multiple field 
         values.
 
         Inputs:

--- a/mypartners/tests/test_models.py
+++ b/mypartners/tests/test_models.py
@@ -273,18 +273,23 @@ class MyPartnerTests(MyJobsBase):
         contacts[1].email = 'other@email.com'
         contacts[2].partner = PartnerFactory(name='Other Partner')
         for contact in contacts:
-            ContactRecordFactory.create(contact_type="job", 
+            ContactRecordFactory.create(contact_type="job",
                                         contact=contact,
                                         partner=contact.partner)
             ContactRecordFactory.create(contact_type = 'email',
                                         contact=contact,
                                         partner=contact.partner)
 
+        contacts[0].email = 'changed@email.com'
+        ContactRecordFactory.create(contact_type = 'email',
+                                    contact=contacts[0],
+                                    partner=contact.partner)
+
+
         queryset = ContactRecord.objects.all()
-        self.assertEqual(queryset.count(), 8)
+        self.assertEqual(queryset.count(), 9)
 
         contacts = list(queryset.contacts)
-        import ipdb; ipdb.set_trace();
         sum_referrals = sum([contact['referrals'] for contact in contacts])
         sum_records = sum([contact['records'] for contact in contacts])
         self.assertEqual(sum_referrals, queryset.referrals)

--- a/mypartners/tests/test_models.py
+++ b/mypartners/tests/test_models.py
@@ -274,15 +274,17 @@ class MyPartnerTests(MyJobsBase):
         contacts[2].partner = PartnerFactory(name='Other Partner')
         for contact in contacts:
             ContactRecordFactory.create(contact_type="job", 
-                                        contact=contact)
+                                        contact=contact,
+                                        partner=contact.partner)
             ContactRecordFactory.create(contact_type = 'email',
-                                        contact=contact)
+                                        contact=contact,
+                                        partner=contact.partner)
 
         queryset = ContactRecord.objects.all()
         self.assertEqual(queryset.count(), 8)
 
         contacts = list(queryset.contacts)
-
+        import ipdb; ipdb.set_trace();
         sum_referrals = sum([contact['referrals'] for contact in contacts])
         sum_records = sum([contact['records'] for contact in contacts])
         self.assertEqual(sum_referrals, queryset.referrals)

--- a/myreports/tests/test_views.py
+++ b/myreports/tests/test_views.py
@@ -179,7 +179,6 @@ class TestReportView(MyReportsTestCase):
             job_applications="0", job_interviews="0", job_hires="1",
             partner=self.partner)
 
-
     def test_create_report(self):
         """Test that a report model instance is properly created."""
 

--- a/myreports/tests/test_views.py
+++ b/myreports/tests/test_views.py
@@ -179,6 +179,7 @@ class TestReportView(MyReportsTestCase):
             job_applications="0", job_interviews="0", job_hires="1",
             partner=self.partner)
 
+
     def test_create_report(self):
         """Test that a report model instance is properly created."""
 
@@ -206,9 +207,11 @@ class TestReportView(MyReportsTestCase):
         for key in ['applications', 'hires', 'communications', 'emails']:
             self.assertEqual(data[key], 5)
 
-        # check contact stats
-        self.assertEqual(data['contacts'][0]['records'], 5)
-        self.assertEqual(data['contacts'][0]['referrals'], 10)
+        for contact in data['contacts']:
+            self.assertTrue(contact['records'] < 2)
+            self.assertTrue(contact['referrals'] < 2)
+            total = contact['records'] + contact['referrals']
+            self.assertEqual(total, 1)
 
     def test_reports_exclude_archived(self):
         """


### PR DESCRIPTION
We were assuming that contact name was enough to uniquely identify a row in contact reports, which led to double-counting when we were showing counts for each individual contact. This uses a combination of Partner, Contact, and contact email to uniquely identify rows and get the correct counts.