### PR TITLE
[PD-2465] Added styling and removed g+ icon.

### DIFF
--- a/templates/def.ui.microsite.mobile.css
+++ b/templates/def.ui.microsite.mobile.css
@@ -281,7 +281,7 @@ a.direct_mobileJumpLink{
 	    margin: 10px;
 	}
 	#addThis{
-		width: 226px;
+		width: 180px;
 		padding: 0;
 		margin: 10px auto 0 auto;
 		text-align: center;

--- a/templates/includes/add_this.html
+++ b/templates/includes/add_this.html
@@ -3,7 +3,6 @@
     <a class="addthis_button_facebook"></a>
     <a class="addthis_button_twitter"></a>
     <a class="addthis_button_linkedin"></a>    
-    <a class="addthis_button_google_plusone" g:plusone:href="{{request.build_absolute_uri}}" g:plusone:count="false" g:plusone:expandTo="left"></a>
     <a class="addthis_button_email"></a>    
     <a class="addthis_button_compact"></a>    
 </div>

--- a/templates/myblocks/blocks/share.html
+++ b/templates/myblocks/blocks/share.html
@@ -5,7 +5,6 @@
         <a class="addthis_button_facebook"></a>
         <a class="addthis_button_twitter"></a>
         <a class="addthis_button_linkedin"></a>
-        <a class="addthis_button_google_plusone" g:plusone:href="{{ request.build_absolute_uri }}" g:plusone:count="false" g:plusone:expandTo="left"></a>
         <a class="addthis_button_email"></a>
         <a class="addthis_button_compact"></a>
     </div>

--- a/templates/stylesheet.css
+++ b/templates/stylesheet.css
@@ -574,7 +574,7 @@ img.pls-dropTR {
 
 #addThis {
 	float: left;
-	padding: 12px 0 0 42px;
+	padding: 12px 0 0 60px;
 	text-align: center;
 }
 #addThis a:hover { background: none; }


### PR DESCRIPTION
Had no way to test this as addThis doesn't seem to run locally. Manually inspecting the page, removing hte anchor tag, and applying the styles inline seems to work though (styles verified by @fezick ).

The myblocks base template doesn't seem to load either of the stylesheets, so I'm not convinced the share widget has ever worked. IF it comes up broken later, we at least have this as a reference.