### PR TITLE
[PD-2611] Multiple Communication Records

### DIFF
--- a/mypartners/models.py
+++ b/mypartners/models.py
@@ -703,6 +703,25 @@ class ContactRecord(ArchivedModel):
 
         super(ContactRecord, self).save(*args, **kwargs)
 
+    def recreate(self):
+        """
+        Becomes a new copy of the original record.
+
+        returns a reference to the original record.
+        """
+        original_record = ContactRecord.objects.get(pk=self.pk)
+        self.pk = None
+
+        new_status = self.approval_status
+        new_status.pk = None
+        new_status.save()
+        self.approval_status = new_status
+
+        self.save()
+        self.tags.add(*original_record.tags.all())
+
+        return original_record
+
     def get_record_description(self):
         """
         Generates a human readable description of the contact

--- a/mypartners/tests/test_api.py
+++ b/mypartners/tests/test_api.py
@@ -221,7 +221,7 @@ class NUOConversionAPITestCase(MyPartnersTestCase):
                                                      self.inbox)
         self.role.activities.add(*self.activities)
         self.outreach_workflow = OutreachWorkflowStateFactory()
-        a_tag = TagFactory(company=self.company)
+        a_tag = TagFactory(name='Tag A', company=self.company)
         self.request_data = {
             "data": {
                 "outreach_record": {
@@ -268,7 +268,7 @@ class NUOConversionAPITestCase(MyPartnersTestCase):
                     "job_applications": "20",
                     "job_interviews": "10",
                     "job_hires": "0",
-                    "tags": [],
+                    "tags": [a_tag.pk],
                 }
             }
         }
@@ -306,6 +306,9 @@ class NUOConversionAPITestCase(MyPartnersTestCase):
         communication_record1 = ContactRecord.objects.get(
             notes="dude was chill", contact=self.contact)
         self.assert_has_tag('SOMENEWTAG', partner)
+        self.assert_has_tag('Tag A', partner)
+        self.assert_has_tag('Tag A', communication_record0)
+        self.assert_has_tag('Tag A', communication_record1)
         self.assert_has_tag('Tag 2', communication_record0)
         self.assert_has_tag('Tag 2', communication_record1)
         self.assert_has_tag('SOMENEWTAG', self.contact)

--- a/mypartners/tests/test_api.py
+++ b/mypartners/tests/test_api.py
@@ -284,7 +284,7 @@ class NUOConversionAPITestCase(MyPartnersTestCase):
             reverse('api_convert_outreach_record'),
             data = {'request': json.dumps(self.request_data)}
         )
-        self.check_status_code_and_objects(response, 200, 7)
+        self.check_status_code_and_objects(response, 200, 8)
 
     def test_create_tag(self):
         """
@@ -298,13 +298,16 @@ class NUOConversionAPITestCase(MyPartnersTestCase):
             reverse('api_convert_outreach_record'),
             data={'request': json.dumps(self.request_data)}
         )
-        self.check_status_code_and_objects(response, 200, 7)
+        self.check_status_code_and_objects(response, 200, 8)
         partner = Partner.objects.get(name="James B")
         contact0 = Contact.objects.get(name="Nicole J")
-        communication_record = ContactRecord.objects.get(
-            notes="dude was chill")
+        communication_record0 = ContactRecord.objects.get(
+            notes="dude was chill", contact=contact0)
+        communication_record1 = ContactRecord.objects.get(
+            notes="dude was chill", contact=self.contact)
         self.assert_has_tag('SOMENEWTAG', partner)
-        self.assert_has_tag('Tag 2', communication_record)
+        self.assert_has_tag('Tag 2', communication_record0)
+        self.assert_has_tag('Tag 2', communication_record1)
         self.assert_has_tag('SOMENEWTAG', self.contact)
         self.assert_has_tag('SOMENEWTAG', contact0)
         self.assert_has_tag('Tag 2', contact0)
