### PR TITLE
Fixed overflow styling on partner/contact drop downs

### DIFF
--- a/gulp/src/nonuseroutreach/components/SearchDrop.jsx
+++ b/gulp/src/nonuseroutreach/components/SearchDrop.jsx
@@ -156,11 +156,11 @@ export default class SearchDrop extends Component {
               onMouseEnter={() => this.handleMouseOver(i)}
               onClick={() => this.handleSelect()}
               className={classnames(
-                  {'active': i === activeIndex})}>
-              {result.display}
+                  {'active': i === activeIndex, 'list-result': true})}>
               {typeof result.count !== 'undefined' ?
                 <span className="partner-count">({result.count} contact{result.count === 1 ? '' : 's'})</span>
                 : ''}
+              {result.display}
             </li>
           ))}
         </ul>

--- a/static/custom.css
+++ b/static/custom.css
@@ -629,6 +629,12 @@ h1 > small > a:hover {
 	cursor: pointer;
 }
 
+.list-result {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
 .sidebar {
     background-color: #F7F7F7;
     border: 1px solid #E5E5E5;


### PR DESCRIPTION
Fix styling on overflow drop downs.  Should display as much of the name as visible, ending with an ellipsis if it extends off screen.