### PR TITLE
Add case insensitive regex to filter logic

### DIFF
--- a/gulp/src/nonuseroutreach/actions/navigation-actions.js
+++ b/gulp/src/nonuseroutreach/actions/navigation-actions.js
@@ -49,10 +49,11 @@ export function doFilterRecords() {
     }
     if (termFilter) {
       filtersActive = true;
+      const filterRegex = new RegExp(termFilter, 'i');
       filteredRecords = filteredRecords.filter(record => (
-        record.outreachEmail.indexOf(termFilter) !== -1 ||
-          record.fromEmail.indexOf(termFilter) !== -1 ||
-          record.dateAdded.indexOf(termFilter) !== -1
+        record.outreachEmail.search(filterRegex) !== -1 ||
+          record.fromEmail.search(filterRegex) !== -1 ||
+          record.dateAdded.search(filterRegex) !== -1
         )
       );
     }


### PR DESCRIPTION
As the title says. I realized that my filter logic was case sensitive, which isn't what we're likely looking for in filtering. 