### PR TITLE
Don't throw a 500 when trying to log into an account that doesn't exist [PD-2512]

### DIFF
--- a/myjobs/tests/test_views.py
+++ b/myjobs/tests/test_views.py
@@ -718,6 +718,13 @@ class MyJobsViewsTests(MyJobsBase):
 
             self.client.get(reverse('auth_logout'))
 
+    def test_log_into_nonexistent_account(self):
+        with self.assertRaises(User.DoesNotExist):
+            self.client.post(reverse('home'),
+                             data={'username': 'fake@fake.fake',
+                                   'password': self.password,
+                                   'action': 'login'})
+
     def test_guid_cookies_login_and_off(self):
         """
         Tests logging in and recieving a guid cookie. Logging out deletes guid

--- a/myjobs/tests/test_views.py
+++ b/myjobs/tests/test_views.py
@@ -719,11 +719,11 @@ class MyJobsViewsTests(MyJobsBase):
             self.client.get(reverse('auth_logout'))
 
     def test_log_into_nonexistent_account(self):
-        with self.assertRaises(User.DoesNotExist):
-            self.client.post(reverse('home'),
-                             data={'username': 'fake@fake.fake',
-                                   'password': self.password,
-                                   'action': 'login'})
+        response = self.client.post(reverse('home'),
+                                    data={'username': 'fake@fake.fake',
+                                          'password': self.password,
+                                          'action': 'login'})
+        self.assertEqual(response.status_code, 200)
 
     def test_guid_cookies_login_and_off(self):
         """

--- a/registration/forms.py
+++ b/registration/forms.py
@@ -123,7 +123,7 @@ class CustomAuthForm(AuthenticationForm):
 
     def clean_username(self):
         username = self.cleaned_data.get('username')
-        user = User.objects.get(email__iexact=username)
+        user = User.objects.get_email_owner(email=username)
         if user and user.is_locked_out():
             raise ValidationError(
                 'This account has been locked due to repeated login ' +


### PR DESCRIPTION
If you want to test:

Try logging into a fake account. On base qc, you get no indication that something went wrong aside from an error in your dev console. On this branch, you get a form error.