### PR TITLE
Prevent history change only when we should.

### DIFF
--- a/gulp/src/nonuseroutreach/actions/process-outreach-actions.js
+++ b/gulp/src/nonuseroutreach/actions/process-outreach-actions.js
@@ -146,6 +146,11 @@ export function convertOutreach(record) {
 }
 
 /**
+ * We don't need to worry about the user losing work anymore.
+ */
+export const markCleanAction = createAction('NUO_MARK_CLEAN');
+
+/**
  * We have new form data from the API
  *
  * forms: new forms from the API
@@ -168,6 +173,7 @@ export function doLoadEmail(outreachId) {
           convertOutreach(outreach),
           forms));
       dispatch(editFormAction('outreach_record', 'pk', outreachId, null));
+      dispatch(markCleanAction());
     } catch (e) {
       dispatch(errorAction(e.message));
     }
@@ -230,6 +236,7 @@ export function doSubmit(validateOnly, onSuccess) {
       if (validateOnly) {
         dispatch(noteFormsAction(formsFromApi(response)));
       } else if (onSuccess) {
+        dispatch(markCleanAction());
         onSuccess();
       }
     } catch (e) {

--- a/gulp/src/nonuseroutreach/reducers/process-outreach-reducer.js
+++ b/gulp/src/nonuseroutreach/reducers/process-outreach-reducer.js
@@ -42,6 +42,7 @@ export function getErrorsForForms(forms, key) {
  *    contacts: [{ field contents for new contacts}]
  *    communication_record: field contents for record
  *  }
+ *  dirty: the user could lose work if they leave
  */
 export default handleActions({
   'NUO_RESET_PROCESS': (state, action) => {
@@ -107,6 +108,7 @@ export default handleActions({
 
     return {
       ...state,
+      dirty: true,
       record: {
         ...state.record,
         partner: {
@@ -122,6 +124,7 @@ export default handleActions({
 
     return {
       ...state,
+      dirty: true,
       forms: {
         ...state.forms,
         contacts: [
@@ -147,6 +150,7 @@ export default handleActions({
 
     const newState = {
       ...state,
+      dirty: true,
       state: 'NEW_PARTNER',
       forms: {
         ...state.forms,
@@ -174,6 +178,7 @@ export default handleActions({
 
     const newState = {
       ...state,
+      dirty: true,
       state: 'NEW_CONTACT',
       contactIndex: newIndex,
       forms: {
@@ -289,6 +294,7 @@ export default handleActions({
 
       return {
         ...state,
+        dirty: true,
         record: {
           ...state.record,
           [formName]: newFormSet,
@@ -300,6 +306,7 @@ export default handleActions({
 
     return {
       ...state,
+      dirty: true,
       record: {
         ...state.record,
         [formName]: {
@@ -307,6 +314,13 @@ export default handleActions({
           [field]: value,
         },
       },
+    };
+  },
+
+  'NUO_MARK_CLEAN': (state) => {
+    return {
+      ...state,
+      dirty: false,
     };
   },
 
@@ -373,24 +387,6 @@ export default handleActions({
       ...state,
       newTags: {
         ...remainingTags,
-      },
-    };
-  },
-
-  'NUO_ADD_PARTNER_TAG': (state, action) => {
-    const newTag = action.payload;
-
-    return {
-      ...state,
-      record: {
-        ...state.record,
-        partner: {
-          ...state.record.partner,
-          tags: {
-            ...state.record.partner.tags,
-            newTag,
-          },
-        },
       },
     };
   },

--- a/gulp/src/nonuseroutreach/spec/process-outreach-reducer-spec.js
+++ b/gulp/src/nonuseroutreach/spec/process-outreach-reducer-spec.js
@@ -14,6 +14,7 @@ import {
   deletePartnerAction,
   deleteContactAction,
   deleteCommunicationRecordAction,
+  markCleanAction,
 } from '../actions/process-outreach-actions';
 
 describe('processEmailReducer', () => {
@@ -36,6 +37,10 @@ describe('processEmailReducer', () => {
     it('should remember the given workflow blankForms', () => {
       expect(result.blankForms).toDiffEqual(blankForms);
     });
+
+    it('should be clean', () => {
+      expect(result.dirty).toBeFalsy();
+    });
   });
 
   describe('handling choosePartnerAction', () => {
@@ -50,6 +55,10 @@ describe('processEmailReducer', () => {
 
     it('should have the partner name', () => {
       expect(result.record.partner.name).toEqual('acme');
+    });
+
+    it('should be dirty', () => {
+      expect(result.dirty).toBeTruthy();
     });
   });
 
@@ -89,6 +98,10 @@ describe('processEmailReducer', () => {
     it('places a null placeholder in the forms', () => {
       expect(result.forms.contacts[0]).toBe(null);
     });
+
+    it('should be dirty', () => {
+      expect(result.dirty).toBeTruthy();
+    });
   });
 
   describe('handling newPartnerAction', () => {
@@ -119,6 +132,9 @@ describe('processEmailReducer', () => {
       expect(result.record.partner.name).toEqual('Partner Name Inc.');
     });
 
+    it('should be dirty', () => {
+      expect(result.dirty).toBeTruthy();
+    });
   });
 
   describe('handling newContactAction', () => {
@@ -155,6 +171,10 @@ describe('processEmailReducer', () => {
 
     it('keep the partner', () => {
       expect(result.record.partner).toEqual(state.record.partner);
+    });
+
+    it('should be dirty', () => {
+      expect(result.dirty).toBeTruthy();
     });
   });
 
@@ -194,6 +214,13 @@ describe('processEmailReducer', () => {
             a: 'b',
           },
         });
+      });
+
+      it('marks the process as dirty', () => {
+        const action = editFormAction('partner', 'name', 'Bob');
+        const result = reducer({}, action);
+
+        expect(result.dirty).toBeTruthy();
       });
     });
 
@@ -241,6 +268,21 @@ describe('processEmailReducer', () => {
           },
         });
       });
+
+      it('marks the process as dirty', () => {
+        const action = editFormAction('contacts', 'city', 'elsewhere2', 1);
+        const result = reducer({}, action);
+
+        expect(result.dirty).toBe(true);
+      });
+    });
+  });
+
+  describe('handling markCleanAction', () => {
+    const action = markCleanAction();
+    it('transitions from dirty to clean', () => {
+      const result = reducer({dirty: true}, action);
+      expect(result.dirty).toBeFalsy();
     });
   });
 });


### PR DESCRIPTION
Submitting the forms successfully was causing a _very_ confusing modal warning us that we would lose work. This adds dirty tracking to the process reducer so we do the right thing.

## Test

1. Start the workflow.
2. Hit back immediately.
3. Should not get a warning.
4. Start the workflow.
5. Choose a partner.
6. Should get a warning.
7. Complete the workflow.
8. Submit without errors.
9. Should not get a warning.