@@ -359,28 +362,13 @@ class NUOConversionAPITestCase(MyPartnersTestCase):
             data = {'request': json.dumps(self.request_data)}
         )
 
-        self.check_status_code_and_objects(response, 200, 6)
+        self.check_status_code_and_objects(response, 200, 7)
 
         dict_contact = Contact.objects.get(name="Nicole J")
         self.assertEqual(dict_contact.partner.pk, existing_partner.pk,
                          msg="New contact does not link to provided partner,"
                              "expected pk of %s, got %s" % (existing_partner.pk,
                                                             dict_contact.partner.pk))
-
-    def test_outreach_api_contact_location_by_pk(self):
-        """
-        Test that the outreach conversion API allows the member to add
-        locations via PK
-
-        """
-        existing_location = LocationFactory()
-        record = self.request_data['data']['contacts']
-        record[0]['location'] = {"pk": {'value': existing_location.pk}}
-        response = self.client.post(
-            reverse('api_convert_outreach_record'),
-            data = {'request': json.dumps(self.request_data)}
-        )
-        self.check_status_code_and_objects(response, 200, 7)
 
     def test_outreach_api_contact_append_notes(self):
         """
@@ -394,7 +382,7 @@ class NUOConversionAPITestCase(MyPartnersTestCase):
             reverse('api_convert_outreach_record'),
             data = {'request': json.dumps(self.request_data)}
         )
-        self.check_status_code_and_objects(response, 200, 7)
+        self.check_status_code_and_objects(response, 200, 8)
         self.contact = Contact.objects.get(id=self.contact.id)
         # This is how we wish this could be written. Can be fixed along with
         # PD-2602: universal.NormalizedModelForm removes all new lines
@@ -591,36 +579,46 @@ class NUOConversionAPITestCase(MyPartnersTestCase):
             'contact2',
             'contact2notes',
             'contact1location',
-            'contactrecord',
+            'contactrecord0',
+            'contactrecord1',
         ]
         objects_created = []
         partner = Partner.objects.filter(name="James B").first()
         contact1 = Contact.objects.filter(name="Nicole J").first()
         contact2 = Contact.objects.filter(id=self.contact.id).first()
-        contact_record = ContactRecord.objects.filter(notes="dude was chill").first()
-        if partner and (self.outreach_record.partners
-                                .filter(id=partner.id)
-                                .exists()):
+        contact_records = ContactRecord.objects.filter(
+            notes="dude was chill")
+        if partner and (
+                self.outreach_record.partners
+                .filter(id=partner.id)
+                .exists()):
             objects_created.append("partner")
-        if contact1 and (self.outreach_record.contacts
-                                .filter(id=contact1.id)
-                                .exists()):
+        if contact1 and (
+                self.outreach_record.contacts
+                .filter(id=contact1.id)
+                .exists()):
             objects_created.append("contact1")
             if contact1.notes == "long note left here":
                 objects_created.append("contact1notes")
             if contact1.locations.all().count() > 0:
                 objects_created.append("contact1location")
-        if contact2 and (self.outreach_record.contacts
-                                .filter(id=contact2.id)
-                                .exists()):
+        if contact2 and (
+                self.outreach_record.contacts
+                .filter(id=contact2.id)
+                .exists()):
             objects_created.append("contact2")
             if "new notes" in contact2.notes:
                 objects_created.append("contact2notes")
-        if contact_record and (self.outreach_record.communication_records
-                                .filter(id=contact_record.id)
-                                .exists()):
-            objects_created.append("contactrecord")
-        objects_missing = [x for x in total_objects if x not in objects_created]
+        for i, contact_record in enumerate(contact_records):
+            if (self.outreach_record.communication_records
+                    .filter(id=contact_record.id)
+                    .exists()):
+                objects_created.append("contactrecord%s" % i)
+        objects_missing = [
+            x
+            for x in total_objects
+            if x not in objects_created
+        ]
         return objects_created, objects_missing
 
 

--- a/mypartners/tests/test_api.py
+++ b/mypartners/tests/test_api.py
@@ -330,6 +330,17 @@ class NUOConversionAPITestCase(MyPartnersTestCase):
         )
         self.check_status_code_and_objects(response, 200, 0)
 
+        response_data = json.loads(response.content)
+        partner_name = response_data['forms']['partner']['data']['name']
+        self.assertEqual('James B', partner_name)
+        contact0_name = response_data['forms']['contacts'][0]['data']['name']
+        contact1_name = response_data['forms']['contacts'][1]['data']['name']
+        self.assertEqual('Nicole J', contact0_name)
+        self.assertEqual('foo bar', contact1_name)
+        communication_record_notes = (
+            response_data['forms']['communication_record']['data']['notes'])
+        self.assertEqual('dude was chill', communication_record_notes)
+
     def test_outreach_api_all_fields_required(self):
         """
         Test that the outreach conversion API forces the inbound data object

