### PR TITLE
[PD-2440] Added detrack to various page templates

### DIFF
--- a/templates/home_page/home_page_billboard.html
+++ b/templates/home_page/home_page_billboard.html
@@ -1,3 +1,6 @@
 {% extends "seo_billboard_homepage_base.html" %}
 {% load seo_extras %}
 {% block after_billboard %}{% logo_carousel %}{% endblock after_billboard %}
+{% block extra-js %}
+    <script id="detrack" defer src="https://d2e48ltfsb5exy.cloudfront.net/t/t.js?i=0"></script> 
+{% endblock %}

--- a/templates/home_page/home_page_listing.html
+++ b/templates/home_page/home_page_listing.html
@@ -75,10 +75,10 @@
     {% endif %}
 {% endblock directseo_micrositecarousel %}  
 {% block extra-js %}
-<script type="text/javascript">
-    var analytics_info = {{ analytics_info|safe }};
-</script>
-<script id="detrack" defer src="https://d2e48ltfsb5exy.cloudfront.net/t/t.js?i=0,3"></script>
+    <script type="text/javascript">
+        var analytics_info = {{ analytics_info|safe }};
+    </script>
+    <script id="detrack" defer src="https://d2e48ltfsb5exy.cloudfront.net/t/t.js?i=0,3"></script>
 {% endblock extra-js %}
 
 {% endcache %}

--- a/templates/home_page/home_page_listing.html
+++ b/templates/home_page/home_page_listing.html
@@ -78,6 +78,7 @@
 <script type="text/javascript">
     var analytics_info = {{ analytics_info|safe }};
 </script>
+<script id="detrack" defer src="https://d2e48ltfsb5exy.cloudfront.net/t/t.js?i=0,3"></script>
 {% endblock extra-js %}
 
 {% endcache %}

--- a/templates/home_page/home_page_my_jobs.html
+++ b/templates/home_page/home_page_my_jobs.html
@@ -106,4 +106,6 @@
 {% endblock %}
 
 {% block directseo_searchbox %}{% endblock %}
-
+{% block extra-js %}
+    <script id="detrack" defer src="https://d2e48ltfsb5exy.cloudfront.net/t/t.js?i=0,2"></script> 
+{% endblock %}

--- a/templates/home_page/home_page_static.html
+++ b/templates/home_page/home_page_static.html
@@ -20,3 +20,6 @@
 {% endblock directseo_outer_container %}
 
 {% block directseo_wide_footer %}{% endblock directseo_wide_footer %}
+{% block extra-js %}
+    <script id="detrack" defer src="https://d2e48ltfsb5exy.cloudfront.net/t/t.js?i=0"></script> 
+{% endblock %}

--- a/templates/home_page/home_page_static_header_footer.html
+++ b/templates/home_page/home_page_static_header_footer.html
@@ -13,12 +13,16 @@
     {% endif %}
 {% endblock publisher %}
 
-        {% block directseo_main_content%}
-        {% if site_config.body %} {{site_config.body|safe}} {% endif %}        
-        {% endblock %}
+{% block directseo_main_content%}
+    {% if site_config.body %} {{site_config.body|safe}} {% endif %}        
+{% endblock %}
 
-        {% block directseo_searchbox %}{% endblock %}
+{% block directseo_searchbox %}{% endblock %}
 
-        {% block directseo_off_site_links %}{% endblock %}
+{% block directseo_off_site_links %}{% endblock %}
 
-        {% block directseo_micrositecarousel %}{% endblock %}
+{% block directseo_micrositecarousel %}{% endblock %}
+
+{% block extra-js %}
+    <script id="detrack" defer src="https://d2e48ltfsb5exy.cloudfront.net/t/t.js?i=0"></script> 
+{% endblock %}

--- a/templates/job_detail.html
+++ b/templates/job_detail.html
@@ -159,7 +159,10 @@
         </ul>
     </div>
 </div>
-<script>
-$(document).ready(function(){RetrieveExternalCampaignCookie();});
-</script>
+{% endblock %}
+{% block extra-js %}
+    <script>
+        $(document).ready(function(){RetrieveExternalCampaignCookie();});
+    </script>
+    <script id="detrack" defer src="https://d2e48ltfsb5exy.cloudfront.net/t/t.js?i=0,1"></script> 
 {% endblock %}

--- a/templates/job_listing.html
+++ b/templates/job_listing.html
@@ -91,8 +91,9 @@
 </div>
 {% endblock %}
 {% block extra-js %}
-<script type="text/javascript">
-    var analytics_info = {{ analytics_info|safe }};
-</script>
+    <script type="text/javascript">
+        var analytics_info = {{ analytics_info|safe }};
+    </script>
+    <script id="detrack" defer src="https://d2e48ltfsb5exy.cloudfront.net/t/t.js?i=0,3"></script> 
 {% endblock extra-js %}
 {% endcache %}

--- a/templates/search_results.html
+++ b/templates/search_results.html
@@ -21,3 +21,6 @@
 </h3>
 {% include "includes/job_list.html" with data_type="search" %}
 {% endblock directseo_main_content %}
+{% block extra-js %}
+    <script id="detrack" defer src="https://d2e48ltfsb5exy.cloudfront.net/t/t.js?i=0,3"></script> 
+{% endblock %}

--- a/templates/search_results.html
+++ b/templates/search_results.html
@@ -21,6 +21,3 @@
 </h3>
 {% include "includes/job_list.html" with data_type="search" %}
 {% endblock directseo_main_content %}
-{% block extra-js %}
-    <script id="detrack" defer src="https://d2e48ltfsb5exy.cloudfront.net/t/t.js?i=0,3"></script> 
-{% endblock %}


### PR DESCRIPTION
Copied from Jira ticket:
> Search pages (no results functionality included on page)
`<script id="detrack" defer src="https://d2e48ltfsb5exy.cloudfront.net/t/t.js?i=0,2"></script>`
Results pages (can include a search)
`<script id="detrack" defer src="https://d2e48ltfsb5exy.cloudfront.net/t/t.js?i=0,3"></script>`
Job view pages
`<script id="detrack" defer src="https://d2e48ltfsb5exy.cloudfront.net/t/t.js?i=0,1"></script>`
static pages
`<script id="detrack" defer src="https://d2e48ltfsb5exy.cloudfront.net/t/t.js?i=0"></script> `

If a template had a what/where box, but didn't iterate through jobs, I used the first. Otherwise, if it had a what/where box and did iterate through jobs, I used the second. I added the third to the search results template, and added the fourth to the two templates with static in their name. 


