### PR TITLE
Consolidate State

### DIFF
--- a/gulp/src/nonuseroutreach/actions/process-outreach-actions.js
+++ b/gulp/src/nonuseroutreach/actions/process-outreach-actions.js
@@ -125,8 +125,8 @@ export function doSubmit() {
         pk: process.outreachId,
         current_workflow_state: reviewed.id,
       },
-      partner: {pk: process.partnerId},
-      contacts: [{pk: process.contactId}],
+      partner: record.partner,
+      contacts: record.contacts,
       contactrecord: {
         ...record.communicationrecord,
         date_time: '2016-1-1',

--- a/gulp/src/nonuseroutreach/actions/process-outreach-actions.js
+++ b/gulp/src/nonuseroutreach/actions/process-outreach-actions.js
@@ -15,7 +15,7 @@ export const resetProcessAction = createAction('NUO_RESET_PROCESS',
  *  partner: partner data
  */
 export const choosePartnerAction = createAction('NUO_CHOOSE_PARTNER',
-    (partnerId, partner) => ({partnerId, partner}));
+    (partnerId, name) => ({partnerId, name}));
 
 /**
  * Use chose a contact.
@@ -24,7 +24,7 @@ export const choosePartnerAction = createAction('NUO_CHOOSE_PARTNER',
  *  contact: contact data
  */
 export const chooseContactAction = createAction('NUO_CHOOSE_CONTACT',
-    (contactId, contact) => ({contactId, contact}));
+    (contactId, name) => ({contactId, name}));
 
 /**
  * Use chose to create a new partner

--- a/gulp/src/nonuseroutreach/components/ProcessRecordPage.jsx
+++ b/gulp/src/nonuseroutreach/components/ProcessRecordPage.jsx
@@ -98,7 +98,7 @@ class ProcessRecordPage extends Component {
     ]));
   }
 
-  renderKnownContact() {
+  renderNewCommunicationRecord() {
     const {dispatch, form, communicationRecordFormContents} = this.props;
 
     const fields = map(form.ordered_fields, fieldName => (
@@ -160,7 +160,7 @@ class ProcessRecordPage extends Component {
     } else if (processState === 'SELECT_CONTACT') {
       return this.renderSelectContact();
     } else if (processState === 'NEW_COMMUNICATIONRECORD') {
-      return this.renderKnownContact();
+      return this.renderNewCommunicationRecord();
     } else if (processState === 'NEW_PARTNER') {
       return this.renderNewPartner();
     } else if (processState === 'NEW_CONTACT') {

--- a/gulp/src/nonuseroutreach/components/ProcessRecordPage.jsx
+++ b/gulp/src/nonuseroutreach/components/ProcessRecordPage.jsx
@@ -21,7 +21,7 @@ class ProcessRecordPage extends Component {
   handleChoosePartner(obj) {
     const {dispatch} = this.props;
 
-    dispatch(choosePartnerAction(obj.value, {value: '', name: obj.display}));
+    dispatch(choosePartnerAction(obj.value, obj.display));
   }
 
   async handleChooseContact(obj) {
@@ -186,13 +186,13 @@ ProcessRecordPage.propTypes = {
 export default connect(state => ({
   outreachId: state.process.outreachId,
   processState: state.process.state,
-  partnerName: get(state.process, 'partner.name'),
-  partnerId: state.process.partnerId,
+  partnerName: get(state.process, 'record.partner.partnername'),
+  partnerId: get(state.process, 'record.partner.pk'),
   contactName: get(state.process, 'contact.name'),
   contactId: state.process.contactId,
   form: state.process.form,
   partnerFormContents: state.process.record.partner,
-  contactFormsContents: state.process.record.contacts[0],
+  contactFormsContents: state.process.record.contacts,
   communicationRecordFormContents:
     state.process.record.communicationrecord,
 }))(ProcessRecordPage);

--- a/gulp/src/nonuseroutreach/reducers/process-outreach-reducer.js
+++ b/gulp/src/nonuseroutreach/reducers/process-outreach-reducer.js
@@ -21,10 +21,7 @@ const defaultState = {
  *
  *  outreach: information for the current outreach record
  *  outreachId: id for the current outreach record
- *  partner: information for the selected partner
- *  partnerId: id for the selected partner
- *  contacts: info for selected contacts
- *  contactIds: ids for selected contacts
+ *  contactIndex: if editing a contact, which one is the user concerned with?
  *  form: when editing, information for the form fields
  *  record: The record which will be submitted {
  *    outreachrecord: the outreach record we are working on
@@ -46,24 +43,37 @@ export default handleActions({
   },
 
   'NUO_CHOOSE_PARTNER': (state, action) => {
-    const {partner, partnerId} = action.payload;
+    const {name, partnerId} = action.payload;
 
     return {
       ...state,
       state: 'SELECT_CONTACT',
-      partnerId,
-      partner,
+      record: {
+        ...state.record,
+        partner: {
+          pk: partnerId,
+          partnername: name,
+        },
+      },
     };
   },
 
   'NUO_CHOOSE_CONTACT': (state, action) => {
-    const {contact, contactId} = action.payload;
+    const {name, contactId} = action.payload;
 
     return {
       ...state,
       state: 'NEW_COMMUNICATIONRECORD',
-      contactId,
-      contact,
+      record: {
+        ...state.record,
+        contacts: [
+          ...state.record.contacts,
+          {
+            pk: contactId,
+            name,
+          },
+        ],
+      },
     };
   },
 
@@ -73,9 +83,12 @@ export default handleActions({
     const newState = {
       ...state,
       state: 'NEW_PARTNER',
-      partnerId: '',
-      partner: {
-        name: partnerName,
+      record: {
+        ...state.record,
+        partner: {
+          pk: '',
+          name: partnerName,
+        },
       },
     };
 
@@ -87,13 +100,22 @@ export default handleActions({
 
   'NUO_NEW_CONTACT': (state, action) => {
     const {contactName} = action.payload;
+    const {contacts} = state.record;
+    const newIndex = contacts.length;
 
     const newState = {
       ...state,
       state: 'NEW_CONTACT',
-      contactId: '',
-      contact: {
-        name: contactName,
+      contactIndex: newIndex,
+      record: {
+        ...state.record,
+        contacts: [
+          ...state.record.contacts,
+          {
+            pk: '',
+            name: contactName,
+          },
+        ],
       },
     };
 

--- a/gulp/src/nonuseroutreach/spec/process-outreach-reducer-spec.js
+++ b/gulp/src/nonuseroutreach/spec/process-outreach-reducer-spec.js
@@ -32,58 +32,64 @@ describe('processEmailReducer', () => {
   });
 
   describe('handling choosePartnerAction', () => {
-    const partner = {
-      name: 'acme',
-    };
-    const result = reducer({}, choosePartnerAction(4, partner));
+    const result = reducer(
+      {record: {partner: {}}},
+      choosePartnerAction(4, 'acme'));
 
     it('should set the right state', () => {
       expect(result.state).toEqual('SELECT_CONTACT');
     });
 
     it('should have the partner id', () => {
-      expect(result.partnerId).toEqual(4);
+      expect(result.record.partner.pk).toEqual(4);
     });
 
-    it('should have the partner', () => {
-      expect(result.partner).toEqual(partner);
+    it('should have the partner name', () => {
+      expect(result.record.partner.partnername).toEqual('acme');
     });
   });
 
   describe('handling chooseContactAction', () => {
     const state = {
-      partnerId: 4,
-      partner: {name: 'acme'},
+      record: {
+        partner: {
+          pk: 4,
+          name: 'acme',
+        },
+        contacts: [
+          {pk: 99},
+        ],
+      },
     };
-    const contact = {
-      name: 'bob',
-    };
-    const result = reducer(state, chooseContactAction(3, contact));
+    const result = reducer(state, chooseContactAction(3, 'bob'));
 
     it('should set the right state', () => {
       expect(result.state).toEqual('NEW_COMMUNICATIONRECORD');
     });
 
-    it('should have the contact id', () => {
-      expect(result.contactId).toEqual(3);
+    it('should have the previous contacts', () => {
+      expect(result.record.contacts[0]).toEqual(state.record.contacts[0]);
     });
 
-    it('should have the contact', () => {
-      expect(result.contact).toEqual(contact);
+    it('should have the contact id', () => {
+      expect(result.record.contacts[1].pk).toEqual(3);
+    });
+
+    it('should have the contact name', () => {
+      expect(result.record.contacts[1].name).toEqual('bob');
     });
 
     it('should retain the partner', () => {
-      expect(result.partnerId).toEqual(4);
-      expect(result.partner).toEqual(state.partner);
+      expect(result.record.partner).toEqual(state.record.partner);
     });
   });
 
   describe('handling newPartnerAction', () => {
     const state = {
-      contactId: 3,
-      contact: {},
-      partnerId: 4,
-      partner: {},
+      record: {
+        contacts: [{pk: 3}],
+        partner: {pk: 4},
+      },
     };
     const result = reducer(state, newPartnerAction('Partner Name Inc.'));
 
@@ -91,53 +97,49 @@ describe('processEmailReducer', () => {
       expect(result.state).toEqual('NEW_PARTNER');
     });
 
-    it('should have no contactId', () => {
-      expect(result.contactId).not.toBeDefined();
-    });
-
-    it('should have no contact', () => {
-      expect(result.contact).not.toBeDefined();
+    it('should retain contacts', () => {
+      expect(result.record.contacts).toEqual(state.record.contacts);
     });
 
     it('should have a blank partnerId', () => {
-      expect(result.partnerId).toEqual('');
+      expect(result.record.partner.pk).toEqual('');
     });
 
     it('should have a partner name', () => {
-      expect(result.partner.name).toEqual('Partner Name Inc.');
+      expect(result.record.partner.name).toEqual('Partner Name Inc.');
     });
 
   });
 
   describe('handling newContactAction', () => {
     const state = {
-      contactId: 3,
-      contact: {},
-      partnerId: 4,
-      partner: {},
+      record: {
+        contacts: [{pk: 3}],
+        partner: {pk: 4},
+      },
     };
     const result = reducer(state, newContactAction('Some Person'));
 
     it('should set the right state', () => {
       expect(result.state).toEqual('NEW_CONTACT');
+      expect(result.contactIndex).toEqual(1);
     });
 
     it('should have a blank contactId', () => {
-      expect(result.contactId).toEqual('');
+      expect(result.record.contacts[1].pk).toEqual('');
     });
 
     it('should have a contact name', () => {
-      expect(result.contact.name).toEqual('Some Person');
+      expect(result.record.contacts[1].name).toEqual('Some Person');
     });
 
-    it('should keep partnerId', () => {
-      expect(result.partnerId).toEqual(4);
+    it('should keep the previous contacts', () => {
+      expect(result.record.contacts[0]).toEqual(state.record.contacts[0]);
     });
 
-    it('should keep partner', () => {
-      expect(result.partner).toEqual({});
+    it('should keep the partner', () => {
+      expect(result.record.partner).toEqual(state.record.partner);
     });
-
   });
 
   describe('handling receiveFormAction', () => {


### PR DESCRIPTION
Consolidate form and item selection state into the `record` property. See the docstring in `process-outreach-reducer.js` for details.

Behavior shouldn't change. Forms should display. The happy path of select partner, select contact, record form, submit should still work.