### PR TITLE
Added veiw source name to csv output.

### DIFF
--- a/myjobs/tests/test_admin.py
+++ b/myjobs/tests/test_admin.py
@@ -106,6 +106,7 @@ class MyJobsAdminTests(MyJobsBase):
         # into a list of dicts
         formatted_manipulations = [{
             u'View Source': unicode(m.view_source),
+            u'View Source Name': '',
             u'BUID': unicode(m.buid),
             u'Action Type': unicode(m.action_type),
             u'Value 1': unicode(m.value_1),

--- a/redirect/admin.py
+++ b/redirect/admin.py
@@ -170,8 +170,8 @@ class DestinationManipulationAdmin(admin.ModelAdmin):
         """Gives the ability to save the queryset as a csv"""
 
         query = request.GET.get('q')
-        # Older versions of Django are broken with respect to the 
-        # "Select all x destination manipulations" link in that regardless of 
+        # Older versions of Django are broken with respect to the
+        # "Select all x destination manipulations" link in that regardless of
         # if it is chosen or not, you will always only get at most 100 records.
         # Thus, we manually run the filter and return all results if this
         # option is present.
@@ -181,16 +181,20 @@ class DestinationManipulationAdmin(admin.ModelAdmin):
         else:
             result = queryset
 
-        fields = ("BUID", "View Source", "Action Type", "Action", "Value 1",
-                  "Value 2")
+        fields = ("BUID", "View Source", "View Source Name", "Action Type",
+                  "Action", "Value 1", "Value 2")
         output = StringIO()
         writer = csv.writer(output)
         writer.writerow(fields)
 
         for item in result:
+            view_source = ViewSource.objects.filter(
+                view_source_id=item.view_source).first()
+
             writer.writerow([
                 item.buid,
                 item.view_source,
+                getattr(view_source, 'name', ''),
                 item.action_type,
                 item.action,
                 item.value_1,


### PR DESCRIPTION
Back when I made it possible to export destination manipulations as CSV, I forgot to include the view source name. This corrects that.