### PR TITLE
[PD-2616] See New Partners in PRM

### DIFF
--- a/mypartners/tests/test_api.py
+++ b/mypartners/tests/test_api.py
@@ -604,7 +604,7 @@ class NUOConversionAPITestCase(MyPartnersTestCase):
             notes="dude was chill")
         if partner and (
                 self.outreach_record.partners
-                .filter(id=partner.id)
+                .filter(id=partner.id, owner=self.company)
                 .exists()):
             objects_created.append("partner")
         if contact1 and (

--- a/mypartners/views.py
+++ b/mypartners/views.py
@@ -2252,9 +2252,6 @@ def api_convert_outreach_record(request):
         # on subsequent passes, make new communication records for each contact
         if i > 0:
             communication_record.recreate()
-            attach_new_tags(
-                new_tags, created_tags, 'communicationrecord',
-                communication_record)
 
         contact.partner = partner
         contact.save()

--- a/mypartners/views.py
+++ b/mypartners/views.py
@@ -2231,6 +2231,8 @@ def api_convert_outreach_record(request):
         partner_form.save()
         outreach.partners.add(partner_form.instance)
         partner = partner_form.instance
+        partner.owner = user_company
+        partner.save()
         attach_new_tags(new_tags, created_tags, 'partner', partner)
 
     if communication_record_form:


### PR DESCRIPTION
New partners weren't linked to the user's company and weren't showing up in PRM. This fixes that. Also, @tdphillips found that some new tag attachment code was redundant. That is fixed in this PR.

## Test

1. Create a new partner in NUO. Look for it in PRM.
2. In NUO create a new communication record with an existing tag and a new tag and attached to multiple contacts. (got all that?) Verify in PRM that the new and existing tags are on both communication records.

