### PR TITLE
Clean up our RabbitMQ admin

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -957,7 +957,7 @@ def task_priority_etl_to_solr(guid, buid, name):
         raise task_priority_etl_to_solr.retry(exc=e)
 
 
-@task(name="tasks.check_solr_count", send_error_emails=True)
+@task(name="tasks.check_solr_count", send_error_emails=True, ignore_result=True)
 def task_check_solr_count(buid, count):
     buid = int(buid)
     conn = Solr(settings.HAYSTACK_CONNECTIONS['default']['URL'])


### PR DESCRIPTION
The check_solr_count task is creating a lot of 1 item queues with the results that clutter up our rabbitMQ interface.  We don't use the results, so it shouldn't bother to store them.