### PR TITLE
[PD-1683] Make "nofollow" count facet slugs properly

### DIFF
--- a/myblocks/models.py
+++ b/myblocks/models.py
@@ -822,13 +822,20 @@ class Page(models.Model):
     def get_template(self, request):
         filters = context_tools.get_filters(request)
 
+        facet_slugs = []
+        if filters.get('facet_slugs', None):
+            facet_slugs = filters['facet_slug'].split('/')
+
         context = self.context(request)
         context.update({
             'body': mark_safe(self.get_body()),
             'google_analytics': context_tools.get_google_analytics(request),
             'head': mark_safe(self.get_head()),
             'max_filter_settings': settings.ROBOT_FILTER_LEVEL,
-            'num_filters': len([k for (k, v) in filters.iteritems() if v]),
+            # see how many active filters there are and then add total number of
+            # facet slugs as there may be multiple filters in the facet slug entry
+            'num_filters': len([k for (k, v) in filters.iteritems()
+                                if v and k != 'facet_slug']) + len(facet_slugs),
             'page': self,
             'STATIC_URL': settings.STATIC_URL,
         })

--- a/seo/views/search_views.py
+++ b/seo/views/search_views.py
@@ -1702,7 +1702,7 @@ def search_by_results_and_slugs(request, *args, **kwargs):
         cf_count_tup = get_custom_facets(request, filters=filters,
                                          query_string=query_path)
 
-        if not filters['facet_slug']:
+        if not filters.get('facet_slug', None):
             custom_facet_counts = cf_count_tup
         else:
             facet_slugs = filters['facet_slug'].split('/')
@@ -1765,7 +1765,6 @@ def search_by_results_and_slugs(request, *args, **kwargs):
     results_heading = helpers.build_results_heading(breadbox)
     breadbox.job_count = intcomma(total_default_jobs + total_featured_jobs)
     count_heading = helpers.build_results_heading(breadbox)
-
     data_dict = {
         'breadbox': breadbox,
         'build_num': settings.BUILD,
@@ -1781,7 +1780,10 @@ def search_by_results_and_slugs(request, *args, **kwargs):
         'max_filter_settings': settings.ROBOT_FILTER_LEVEL,
         'moc_id_term': moc_id_term if moc_id_term else '\*',
         'moc_term': moc_term,
-        'num_filters': len([k for (k, v) in filters.iteritems() if v]),
+        # see how many active filters there are and then add total number of
+        # facet slugs as there may be multiple filters in the facet slug entry
+        'num_filters': len([k for (k, v) in filters.iteritems()
+                            if v and k != 'facet_slug']) + len(facet_slugs),
         'total_jobs_count': get_total_jobs_count(),
         'results_heading': results_heading,
         'search_url': request.path,

--- a/templates/myblocks/myblocks_base.html
+++ b/templates/myblocks/myblocks_base.html
@@ -12,7 +12,7 @@
         <script type="text/javascript" src="//d2e48ltfsb5exy.cloudfront.net/framework/v2/js/code/jquery-ui-1.8.17.custom.min.js"></script>
         <script type="text/javascript">var pager_num_items = {% if site_config.num_subnav_items_to_show %}{{ site_config.num_subnav_items_to_show }}{% else %}0{% endif %};</script>
 
-        {% if num_filters > max_filter_settings %}
+        {% if num_filters >= max_filter_settings %}
             <meta name="robots" content="nofollow">
         {% endif %}
 


### PR DESCRIPTION
## Overview

This is the ACTUAL PR for 1683. The previous PR was actually PD-2478 in disguise!

Basically, this PR causes the filter counts to properly reflect multiple filters on the facet_slugs category. Now, after more than one facet_slug filter is applied, the robots "nofollow" meta tag will be properly applied

## Testing

Navigate to the following links and check the source for the following line..
`<meta name="robots" content="nofollow">`

http://ANYSTATE.jobs/operator-jobs/new-jobs/   (should NOT have the above tag)
http://ANYSTATE.jobs/manager-jobs/operator-jobs/new-jobs/  (should have nofollow)
http://ANYSTATE.jobs/business-jobs/manager-jobs/operator-jobs/new-jobs/  (should have nofollow)