### PR TITLE
[PD-2485] Stopped using grid as it's adding container which we don't want.

### DIFF
--- a/gulp/src/nonuseroutreach/components/NonUserOutreachApp.jsx
+++ b/gulp/src/nonuseroutreach/components/NonUserOutreachApp.jsx
@@ -1,5 +1,5 @@
 import React, {Component, PropTypes} from 'react';
-import {Col, Grid, Row} from 'react-bootstrap';
+import {Col, Row} from 'react-bootstrap';
 import {connect} from 'react-redux';
 import {Loading} from 'common/ui/Loading';
 import {Menu} from './Menu';
@@ -14,7 +14,7 @@ class NonUserOutreachApp extends Component {
   render() {
     const {loading, tips} = this.props;
     return (
-      <Grid>
+      <div>
         <Row>
           <Col sm={12}>
             <div className="breadcrumbs">
@@ -33,7 +33,7 @@ class NonUserOutreachApp extends Component {
             <Menu tips={tips} />
           </Col>
         </Row>
-      </Grid>
+      </div>
     );
   }
 }


### PR DESCRIPTION
Apparently `<Grid />` means `<div class="container"`, which is of course a very bad idea in the middle of a layout that's already started. I didn't simply remove it since there can only be one root node in a react component (eg. two rows side by side is a no go, but two rows wrapped in a div is fine).