### PR TITLE
[PD-2575] added redirect to 'Records' view when the Submit button in t…

### DIFF
--- a/gulp/src/nonuseroutreach/actions/process-outreach-actions.js
+++ b/gulp/src/nonuseroutreach/actions/process-outreach-actions.js
@@ -172,7 +172,7 @@ export function extractErrorObject(fieldArray) {
 /**
  * Submit data to create a communication record.
  */
-export function doSubmit(validateOnly) {
+export function doSubmit(validateOnly, onSuccess) {
   return async (dispatch, getState, {api}) => {
     try {
       const process = getState().process;
@@ -205,7 +205,9 @@ export function doSubmit(validateOnly) {
         contactrecord: record.communicationrecord,
       };
       await api.submitContactRecord(request, validateOnly);
-      // TODO: do something with response.
+      if (!validateOnly && onSuccess) {
+        onSuccess();
+      }
     } catch (e) {
       if (e.data) {
         const formErrors = e.data.form_errors;

--- a/gulp/src/nonuseroutreach/components/ProcessRecordPage.jsx
+++ b/gulp/src/nonuseroutreach/components/ProcessRecordPage.jsx
@@ -75,7 +75,7 @@ class ProcessRecordPage extends Component {
   async handleSubmit() {
     const {dispatch} = this.props;
 
-    await dispatch(doSubmit());
+    await dispatch(doSubmit(false, () => history.pushState(null, '/records')));
   }
 
   renderCard(title, children) {

--- a/gulp/src/nonuseroutreach/components/ProcessRecordPage.jsx
+++ b/gulp/src/nonuseroutreach/components/ProcessRecordPage.jsx
@@ -73,7 +73,7 @@ class ProcessRecordPage extends Component {
   }
 
   async handleSubmit() {
-    const {dispatch} = this.props;
+    const {dispatch, history} = this.props;
 
     await dispatch(doSubmit(false, () => history.pushState(null, '/records')));
   }
@@ -236,6 +236,7 @@ class ProcessRecordPage extends Component {
 
 ProcessRecordPage.propTypes = {
   dispatch: PropTypes.func.isRequired,
+  history: PropTypes.object.isRequired,
   outreachId: PropTypes.string.isRequired,
   processState: PropTypes.string.isRequired,
   partnerName: PropTypes.string,

--- a/mypartners/views.py
+++ b/mypartners/views.py
@@ -2156,7 +2156,7 @@ def api_convert_outreach_record(request):
     outreach_record.current_workflow_state = workflow_status
     outreach_record.save()
 
-    return HttpResponse("success")
+    return HttpResponse('"success"')
 
 @requires('read tag')
 def tag_names(request):


### PR DESCRIPTION
Added redirect to 'Records' view when the Submit button in the Card component is triggered.

Test:
1. From the "Beta" option in the top navigation, click the "Non-User Outreach" from the drop down.
2. Click on the "Outreach Records" option from the right navigation.
3. Click on the "Review" button in the Email data table.
4. Type a legitimate value in the "Partner Organization" input box.
5. Type a legitimate value in the "Contact Search" input box.
6. In the "Communication Record" view, please enter a value for "Communication Type" and "Date & Time", which should be "2016-1-1", then click the "Add Record" button.
7. In the "Form Ready for Submission" view, please select a "Workflow Status" in the drop down, then click the "Submit" button, this will take you back to the Email data table. 
8.  If the functionality is correct, then the "Status" value will change to whatever value was selected in the previous step.
