### PR TITLE
[PD-2573] append only contact form

### DIFF
--- a/gulp/src/common/ui/CheckBox.jsx
+++ b/gulp/src/common/ui/CheckBox.jsx
@@ -8,7 +8,16 @@ import React from 'react';
  */
 
 function CheckBox(props) {
-  const {name, onChange, required, initial, isHidden, autoFocus} = props;
+  const {
+    name,
+    onChange,
+    required,
+    initial,
+    isHidden,
+    autoFocus,
+    disable,
+  } = props;
+
   return (
     <input
       type="checkbox"
@@ -19,6 +28,7 @@ function CheckBox(props) {
       hidden={isHidden}
       defaultChecked={initial}
       onChange={onChange}
+      disabled={disable}
       autoFocus={autoFocus}
       />
   );
@@ -48,6 +58,10 @@ CheckBox.propTypes = {
    * Must this field have a value before submitting form?
    */
   required: React.PropTypes.bool,
+  /**
+   * Disable this control
+   */
+  disable: React.PropTypes.bool,
   /**
    * Should this bad boy focus, all auto like?
    */

--- a/gulp/src/common/ui/DateField.jsx
+++ b/gulp/src/common/ui/DateField.jsx
@@ -165,8 +165,11 @@ class DateField extends React.Component {
       isHidden,
       value,
       placeholder,
+      disable,
       error,
     } = this.props;
+
+    const filteredOnChange = disable ? () => {} : onChange;
 
     let momentObject = moment(value, 'MM/DD/YYYY');
     let day;
@@ -229,7 +232,7 @@ class DateField extends React.Component {
             hidden={isHidden}
             value={value}
             placeholder={placeholder}
-            onChange={onChange}
+            onChange={filteredOnChange}
             onFocus={e => this.toggleCalendar(e, this)}
             onBlur={e => this.onInputBlur(e)}
           />
@@ -291,6 +294,10 @@ DateField.propTypes = {
   * half of them will fall after it.
   */
   pastOnly: React.PropTypes.bool,
+  /**
+   * Disable this control
+   */
+  disable: React.PropTypes.bool,
 };
 
 DateField.defaultProps = {

--- a/gulp/src/common/ui/RemoteFormField.jsx
+++ b/gulp/src/common/ui/RemoteFormField.jsx
@@ -11,8 +11,9 @@ import FieldWrapper from 'common/ui/FieldWrapper';
 export default class RemoteFormField extends Component {
   render() {
     const {fieldName, form, value, onChange} = this.props;
-    const field = form.fields[fieldName];
+    const field = form.fields[fieldName] || {};
     const errors = form.errors[fieldName];
+    const fieldDisable = field.readonly;
 
     function wrap(child) {
       return (
@@ -40,6 +41,7 @@ export default class RemoteFormField extends Component {
           isHidden={field.widget.is_hidden}
           placeholder={field.widget.attrs.placeholder}
           autoFocus={field.widget.attrs.autofocus}
+          disable={fieldDisable}
           />
       );
     case 'textarea':
@@ -53,6 +55,7 @@ export default class RemoteFormField extends Component {
           isHidden={field.widget.is_hidden}
           placeholder={field.widget.attrs.placeholder}
           autoFocus={field.widget.attrs.autofocus}
+          disable={fieldDisable}
           />
       );
     case 'date':
@@ -67,6 +70,7 @@ export default class RemoteFormField extends Component {
           placeholder={field.widget.attrs.placeholder}
           autoFocus={field.widget.attrs.autofocus}
           numberOfYears={50}
+          disable={fieldDisable}
           pastOnly
           />
       );
@@ -77,6 +81,7 @@ export default class RemoteFormField extends Component {
           onChange={e => onChange(e, fieldName)}
           value={getDisplayForValue(field.choices, value)}
           choices={field.choices}
+          disable={fieldDisable}
           />
       );
     case 'checkbox':
@@ -90,6 +95,7 @@ export default class RemoteFormField extends Component {
           isHidden={field.widget.is_hidden}
           placeholder={field.widget.attrs.placeholder}
           autoFocus={field.widget.attrs.autofocus}
+          disable={fieldDisable}
           />
       );
     default:

--- a/gulp/src/common/ui/TextField.jsx
+++ b/gulp/src/common/ui/TextField.jsx
@@ -4,7 +4,21 @@ import React from 'react';
  * Simple input element with onChange handler
  */
 function TextField(props) {
-  const {name, onChange, required, maxLength, value, isHidden, placeholder, autoFocus, onFocus, className, onBlur} = props;
+  const {
+    name,
+    onChange,
+    required,
+    maxLength,
+    value,
+    isHidden,
+    placeholder,
+    autoFocus,
+    onFocus,
+    className,
+    onBlur,
+    disable,
+  } = props;
+
   return (
     <span className="react-component">
       <input
@@ -21,6 +35,7 @@ function TextField(props) {
         onChange={onChange}
         autoFocus={autoFocus}
         onFocus={onFocus}
+        disabled={disable}
         onBlur={onBlur}
         />
     </span>
@@ -71,6 +86,10 @@ TextField.propTypes = {
    * What happens onBlur?
    */
   onBlur: React.PropTypes.func,
+  /**
+   * Disable this control
+   */
+  disable: React.PropTypes.bool,
   /**
    * Classes
    */

--- a/gulp/src/common/ui/Textarea.jsx
+++ b/gulp/src/common/ui/Textarea.jsx
@@ -4,7 +4,17 @@ import React from 'react';
  * Simple Textarea element with onChange handler
  */
 function Textarea(props) {
-  const {name, onChange, required, initial, isHidden, placeholder, autoFocus} = props;
+  const {
+    name,
+    onChange,
+    required,
+    initial,
+    isHidden,
+    placeholder,
+    autoFocus,
+    disable,
+  } = props;
+
   return (
     <textarea
       defaultValue={initial}
@@ -14,6 +24,7 @@ function Textarea(props) {
       hidden={isHidden}
       placeholder={placeholder}
       onChange={onChange}
+      disabled={disable}
       autoFocus={autoFocus}
       />
   );
@@ -47,6 +58,10 @@ Textarea.propTypes = {
    * Must this field have a value before submitting form?
    */
   required: React.PropTypes.bool,
+  /**
+   * Disable this control
+   */
+  disable: React.PropTypes.bool,
   /**
    * Should this bad boy focus, all auto like?
    */

--- a/gulp/src/nonuseroutreach/actions/process-outreach-actions.js
+++ b/gulp/src/nonuseroutreach/actions/process-outreach-actions.js
@@ -187,9 +187,7 @@ function omitErrors(obj) {
  */
 export function formatContact(contact) {
   if (contact.pk.value) {
-    return {
-      pk: contact.pk,
-    };
+    return contact;
   }
   return omitErrors({
     pk: {value: ''},

--- a/gulp/src/nonuseroutreach/components/OutreachCardContainer.jsx
+++ b/gulp/src/nonuseroutreach/components/OutreachCardContainer.jsx
@@ -28,17 +28,17 @@ class OutreachCardContainer extends Component {
     switch (type) {
     case 'contacts':
       return map(filter(stateObject, c => !isEmpty(c)),
-        (contact, i) => this.handleContact(contact, i));
+        (contact, i) => this.renderContact(contact, i));
     case 'partner':
-      return this.handlePartner(stateObject);
+      return this.renderPartner(stateObject);
     case 'communicationrecord':
-      return this.handleCommunicationRecord(stateObject);
+      return this.renderCommunicationRecord(stateObject);
     default:
       break;
     }
   }
 
-  handleContact(contact, index) {
+  renderContact(contact, index) {
     const {dispatch} = this.props;
 
     return (
@@ -54,7 +54,7 @@ class OutreachCardContainer extends Component {
     );
   }
 
-  handlePartner(partner) {
+  renderPartner(partner) {
     const {dispatch} = this.props;
 
     return (
@@ -70,7 +70,7 @@ class OutreachCardContainer extends Component {
     );
   }
 
-  handleCommunicationRecord() {
+  renderCommunicationRecord() {
     const {dispatch, communicationrecord} = this.props;
 
     return (

--- a/gulp/src/nonuseroutreach/components/OutreachCardContainer.jsx
+++ b/gulp/src/nonuseroutreach/components/OutreachCardContainer.jsx
@@ -18,7 +18,7 @@ class OutreachCardContainer extends Component {
     const {dispatch, partner} = this.props;
 
     if (!get(partner, 'pk.value')) {
-      dispatch(editPartnerAction())
+      dispatch(editPartnerAction());
     }
   }
 

--- a/gulp/src/nonuseroutreach/components/OutreachCardContainer.jsx
+++ b/gulp/src/nonuseroutreach/components/OutreachCardContainer.jsx
@@ -14,6 +14,14 @@ import {
 
 
 class OutreachCardContainer extends Component {
+  handlePartnerNav() {
+    const {dispatch, partner} = this.props;
+
+    if (!get(partner, 'pk.value')) {
+      dispatch(editPartnerAction())
+    }
+  }
+
   propsToCards() {
     const cardsReturn = [];
     for (const key in this.props) {
@@ -62,7 +70,7 @@ class OutreachCardContainer extends Component {
         key="partner"
         type="partner"
         displayText={get(partner, 'name.value')}
-        onNav={() => dispatch(editPartnerAction())}
+        onNav={() => this.handlePartnerNav()}
         onDel={() => {
           dispatch(deletePartnerAction());
           dispatch(determineProcessStateAction());

--- a/gulp/src/nonuseroutreach/components/ProcessRecordPage.jsx
+++ b/gulp/src/nonuseroutreach/components/ProcessRecordPage.jsx
@@ -11,6 +11,7 @@ import {get} from 'lodash-compat/object';
 import {
   partnerForm,
   contactForm,
+  contactNotesOnlyForm,
   communicationRecordForm,
 } from 'nonuseroutreach/forms';
 
@@ -174,6 +175,23 @@ class ProcessRecordPage extends Component {
     );
   }
 
+  renderAppendContactNotes() {
+    const {dispatch, contactIndex, contactFormsContents} = this.props;
+    const contactFormContents = contactFormsContents[contactIndex] || {};
+
+    return (
+      <Form
+        form={contactNotesOnlyForm}
+        title="Contact Details"
+        submitTitle="Add Contact"
+        formContents={contactFormContents}
+        onEdit={(n, v) =>
+          dispatch(editFormAction('contacts', n, v, contactIndex))}
+        onSubmit={() => this.handleSaveContact()}
+        />
+    );
+  }
+
   renderSelectWorkflow() {
     const {dispatch,
       workflowState,
@@ -216,6 +234,8 @@ class ProcessRecordPage extends Component {
       contents = this.renderNewPartner();
     } else if (processState === 'NEW_CONTACT') {
       contents = this.renderNewContact();
+    } else if (processState === 'CONTACT_APPEND') {
+      contents = this.renderAppendContactNotes();
     } else if (processState === 'SELECT_WORKFLOW_STATE') {
       contents = this.renderSelectWorkflow();
     }

--- a/gulp/src/nonuseroutreach/forms.js
+++ b/gulp/src/nonuseroutreach/forms.js
@@ -431,7 +431,6 @@ export const contactNotesOnlyForm = {
   fields: mapValues(contactForm.fields, (f, key) =>
     key === 'notes' ? f : readonlyField(f)),
 };
-console.log('contactNotesOnlyForm', contactNotesOnlyForm);
 
 export const communicationRecordForm = {
   fields: {

--- a/gulp/src/nonuseroutreach/forms.js
+++ b/gulp/src/nonuseroutreach/forms.js
@@ -1,3 +1,5 @@
+import {mapValues} from 'lodash-compat';
+
 const communicationTypes = [
   {display: 'Email', value: 'email'},
   {display: 'Phone', value: 'phone'},
@@ -416,6 +418,20 @@ export const contactForm = {
     'notes',
   ],
 };
+
+function readonlyField(field) {
+  return {
+    ...field,
+    readonly: true,
+  };
+}
+
+export const contactNotesOnlyForm = {
+  ...contactForm,
+  fields: mapValues(contactForm.fields, (f, key) =>
+    key === 'notes' ? f : readonlyField(f)),
+};
+console.log('contactNotesOnlyForm', contactNotesOnlyForm);
 
 export const communicationRecordForm = {
   fields: {

--- a/gulp/src/nonuseroutreach/reducers/process-outreach-reducer.js
+++ b/gulp/src/nonuseroutreach/reducers/process-outreach-reducer.js
@@ -142,12 +142,6 @@ export default handleActions({
   },
 
   'NUO_EDIT_PARTNER': (state) => {
-    if (get(state, 'record.partner.pk')) {
-      return {
-        ...state,
-        state: 'SELECT_PARTNER',
-      };
-    }
     return {
       ...state,
       state: 'NEW_PARTNER',

--- a/gulp/src/nonuseroutreach/reducers/process-outreach-reducer.js
+++ b/gulp/src/nonuseroutreach/reducers/process-outreach-reducer.js
@@ -17,6 +17,7 @@ const defaultState = {
  *    NEW_PARTNER: the user is editing a new partner
  *    SELECT_CONTACT: the user is selecting a contact AFTER selecting a partner
  *    NEW_CONTACT: the user is editng a new contact
+ *    CONTACT_APPEND: the user is adding notes to an existing contact
  *    NEW_COMMUNICATIONRECORD: the user is editing the new record
  *    SELECT_WORKFLOW_STATE: the user is picking the new workflow state
  *
@@ -156,15 +157,14 @@ export default handleActions({
   'NUO_EDIT_CONTACT': (state, action) => {
     const {contactIndex} = action.payload;
 
-    const pk = get(state, `record.contact.${contactIndex}.pk`);
-    const newState = pk ? 'SELECT_CONTACT' : 'NEW_CONTACT';
+    const pk = get(state, `record.contacts[${contactIndex}].pk.value`);
+    const newState = pk ? 'CONTACT_APPEND' : 'NEW_CONTACT';
     return {
       ...state,
       state: newState,
       contactIndex,
     };
   },
-
 
   'NUO_EDIT_COMMUNICATIONRECORD': (state) => {
     return {

--- a/gulp/src/nonuseroutreach/spec/process-outreach-actions-spec.js
+++ b/gulp/src/nonuseroutreach/spec/process-outreach-actions-spec.js
@@ -163,12 +163,12 @@ describe('formatContact', () => {
     });
   });
 
-  it('leaves out location when linking', () => {
+  it('does not introduce a location key when linking', () => {
     const contact = {
       pk: {value: 333},
       name: {value: 'a'},
     };
-    expect(formatContact(contact)).toDiffEqual({pk: {value: 333}});
+    expect(formatContact(contact)).toDiffEqual(contact);
   });
 });
 

--- a/gulp/src/nonuseroutreach/spec/process-outreach-reducer-spec.js
+++ b/gulp/src/nonuseroutreach/spec/process-outreach-reducer-spec.js
@@ -229,7 +229,7 @@ describe('handling editContactAction', () => {
   describe('when there is no pk', () => {
     const result = reducer({}, editContactAction(3));
 
-    it('should switch state to new if there is no pk', () => {
+    it('should switch state', () => {
       expect(result.state).toEqual('NEW_CONTACT');
     });
 
@@ -238,15 +238,15 @@ describe('handling editContactAction', () => {
     });
   });
 
-  describe('when there is no pk', () => {
+  describe('when there is a pk', () => {
     const result = reducer({
       record: {
-        contact: [{pk: 3}],
+        contacts: [{pk: {value: 3}}],
       },
     }, editContactAction(0));
 
-    it('should switch state to select if there is a pk', () => {
-      expect(result.state).toEqual('SELECT_CONTACT');
+    it('should switch state', () => {
+      expect(result.state).toEqual('CONTACT_APPEND');
     });
 
     it('should set the contact index', () => {

--- a/gulp/src/nonuseroutreach/spec/process-outreach-reducer-spec.js
+++ b/gulp/src/nonuseroutreach/spec/process-outreach-reducer-spec.js
@@ -210,18 +210,9 @@ describe('handling noteFormsAction', () => {
 });
 
 describe('handling editPartnerAction', () => {
-  it('should switch state to new if there is no pk', () => {
+  it('should switch state to new', () => {
     const result = reducer({}, editPartnerAction());
     expect(result.state).toEqual('NEW_PARTNER');
-  });
-
-  it('should switch state to select if there is a pk', () => {
-    const result = reducer({
-      record: {
-        partner: {pk: 3},
-      },
-    }, editPartnerAction());
-    expect(result.state).toEqual('SELECT_PARTNER');
   });
 });
 


### PR DESCRIPTION
Show a special append notes only form when clicking an existing contact mini card.

## Test

1. Select an existing partner and contact. You should be at the communication record form.
2. Click on the contact's mini-card.
3. See the new append-notes-only form.