### PR TITLE
Update default_settings.py

### DIFF
--- a/default_settings.py
+++ b/default_settings.py
@@ -253,7 +253,7 @@ CELERYBEAT_SCHEDULE = {
     },
     'analytics-solr-update': {
         'task': 'tasks.update_solr_from_log',
-        'schedule': crontab(hour='*/1'),
+        'schedule': crontab(hour='*/1', minute=0),
     },
     'morning-sitemap-ping': {
         'task': 'tasks.submit_all_sitemaps',


### PR DESCRIPTION
This runs every minute. If we define a value for minute, it should run every hour.

Outstanding question: Do we need to continue updating solr? The solr collection in this instance is being used for candidate dashboard. @fezick, @JLMcLaugh 

Similarly, do we really need to run update_solr_from_model every five minutes?