### PR TITLE
Forbid deletion of all roles from last company admin user [PD-2491]

### DIFF
--- a/myjobs/models.py
+++ b/myjobs/models.py
@@ -347,6 +347,10 @@ class User(AbstractBaseUser, PermissionsMixin):
     def __unicode__(self):
         return self.email
 
+    def is_last_admin(self, company):
+        return list(company.role_set.filter(name="Admin").filter(
+                user=self).values_list('user', flat=True)) == [self.id]
+
     natural_key = __unicode__
 
     def save(self, force_insert=False, force_update=False, using=None,

--- a/myjobs/models.py
+++ b/myjobs/models.py
@@ -348,8 +348,8 @@ class User(AbstractBaseUser, PermissionsMixin):
         return self.email
 
     def is_last_admin(self, company):
-        return list(company.role_set.filter(name="Admin").filter(
-                user=self).values_list('user', flat=True)) == [self.id]
+        return list(company.role_set.filter(name="Admin").values_list(
+            'user', flat=True)) == [self.id]
 
     natural_key = __unicode__
 

--- a/myjobs/tests/setup.py
+++ b/myjobs/tests/setup.py
@@ -148,7 +148,7 @@ class MyJobsBase(TestCase):
 
     def assertRequires(self, view_name, *activities, **kwargs):
         """
-        Asserst that the given view is only accessible when a user has a role
+        Asserts that the given view is only accessible when a user has a role
         with the given activities.
 
         """

--- a/myjobs/tests/test_api.py
+++ b/myjobs/tests/test_api.py
@@ -15,7 +15,7 @@ from setup import MyJobsBase
 
 class UserResourceTestCase(MyJobsBase):
     def setUp(self):
-        super(UserResourceTests, self).setUp()
+        super(UserResourceTestCase, self).setUp()
         create_api_key(User, instance=self.user, created=True)
         self.client = TestClient(
             path='/api/v1/user/',

--- a/myjobs/tests/test_api.py
+++ b/myjobs/tests/test_api.py
@@ -59,7 +59,6 @@ class UserManagementTestCase(MyJobsBase):
     def setUp(self):
         super(UserManagementTestCase, self).setUp()
         self.role.activities = self.activities
-        self.user.role = self.role
 
     def test_protect_admin(self):
         """

--- a/myjobs/tests/test_api.py
+++ b/myjobs/tests/test_api.py
@@ -92,7 +92,7 @@ class UserManagementTestCase(MyJobsBase):
 
 class SavedSearchResourceTestCase(MyJobsBase):
     def setUp(self):
-        super(SavedSearchResourceTests, self).setUp()
+        super(SavedSearchResourceTestCase, self).setUp()
         self.client = TestClient(
             path='/api/v1/savedsearch/',
             data={'email': 'alice@example.com',

--- a/myjobs/tests/test_api.py
+++ b/myjobs/tests/test_api.py
@@ -4,6 +4,7 @@ from django.core.urlresolvers import reverse
 
 from tastypie.models import create_api_key
 
+from myjobs.tests.factories import RoleFactory
 from myjobs.models import User
 from myjobs.tests.factories import UserFactory
 from myjobs.tests.test_views import TestClient
@@ -12,7 +13,7 @@ from mysearches.models import SavedSearch
 from setup import MyJobsBase
 
 
-class UserResourceTests(MyJobsBase):
+class UserResourceTestCase(MyJobsBase):
     def setUp(self):
         super(UserResourceTests, self).setUp()
         create_api_key(User, instance=self.user, created=True)
@@ -54,8 +55,43 @@ class UserResourceTests(MyJobsBase):
             self.assertFalse(content['user_created'])
             self.assertEqual(content['email'].lower(), 'alice@example.com')
 
+class UserManagementTestCase(MyJobsBase):
+    def setUp(self):
+        super(UserManagementTestCase, self).setUp()
+        self.role.activities = self.activities
+        self.user.role = self.role
 
-class SavedSearchResourceTests(MyJobsBase):
+    def test_protect_admin(self):
+        """
+        Can't delete all roles for the last admin associated with a company
+
+        """
+        self.assertEqual(self.role.user_set.all().count(), 1)
+        empty_role = RoleFactory.build(company=self.company, name="Empty")
+
+        response = self.client.post(path='/manage-users/api/users/edit/%s/' % 
+                                    self.user.id,
+                data={'assigned_roles[]': ['Empty']})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(self.role.user_set.all().count(), 1, 
+                         "Removed last User from Admin Role")
+        response_data = json.loads(response.content)
+        self.assertEqual(response_data['success'], "false")
+        self.assertIn("one user assigned to the Admin role",
+                      response_data['message'],
+                      "Unassigning an admin role failed for the wrong reason")
+
+        response = self.client.delete(path='/manage-users/api/users/delete/%s/' % self.user.id)
+        response_data = json.loads(response.content)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(self.role.user_set.all().count(), 1, 
+                         "Removed last User from Admin Role")
+        self.assertEqual(response_data['success'], "false")
+        self.assertIn("You must add another admin before deleting",
+                      response_data['message'], "Delete user failed for the wrong reason")
+
+
+class SavedSearchResourceTestCase(MyJobsBase):
     def setUp(self):
         super(SavedSearchResourceTests, self).setUp()
         self.client = TestClient(

--- a/myjobs/tests/test_manage_users.py
+++ b/myjobs/tests/test_manage_users.py
@@ -1,10 +1,11 @@
+import json
+
 from django.core import mail
 from django.core.urlresolvers import reverse
-from myjobs.models import User
-from myjobs.tests.factories import RoleFactory
+
+from myjobs.tests.factories import RoleFactory, UserFactory
 from seo.tests.factories import CompanyFactory
 from setup import MyJobsBase
-import json
 
 
 class ManageUsersTests(MyJobsBase):
@@ -555,7 +556,17 @@ class ManageUsersTests(MyJobsBase):
         """
         Tests deleting a user
         """
+        # You can't delete the last admin; this should fail.
         expected_user_pk = self.user.pk
+        response = self.client.delete(reverse('api_delete_user',
+                                              args=[expected_user_pk]))
+        output = json.loads(response.content)
+        self.assertEqual(output["success"], "false")
+        self.assertTrue("You must add another admin" in output["message"])
+
+        # Create another admin and try again.
+        new_user = UserFactory(email='newuser@example.com')
+        new_user.roles.add(*list(self.user.roles.all()))
 
         response = self.client.delete(reverse('api_delete_user',
                                               args=[expected_user_pk]))

--- a/myjobs/views.py
+++ b/myjobs/views.py
@@ -1304,21 +1304,23 @@ def api_delete_user(request, user_id=0):
                                 content_type="application/json")
         if user.is_last_admin(company):
             ctx["success"] = "false"
-            ctx["message"] = (u"{email} is the last admin for {company}. "
-                    "You must add another admin before deleting "
-                    "{email}.").format(email=user.email, 
-                            company=company)
+            ctx["message"] = (
+                u"{email} is the last admin for {company}. "
+                "You must add another admin before deleting "
+                "{email}.").format(email=user.email,
+                                   company=company)
             return HttpResponse(json.dumps(ctx),
                                 content_type="application/json")
 
         roles = Role.objects.filter(company=company)
         for role in roles:
-            user[0].roles.remove(role.id)
+            user.roles.remove(role.id)
 
         ctx["success"] = "true"
         ctx["message"] = "User deleted."
 
         return HttpResponse(json.dumps(ctx), content_type="application/json")
+
 
 def request_company_access(request):
     """


### PR DESCRIPTION
We were ensuring that we didn't remove the admin role from the last admin user when editing roles, but not when deleting all company roles from a user. This adds a check to myjobs.api_delete_user.