### PR TITLE
[PD-2577] More reliable form validation.

### DIFF
--- a/gulp/src/common/spec/diff-equal.js
+++ b/gulp/src/common/spec/diff-equal.js
@@ -20,7 +20,18 @@ function toDiffEqual(util, customEqualityTesters) {
         if (typeof object === 'undefined') {
           return 'undefined';
         }
-        return JSON.stringify(object, null, 2);
+        // JSON.stringify censors keys with undefined values by default.
+        // This behavior results in isEqual returning false, but the json
+        // diff not having any differences. This function puts a placeholder
+        // string in those keys.
+        function replacer(key, value) {
+          if (typeof value === 'undefined') {
+            return '--undefined--';
+          } else {
+            return value;
+          }
+        }
+        return JSON.stringify(object, replacer, 2);
       }
 
       const expectedString = stringify(expected);

--- a/gulp/src/nonuseroutreach/actions/process-outreach-actions.js
+++ b/gulp/src/nonuseroutreach/actions/process-outreach-actions.js
@@ -7,6 +7,8 @@ import {
   omit,
   mapValues,
   isPlainObject,
+  isEmpty,
+  isUndefined,
 } from 'lodash-compat';
 
 /**
@@ -178,8 +180,11 @@ export function extractErrorObject(fieldArray) {
 /**
  * Return object with the "errors" key removed.
  */
-function omitErrors(obj) {
-  return mapValues(obj, v => isPlainObject(v) ? omit(v, 'errors') : v);
+function withoutEmptyValuesOrErrors(obj) {
+  const withoutErrors =
+    mapValues(obj, v => isPlainObject(v) ? omit(v, 'errors') : v);
+  return omit(withoutErrors, o =>
+    isPlainObject(o) && isEmpty(o) || isUndefined(o));
 }
 
 /**
@@ -191,12 +196,12 @@ export function formatContact(contact) {
       pk: contact.pk,
     };
   }
-  return omitErrors({
+  return withoutEmptyValuesOrErrors({
     pk: {value: ''},
     name: contact.name,
     email: contact.email,
     phone: contact.phone,
-    location: omitErrors({
+    location: withoutEmptyValuesOrErrors({
       pk: {value: ''},
       address_line_one: contact.address_line_one,
       address_line_two: contact.address_line_two,
@@ -251,10 +256,10 @@ export function formsFromApi(forms) {
  */
 export function formsToApi(forms) {
   return {
-    outreachrecord: omitErrors({...forms.outreachrecord}),
-    partner: omitErrors({...forms.partner}),
+    outreachrecord: withoutEmptyValuesOrErrors({...forms.outreachrecord}),
+    partner: withoutEmptyValuesOrErrors({...forms.partner}),
     contacts: map(forms.contacts, c => formatContact(c)),
-    contactrecord: omitErrors({...forms.communicationrecord}),
+    contactrecord: withoutEmptyValuesOrErrors({...forms.communicationrecord}),
   };
 }
 

--- a/gulp/src/nonuseroutreach/spec/process-outreach-actions-spec.js
+++ b/gulp/src/nonuseroutreach/spec/process-outreach-actions-spec.js
@@ -334,6 +334,49 @@ describe('formsToApi', () => {
     });
   });
 
+  it('removes empty value objects', () => {
+    const flatContact = {
+      pk: {value: ''},
+      name: {value: 'a', errors: ['a']},
+      email: {value: 'e'},
+      city: {errors: ['a']},
+      state: {errors: ['b']},
+      notes: {value: 'n'},
+    };
+    const hasErrors = {
+      name: {
+        value: 'someone',
+        errors: ['b'],
+      },
+    };
+    const input = {
+      partner: hasErrors,
+      contacts: [flatContact, flatContact],
+      outreachrecord: hasErrors,
+      communicationrecord: hasErrors,
+    };
+    const output = formsToApi(input);
+    const contact = {
+      pk: {value: ''},
+      name: {value: 'a'},
+      email: {value: 'e'},
+      location: {
+        pk: {value: ''},
+      },
+      tags: [],
+      notes: {value: 'n'},
+    };
+    const noErrors = {
+      name: {value: 'someone'},
+    };
+    expect(output).toDiffEqual({
+      outreachrecord: noErrors,
+      partner: noErrors,
+      contacts: [contact, contact],
+      contactrecord: noErrors,
+    });
+  })
+
   it('renames commrec', () => {
     const input = {
       communicationrecord: {1: 2},


### PR DESCRIPTION
Before this it was possible to submit an empty city or state in a contact, which was being recorded as '{}'. That was bad.

## Test

1. Select Partner
2. Create a new contact.
3. Click 'add contact'.
4. Click the contact mini card.
5. See the errors on city/state.
6. Click 'add contact' again.
7. Click the contact mini card again.
8. See the errors on city/state are still there.