### PR TITLE
[PD-2570] Added run tests script to package.json

### DIFF
--- a/gulp/package.json
+++ b/gulp/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "clean-shrinkwrap": "babel-node clean-shrinkwrap.js",
-    "devserver": "webpack-dev-server -d --progress --config=webpack.dev.config.js --inline"
+    "devserver": "webpack-dev-server -d --progress --config=webpack.dev.config.js --inline",
+    "tests": "gulp watch-tasks watch"
   },
   "author": "DirectEmployers Association",
   "license": "(GPL-2.0 OR GPL-3.0 OR MIT)",


### PR DESCRIPTION
Created a "tests" script under "scripts" in the packgage.json file in the gulp directory.  To run this command from the terminal, cd to the gulp directory and type: "npm run tests".  This command will "watch" the JavaScript Unit tests as you develop.

The purpose of this task is to replace Docker with NPM when running JavaScript unit tests, NPM is a native JavaScript Node module and as such, plays "nicer" with other JavaScript stuff.