### PR TITLE
[PD-1683] Add "nofollow" flag when more than one filter applied

### DIFF
--- a/templates/seo_base.html
+++ b/templates/seo_base.html
@@ -73,7 +73,7 @@
         {% endif %}
     {% endblock seo_description %}
 
-    {% if num_filters > max_filter_settings %}
+    {% if num_filters >= max_filter_settings %}
         <meta name="robots" content="nofollow">
     {% endif %}
 


### PR DESCRIPTION
## Overview

When more than one filter is selected during a search, a "nofollow" meta tag is added to prevent Google crawlers from bombarding the website.

This logic was the same before, but would be applied after three filters were selected rather than after two.

Behold my grand PR.