### PR TITLE
Add API for searching for, retrieving, and creating partners [PD-2509]

### DIFF
--- a/mypartners/urls.py
+++ b/mypartners/urls.py
@@ -1,18 +1,30 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import patterns, url, include
 from django.views.generic import RedirectView
+
+nuo_api = patterns('mypartners.views',
+    url(r'^inbox/list$', 'api_get_nuo_inbox_list', name='api_get_nuo_inbox_list'),
+    url(r'^records/list$', 'api_get_nuo_records_list', name='api_get_nuo_records_list'),
+    url(r'^records/record', 'api_get_individual_nuo_record', name='api_get_individual_nuo_record'),
+    url(r'^records/convert', 'api_convert_outreach_record', name='api_convert_outreach_record'),
+    url(r'^inbox/add', 'api_add_nuo_inbox',
+        name='api_add_nuo_inbox'),
+    url(r'^inbox/delete', 'api_delete_nuo_inbox',
+        name='api_delete_nuo_inbox'),
+    url(r'^inbox/update', 'api_update_nuo_inbox',
+        name='api_update_nuo_inbox'),
+)
+
+api = patterns('mypartners.views',
+    url(r'^nonuseroutreach/', include(nuo_api)),
+    url(r'^partner$', 'api_get_partners', name='api_get_partners'),
+    url(r'^partner/(?P<partner_id>\d+)$', 'api_get_partner',
+        name='api_get_partner'),
+    url(r'^partner/create$', 'api_create_partner', name='api_create_partner'),
+)
 
 urlpatterns = patterns('mypartners.views',
     url(r'^$', RedirectView.as_view(url='/prm/view/')),
-    url(r'^api/nonuseroutreach/inbox/list$', 'api_get_nuo_inbox_list', name='api_get_nuo_inbox_list'),
-    url(r'^api/nonuseroutreach/records/list$', 'api_get_nuo_records_list', name='api_get_nuo_records_list'),
-    url(r'^api/nonuseroutreach/records/record', 'api_get_individual_nuo_record', name='api_get_individual_nuo_record'),
-    url(r'^api/nonuseroutreach/records/convert', 'api_convert_outreach_record', name='api_convert_outreach_record'),
-    url(r'^api/nonuseroutreach/inbox/add', 'api_add_nuo_inbox',
-        name='api_add_nuo_inbox'),
-    url(r'^api/nonuseroutreach/inbox/delete', 'api_delete_nuo_inbox',
-        name='api_delete_nuo_inbox'),
-    url(r'^api/nonuseroutreach/inbox/update', 'api_update_nuo_inbox',
-        name='api_update_nuo_inbox'),
+    url('api/', include(api)),
     url(r'^view/$', 'prm', name='prm'),
     url(r'^view$', 'prm', name='prm'),
     url(r'^view/partner-library/add/$', 'create_partner_from_library',


### PR DESCRIPTION
Most of this can be tested in your browser. /prm/api/partner/ and /prm/api/partner/X/ accept GET requests.

We discussed allowing POST requests for /prm/api/partner/ but it was trivial to add support for both.