### PR TITLE
[PD-2579] fix overlapping text

### DIFF
--- a/static/custom.css
+++ b/static/custom.css
@@ -623,7 +623,7 @@ h1 > small > a:hover {
     display:block;
     background-color: #DDDDDD;
 	padding: 8px 8px;
-	margin: 8px; 8px;
+	margin: 8px 8px;
 	border: 0 none;
 	border-radius: 3px;
 	cursor: pointer;
@@ -632,7 +632,7 @@ h1 > small > a:hover {
 .list-result {
     overflow: hidden;
     text-overflow: ellipsis;
-    white-space: nowrap;
+    white-space: normal;
 }
 
 .sidebar {

--- a/static/custom.css
+++ b/static/custom.css
@@ -1,5 +1,4 @@
 
-
 /*Document level classes*/
 
 .topbar h3 a {


### PR DESCRIPTION
Test:

1.  From Beta tab in top nav, click "Non-User Outreach".
2. Click "Outreach Records" in right nav.
3. Click "Review" button in the data table.
4. Type "a", or any character you wish, in the "Contact Search" input box.
5. Observe that text no longer overlap for long names, hopefully :-)