### PR TITLE
[PD - 2589] Browser back button confirm pop up 

### DIFF
--- a/gulp/src/nonuseroutreach/components/NonUserOutreachApp.jsx
+++ b/gulp/src/nonuseroutreach/components/NonUserOutreachApp.jsx
@@ -28,6 +28,17 @@ class NonUserOutreachApp extends Component {
 
   componentWillUnmount() {
     this.unsubscribeToHistory();
+    this.unsubscribeToListenBefore();
+  }
+
+  async handleBeforeListen(_location, cb) {
+    if (this.preventHistory) {
+      const {dispatch} = this.props;
+      const message = 'Are you sure you want to leave this page?';
+      cb(await runConfirmInPlace(dispatch, message));
+    } else {
+      cb(true);
+    }
   }
 
   async handleNewLocation(_, loc) {

--- a/gulp/src/nonuseroutreach/components/NonUserOutreachApp.jsx
+++ b/gulp/src/nonuseroutreach/components/NonUserOutreachApp.jsx
@@ -34,7 +34,7 @@ class NonUserOutreachApp extends Component {
   async handleBeforeListen(_location, cb) {
     if (this.preventHistory) {
       const {dispatch} = this.props;
-      const message = 'All form data will be lost if you navigate away form this page!';
+      const message = 'All your information will be lost if you navigate away from this page.';
       cb(await runConfirmInPlace(dispatch, message));
     } else {
       cb(true);

--- a/gulp/src/nonuseroutreach/components/NonUserOutreachApp.jsx
+++ b/gulp/src/nonuseroutreach/components/NonUserOutreachApp.jsx
@@ -40,7 +40,7 @@ class NonUserOutreachApp extends Component {
   async handleBeforeListen(_location, cb) {
     if (this.preventHistory) {
       const {dispatch} = this.props;
-      const message = 'All of your information will be lost if you navigate away from this page!';
+      const message = 'All of your information will be lost if you navigate away from this page.';
       cb(await runConfirmInPlace(dispatch, message));
     } else {
       cb(true);

--- a/gulp/src/nonuseroutreach/components/NonUserOutreachApp.jsx
+++ b/gulp/src/nonuseroutreach/components/NonUserOutreachApp.jsx
@@ -34,7 +34,7 @@ class NonUserOutreachApp extends Component {
   async handleBeforeListen(_location, cb) {
     if (this.preventHistory) {
       const {dispatch} = this.props;
-      const message = 'Are you sure you want to leave this page?';
+      const message = 'All form data will be lost if you navigate away form this page!';
       cb(await runConfirmInPlace(dispatch, message));
     } else {
       cb(true);

--- a/gulp/src/nonuseroutreach/components/NonUserOutreachApp.jsx
+++ b/gulp/src/nonuseroutreach/components/NonUserOutreachApp.jsx
@@ -13,6 +13,7 @@ import {doGetRecords} from '../actions/record-actions';
 import {doLoadEmail} from '../actions/process-outreach-actions';
 import {setPageAction, doGetWorkflowStateChoices} from '../actions/navigation-actions';
 import Confirm from 'common/ui/Confirm';
+import {runConfirmInPlace} from 'common/actions/confirm-actions';
 
 /* NonUserOutreachApp
  * An app for managing nonuser outreach, providing a sidebar for navigation and
@@ -24,6 +25,11 @@ class NonUserOutreachApp extends Component {
     const {history} = this.props;
     this.unsubscribeToHistory = history.listen(
       (...args) => this.handleNewLocation(...args));
+
+    this.unsubscribeToListenBefore = history.listenBefore(
+      (location, cb) => {
+        this.handleBeforeListen(location, cb);
+      });
   }
 
   componentWillUnmount() {
@@ -34,7 +40,7 @@ class NonUserOutreachApp extends Component {
   async handleBeforeListen(_location, cb) {
     if (this.preventHistory) {
       const {dispatch} = this.props;
-      const message = 'All your information will be lost if you navigate away from this page.';
+      const message = 'All of your information will be lost if you navigate away from this page!';
       cb(await runConfirmInPlace(dispatch, message));
     } else {
       cb(true);
@@ -47,7 +53,7 @@ class NonUserOutreachApp extends Component {
       return;
     }
     const lastComponent = loc.components[loc.components.length - 1];
-
+    this.preventHistory = false;
     if (lastComponent === InboxManagementPage) {
       // update the application's state with the current page and refresh the
       // list of inboxes
@@ -68,6 +74,7 @@ class NonUserOutreachApp extends Component {
     } else if (lastComponent === ProcessRecordPage) {
       // update the application's state with the current page and refresh the
       // email
+      this.preventHistory = true;
       const recordId = loc.location.query.id;
       dispatch(markPageLoadingAction(true));
       await dispatch(doLoadEmail(recordId));


### PR DESCRIPTION
To test:
In NUO > Outreach Records > Review button > "Partner Data" form, click on the browser's back button and our modal will pop up with the text "All of your information will be lost if you navigate away from this page.", click OK to leave or Cancel to stay on view.