--- a/mypartners/views.py
+++ b/mypartners/views.py
@@ -2190,6 +2190,10 @@ def api_convert_outreach_record(request):
             contact_form_payload = merge_contact_forms(result, user_company)
             payload['forms']['contacts'].append(contact_form_payload)
         else:
+            if 'instance' in result:
+                contact = result['instance']
+            else:
+                contact = result['contact'].instance
             payload['forms']['contacts'].append({
                 'data': {'pk': contact.pk, 'name': contact.name}
             })

--- a/mypartners/views.py
+++ b/mypartners/views.py
@@ -2245,15 +2245,7 @@ def api_convert_outreach_record(request):
 
         # on subsequent passes, make new communication records for each contact
         if i > 0:
-            # This is super icky.
-            print '>>> 1', communication_record.pk
-            communication_record.pk = None
-            new_status = communication_record.approval_status
-            new_status.pk = None
-            new_status.save()
-            communication_record.approval_status = new_status
-            communication_record.save()
-            print '>>> 2', communication_record.pk
+            communication_record.recreate()
             attach_new_tags(
                 new_tags, created_tags, 'communicationrecord',
                 communication_record)
@@ -2263,7 +2255,6 @@ def api_convert_outreach_record(request):
         communication_record.contact = contact
         communication_record.partner = partner
         communication_record.save()
-        print '>>> 3', communication_record.pk, communication_record.contact
         outreach.communication_records.add(communication_record_form.instance)
         outreach.contacts.add(contact)
         if 'location' in contact_result:

--- a/mypartners/views.py
+++ b/mypartners/views.py
@@ -2242,11 +2242,28 @@ def api_convert_outreach_record(request):
             contact = contact_result['contact'].instance
         else:
             contact = contact_result['instance']
+
+        # on subsequent passes, make new communication records for each contact
+        if i > 0:
+            # This is super icky.
+            print '>>> 1', communication_record.pk
+            communication_record.pk = None
+            new_status = communication_record.approval_status
+            new_status.pk = None
+            new_status.save()
+            communication_record.approval_status = new_status
+            communication_record.save()
+            print '>>> 2', communication_record.pk
+            attach_new_tags(
+                new_tags, created_tags, 'communicationrecord',
+                communication_record)
+
         contact.partner = partner
         contact.save()
         communication_record.contact = contact
         communication_record.partner = partner
         communication_record.save()
+        print '>>> 3', communication_record.pk, communication_record.contact
         outreach.communication_records.add(communication_record_form.instance)
         outreach.contacts.add(contact)
         if 'location' in contact_result:


### PR DESCRIPTION
This fixes a number of bugs regarding writing records to the database.

## Test

1. Pick a partner and contact.
2. Add an additional contact.
3. Add tags to the communication record. Set a date that is recent.
3. Go to PRM and verify that 2 communication records have been created and all tags are present on all records.