### PR TITLE
[PD-2457] Loading Indicators in NUO

### DIFF
--- a/gulp/src/nonuseroutreach/components/InboxManagementPage.jsx
+++ b/gulp/src/nonuseroutreach/components/InboxManagementPage.jsx
@@ -1,8 +1,5 @@
 import React from 'react';
 import {connect} from 'react-redux';
-import {markPageLoadingAction} from '../../common/actions/loading-actions';
-import {doGetInboxes} from '../actions/inbox-actions';
-import {setPageAction} from '../actions/navigation-actions';
 import Inbox from './Inbox';
 import {Col, Row} from 'react-bootstrap';
 
@@ -11,16 +8,6 @@ import {Col, Row} from 'react-bootstrap';
  * inboxes.
  */
 class InboxManagementPage extends React.Component {
-  async componentDidMount() {
-    // update the application's state with the current page and refresh the
-    // list of inboxes
-    const {dispatch} = this.props;
-    dispatch(setPageAction('inboxes'));
-    dispatch(markPageLoadingAction(true));
-    await dispatch(doGetInboxes());
-    dispatch(markPageLoadingAction(false));
-  }
-
   render() {
     const {dispatch, inboxes} = this.props;
 

--- a/gulp/src/nonuseroutreach/components/InboxManagementPage.jsx
+++ b/gulp/src/nonuseroutreach/components/InboxManagementPage.jsx
@@ -17,7 +17,7 @@ class InboxManagementPage extends React.Component {
     const {dispatch} = this.props;
     dispatch(setPageAction('inboxes'));
     dispatch(markPageLoadingAction(true));
-    dispatch(await doGetInboxes());
+    await dispatch(doGetInboxes());
     dispatch(markPageLoadingAction(false));
   }
 

--- a/gulp/src/nonuseroutreach/components/InboxManagementPage.jsx
+++ b/gulp/src/nonuseroutreach/components/InboxManagementPage.jsx
@@ -11,13 +11,13 @@ import {Col, Row} from 'react-bootstrap';
  * inboxes.
  */
 class InboxManagementPage extends React.Component {
-  componentDidMount() {
+  async componentDidMount() {
     // update the application's state with the current page and refresh the
     // list of inboxes
     const {dispatch} = this.props;
     dispatch(setPageAction('inboxes'));
     dispatch(markPageLoadingAction(true));
-    dispatch(doGetInboxes());
+    dispatch(await doGetInboxes());
     dispatch(markPageLoadingAction(false));
   }
 

--- a/gulp/src/nonuseroutreach/components/Menu.jsx
+++ b/gulp/src/nonuseroutreach/components/Menu.jsx
@@ -8,7 +8,7 @@ export class Menu extends React.Component {
   render() {
     const {tips} = this.props;
     const pageTips = tips.length ? [
-      <h2>Tips</h2>,
+      <h2 key="title">Tips</h2>,
       tips.map((tip, i) => <p key={i}>{tip}</p>),
     ] : [];
 

--- a/gulp/src/nonuseroutreach/components/NonUserOutreachApp.jsx
+++ b/gulp/src/nonuseroutreach/components/NonUserOutreachApp.jsx
@@ -3,6 +3,10 @@ import {Col, Row} from 'react-bootstrap';
 import {connect} from 'react-redux';
 import {Loading} from 'common/ui/Loading';
 import {Menu} from './Menu';
+import InboxManagementPage from './InboxManagementPage';
+import {markPageLoadingAction} from '../../common/actions/loading-actions';
+import {doGetInboxes} from '../actions/inbox-actions';
+import {setPageAction} from '../actions/navigation-actions';
 
 
 /* NonUserOutreachApp
@@ -11,6 +15,34 @@ import {Menu} from './Menu';
  * outreach record management page.
  */
 class NonUserOutreachApp extends Component {
+  componentDidMount() {
+    const {history} = this.props;
+    this.unsubscribeToHistory = history.listen(
+      (...args) => this.handleNewLocation(...args));
+  }
+
+  componentWillUnmount() {
+    this.unsubscribeToHistory();
+  }
+
+  async handleNewLocation(_, loc) {
+    const {dispatch} = this.props;
+
+    const lastComponent = loc.components[loc.components.length - 1];
+    if (lastComponent === InboxManagementPage) {
+      // update the application's state with the current page and refresh the
+      // list of inboxes
+      dispatch(setPageAction('inboxes'));
+      dispatch(markPageLoadingAction(true));
+      await dispatch(doGetInboxes());
+      dispatch(markPageLoadingAction(false));
+      return;
+    }
+
+    // Allow other pages to mount.
+    dispatch(markPageLoadingAction(false));
+  }
+
   render() {
     const {loading, tips} = this.props;
     return (
@@ -39,6 +71,8 @@ class NonUserOutreachApp extends Component {
 }
 
 NonUserOutreachApp.propTypes = {
+  history: PropTypes.object.isRequired,
+  dispatch: PropTypes.func.isRequired,
   // whether or not to show a page loading indicator in the content area
   loading: PropTypes.bool.isRequired,
   // the tips to pass along to the menu component

--- a/gulp/src/nonuseroutreach/components/NonUserOutreachApp.jsx
+++ b/gulp/src/nonuseroutreach/components/NonUserOutreachApp.jsx
@@ -4,8 +4,10 @@ import {connect} from 'react-redux';
 import {Loading} from 'common/ui/Loading';
 import {Menu} from './Menu';
 import InboxManagementPage from './InboxManagementPage';
+import OutreachRecordPage from './OutreachRecordPage';
 import {markPageLoadingAction} from '../../common/actions/loading-actions';
 import {doGetInboxes} from '../actions/inbox-actions';
+import {doGetRecords} from '../actions/record-actions';
 import {setPageAction} from '../actions/navigation-actions';
 
 
@@ -37,7 +39,16 @@ class NonUserOutreachApp extends Component {
       await dispatch(doGetInboxes());
       dispatch(markPageLoadingAction(false));
       return;
+    } else if (lastComponent === OutreachRecordPage) {
+      // update the application's state with the current page and refresh the
+      // list of outreach records
+      dispatch(setPageAction('records'));
+      dispatch(markPageLoadingAction(true));
+      await dispatch(doGetRecords());
+      dispatch(markPageLoadingAction(false));
+      return;
     }
+
 
     // Allow other pages to mount.
     dispatch(markPageLoadingAction(false));

--- a/gulp/src/nonuseroutreach/components/OutreachRecordPage.jsx
+++ b/gulp/src/nonuseroutreach/components/OutreachRecordPage.jsx
@@ -2,9 +2,6 @@ import React from 'react';
 import {connect} from 'react-redux';
 import {Col, Row} from 'react-bootstrap';
 import OutreachRecordTable from './OutreachRecordTable';
-import {markPageLoadingAction} from '../../common/actions/loading-actions';
-import {doGetRecords} from '../actions/record-actions';
-import {setPageAction} from '../actions/navigation-actions';
 
 /* OutreachRecordPage
  * Component which encapsulates the OutreachRecordTable.
@@ -12,16 +9,6 @@ import {setPageAction} from '../actions/navigation-actions';
  * interface will grow to be something more elaborate - Edwin, 6/17/2016
  */
 class OutreachRecordPage extends React.Component {
-  async componentDidMount() {
-    // update the application's state with the current page and refresh the
-    // list of outreach records
-    const {dispatch} = this.props;
-    dispatch(setPageAction('records'));
-    dispatch(markPageLoadingAction(true));
-    await dispatch(doGetRecords());
-    dispatch(markPageLoadingAction(false));
-  }
-
   render() {
     const {records} = this.props;
     return (

--- a/gulp/src/nonuseroutreach/components/OutreachRecordPage.jsx
+++ b/gulp/src/nonuseroutreach/components/OutreachRecordPage.jsx
@@ -18,7 +18,7 @@ class OutreachRecordPage extends React.Component {
     const {dispatch} = this.props;
     dispatch(setPageAction('records'));
     dispatch(markPageLoadingAction(true));
-    dispatch(await doGetRecords());
+    await dispatch(doGetRecords());
     dispatch(markPageLoadingAction(false));
   }
 

--- a/gulp/src/nonuseroutreach/components/OutreachRecordPage.jsx
+++ b/gulp/src/nonuseroutreach/components/OutreachRecordPage.jsx
@@ -12,13 +12,13 @@ import {setPageAction} from '../actions/navigation-actions';
  * interface will grow to be something more elaborate - Edwin, 6/17/2016
  */
 class OutreachRecordPage extends React.Component {
-  componentDidMount() {
+  async componentDidMount() {
     // update the application's state with the current page and refresh the
     // list of outreach records
     const {dispatch} = this.props;
     dispatch(setPageAction('records'));
     dispatch(markPageLoadingAction(true));
-    dispatch(doGetRecords());
+    dispatch(await doGetRecords());
     dispatch(markPageLoadingAction(false));
   }
 


### PR DESCRIPTION
This implements loading indicators for NUO.

## Test

This testing procedure is a little flaky but it does allow you to see the indicator after a few tries.

1. In chrome, open the debugger and go to the networking tab.
2. Go to throttling and create a new profile. "High Latency".
3. Set upload and download to 30000 and the latency to 2000. Save it.
4. Restart the debugger and refresh the page.
5. Go to networking again and select the high latency profile.
6. Refresh the page again. (just in case) It should be slower.
7. Flip frequently between the pages using the buttons in the sidebar.

Note that loading the spinner image is affected by the network latency as well as the XHR requests so it may not show up right away.

