### PR TITLE
[PD-2470] Fixed expiry check.

### DIFF
--- a/myjobs/forms.py
+++ b/myjobs/forms.py
@@ -273,7 +273,7 @@ class CompanyAccessRequestApprovalForm(ModelForm):
 
         if request.expired:
             raise ValidationError(
-                "This request expired on %s" % request.expired_on)
+                "This request expired on %s" % request.expires_on)
 
         if not request.check_access_code(code):
             raise ValidationError(


### PR DESCRIPTION
Fixed a typo in the access request approval form. Will be difficult to test locally without manually expiring a request. I do have a regression test that does just that, though.