### PR TITLE
[PD-2529] Updates to Conversion API

### DIFF
--- a/mypartners/tests/test_api.py
+++ b/mypartners/tests/test_api.py
@@ -235,7 +235,7 @@ class NUOConversionAPITestCase(MyPartnersTestCase):
             reverse('api_convert_outreach_record'),
             data = {'request': json.dumps(self.request_data)}
         )
-        self.check_status_code_and_objects(response, 200, 6)
+        self.check_status_code_and_objects(response, 200, 7)
 
     def test_outreach_conversion_api_validate_only(self):
         """
@@ -284,7 +284,7 @@ class NUOConversionAPITestCase(MyPartnersTestCase):
             data = {'request': json.dumps(self.request_data)}
         )
 
-        self.check_status_code_and_objects(response, 200, 5)
+        self.check_status_code_and_objects(response, 200, 6)
 
         dict_contact = Contact.objects.get(name="Nicole J")
         self.assertEqual(dict_contact.partner.pk, existing_partner.pk,
@@ -304,7 +304,7 @@ class NUOConversionAPITestCase(MyPartnersTestCase):
             reverse('api_convert_outreach_record'),
             data = {'request': json.dumps(self.request_data)}
         )
-        self.check_status_code_and_objects(response, 200, 6)
+        self.check_status_code_and_objects(response, 200, 7)
 
     def test_outreach_api_contact_no_locations(self):
         """
@@ -331,7 +331,7 @@ class NUOConversionAPITestCase(MyPartnersTestCase):
             reverse('api_convert_outreach_record'),
             data = {'request': json.dumps(self.request_data)}
         )
-        self.check_status_code_and_objects(response, 200, 6)
+        self.check_status_code_and_objects(response, 200, 7)
         self.contact = Contact.objects.get(id=self.contact.id)
         self.assertEqual(self.contact.notes, "first part\nnew notes")
 
@@ -473,8 +473,8 @@ class NUOConversionAPITestCase(MyPartnersTestCase):
         :return: tuple of (objects created, objected missing)
 
         """
-        total_objects = ['partner', 'contact1', 'contact2', 'contact2notes',
-                         'location1', 'contactrecord']
+        total_objects = ['partner', 'contact1', 'contact1notes' 'contact2', 'contact2notes',
+                         'contact1location', 'contactrecord']
         objects_created = []
         partner = Partner.objects.filter(name="James B").first()
         contact1 = Contact.objects.filter(name="Nicole J").first()
@@ -488,8 +488,10 @@ class NUOConversionAPITestCase(MyPartnersTestCase):
                                 .filter(id=contact1.id)
                                 .exists()):
             objects_created.append("contact1")
+            if contact1.notes == "long note left here":
+                objects_created.append("contact1note")
             if contact1.locations.all().count() > 0:
-                objects_created.append("location1")
+                objects_created.append("contact1location")
         if contact2 and (self.outreach_record.contacts
                                 .filter(id=contact2.id)
                                 .exists()):

--- a/mypartners/views.py
+++ b/mypartners/views.py
@@ -2017,6 +2017,7 @@ def api_convert_outreach_record(request):
     for contact in data_object['contacts']:
         contact_info = {}
         contact_pk = contact.pop('pk', None)
+        contact_info['notes'] = contact.pop('notes', None)
         contact_info['tags'] = retrieve_tags_objects(contact,
                                                      contact.pop('tags', []))
         contact_location = contact.pop('location', None)
@@ -2077,8 +2078,13 @@ def api_convert_outreach_record(request):
 
     for contact in contacts:
         contact['contact'].partner = partner
+        if contact['contact'].notes:
+            contact['contact'].notes = '%s\n%s' % (contact['contact'].notes,
+                                                   contact['notes'])
+        else:
+            contact['contact'].notes = contact['notes']
         contact['contact'].save()
-        outreach_record.contacts.add(contact_record)
+        outreach_record.contacts.add(contact['contact'])
         if contact.get('location', None):
             contact['location'].save()
             contact['contact'].locations.add(contact['location'])

--- a/mypartners/views.py
+++ b/mypartners/views.py
@@ -2072,11 +2072,13 @@ def api_convert_outreach_record(request):
         return HttpResponse("success, nosave")
 
     partner.save()
+    outreach_record.partners.add(partner)
     add_tags_to_object(partner, partner_tags)
 
     for contact in contacts:
         contact['contact'].partner = partner
         contact['contact'].save()
+        outreach_record.contacts.add(contact_record)
         if contact.get('location', None):
             contact['location'].save()
             contact['contact'].locations.add(contact['location'])
@@ -2085,6 +2087,7 @@ def api_convert_outreach_record(request):
         contact_record.partner = partner
         contact_record.contact = contact['contact']
         contact_record.save()
+        outreach_record.communication_records.add(contact_record)
         add_tags_to_object(contact_record, contact_record_tags)
 
     outreach_record.current_workflow_state = workflow_status

--- a/mypartners/views.py
+++ b/mypartners/views.py
@@ -2028,13 +2028,13 @@ def api_convert_outreach_record(request):
             validator.form_error("contacts", "User does not have permission to"
                                              " create a contact.")
         # parse locations for contact, create where necessary
-        if contact_location:
+        if contact_location and not contact_pk:
             location_pk = contact_location.pop('pk', None)
             contact_info['location'] = return_or_create_object(Location,
                                                               location_pk,
                                                               contact_location,
                                                               'contact')
-        else:
+        elif not contact_pk:
             validator.form_error("contacts", "Location object missing from contact")
         contacts.append(contact_info)
 
@@ -2077,8 +2077,9 @@ def api_convert_outreach_record(request):
     for contact in contacts:
         contact['contact'].partner = partner
         contact['contact'].save()
-        contact['location'].save()
-        contact['contact'].locations.add(contact['location'])
+        if contact.get('location', None):
+            contact['location'].save()
+            contact['contact'].locations.add(contact['location'])
         add_tags_to_object(contact['contact'], contact['tags'])
 
         contact_record.partner = partner


### PR DESCRIPTION
## Overview

The original overhaul of the conversion API lacked a bit of usability that is needed for proper use by the front end.

1) Contacts could no longer be properly added via PK
2) Notes were not properly appended for existing contacts on an add
3) Contacts, Partners, Comm. Records were not linked properly to an O.R. record on save

## Testing

To test, simply ping the existing API with requests that contain the above features.