### PR TITLE
[PD-2578] Make initial contact select work right

### DIFF
--- a/gulp/src/nonuseroutreach/api.js
+++ b/gulp/src/nonuseroutreach/api.js
@@ -60,7 +60,11 @@ export default class Api {
         ...extraParams,
         'q': searchString,
       });
-    return map(results, r => ({value: r.id, display: r.name}));
+    return map(results, r => ({
+      value: r.id,
+      display: r.name,
+      partner: r.partner,
+    }));
   }
 
   async getOutreach(outreachId) {

--- a/gulp/src/nonuseroutreach/components/ProcessRecordPage.jsx
+++ b/gulp/src/nonuseroutreach/components/ProcessRecordPage.jsx
@@ -32,9 +32,12 @@ class ProcessRecordPage extends Component {
     dispatch(determineProcessStateAction());
   }
 
-  async handleChooseContact(obj) {
+  async handleChooseContact(obj, addPartner) {
     const {dispatch} = this.props;
 
+    if (addPartner) {
+      dispatch(choosePartnerAction(obj.partner.pk, obj.partner.name));
+    }
     dispatch(chooseContactAction(obj.value, obj.display));
     dispatch(determineProcessStateAction());
   }
@@ -100,7 +103,7 @@ class ProcessRecordPage extends Component {
         <FieldWrapper label="Contact Search">
           <SearchDrop
             instance="CONTACT"
-            onSelect={obj => this.handleChooseContact(obj)}/>
+            onSelect={obj => this.handleChooseContact(obj, true)}/>
         </FieldWrapper>
       </div>,
     ]));
@@ -115,7 +118,7 @@ class ProcessRecordPage extends Component {
           <SearchDrop
             instance="CONTACT"
             extraParams={{partner_id: partnerId}}
-            onSelect={obj => this.handleChooseContact(obj)}
+            onSelect={obj => this.handleChooseContact(obj, false)}
             onAdd={obj => this.handleNewContact(obj)}
             />
         </FieldWrapper>

--- a/gulp/src/nonuseroutreach/components/SearchDrop.jsx
+++ b/gulp/src/nonuseroutreach/components/SearchDrop.jsx
@@ -160,6 +160,9 @@ export default class SearchDrop extends Component {
               {typeof result.count !== 'undefined' ?
                 <span className="partner-count">({result.count} contact{result.count === 1 ? '' : 's'})</span>
                 : ''}
+              {result.partner ?
+                <span className="partner-count">({result.partner.name})</span>
+                : ''}
               {result.display}
             </li>
           ))}

--- a/mypartners/tests/test_api.py
+++ b/mypartners/tests/test_api.py
@@ -706,6 +706,8 @@ class PRMAPITestCase(MyPartnersTestCase):
         response = self.client.get(reverse('api_get_contacts'))
         payload = json.loads(response.content)
         self.assertEqual(len(payload), new_contacts + 1)
+        self.assertEqual(self.partner.pk, payload[1]['partner']['pk'])
+        self.assertEqual(self.partner.name, payload[1]['partner']['name'])
 
     def test_search_contact_by_q(self):
         """


### PR DESCRIPTION
## Test

1. Select a contact on the initial screen.
2. Observe the contact and partner selected in the minicards area.
3. Refresh.
4. Select a partner and contact separately.
5. Hopefully note the lack of any regressions.

Also note some ugly CSS. Maybe @huy-nguyen-colorado can fix that on another ticket?