### PR TITLE
Add Outreach Workflow State API [PD-2520]

### DIFF
--- a/mypartners/urls.py
+++ b/mypartners/urls.py
@@ -12,6 +12,8 @@ nuo_api = patterns('mypartners.views',
         name='api_delete_nuo_inbox'),
     url(r'^inbox/update', 'api_update_nuo_inbox',
         name='api_update_nuo_inbox'),
+    url(r'^workflowstate$', 'api_get_workflow_states',
+        name='api_get_workflow_states'),
 )
 
 api = patterns('mypartners.views',

--- a/mypartners/views.py
+++ b/mypartners/views.py
@@ -2181,3 +2181,10 @@ def api_create_partner(request):
     if tags:
         partner.tags = tags
     return HttpResponse(json.dumps({'id': partner.pk, 'name': partner.name}))
+
+
+@require_http_methods(['GET', 'POST'])
+def api_get_workflow_states(request):
+    return HttpResponse(json.dumps(
+        [{'id': ows.pk, 'name': ows.state}
+         for ows in OutreachWorkflowState.objects.all()]))


### PR DESCRIPTION
Merge conflicts ahoy.

A few queries.

1 - This is basically identical to the other endpoints but much simpler. Tests?
2 - Does this make sense? NUO-specific stuff is under /prm/api/nonuseroutreach/ while generic PRM stuff is under /prm/api/

Future work - I would like to condense the apis using an as-yet-to-be-determined REST framework. There are deadlines, however. ¯\\\_(ツ)\_/¯