### PR TITLE
Fix for PD-2622

### DIFF
--- a/gulp/src/nonuseroutreach/actions/process-outreach-actions.js
+++ b/gulp/src/nonuseroutreach/actions/process-outreach-actions.js
@@ -161,13 +161,15 @@ export function doLoadEmail(outreachId) {
   return async (dispatch, getState, {api}) => {
     try {
       const outreach = await api.getOutreach(outreachId);
-      const forms = await api.getForms();
+      const forms = await api.getForms(outreachId);
 
       dispatch(
         resetProcessAction(
           convertOutreach(outreach),
           forms));
       dispatch(editFormAction('outreach_record', 'pk', outreachId, null));
+      dispatch(editFormAction('outreach_record', 'current_workflow_state',
+                              forms.outreach_record.data.current_workflow_state, null));
     } catch (e) {
       dispatch(errorAction(e.message));
     }

--- a/gulp/src/nonuseroutreach/api.js
+++ b/gulp/src/nonuseroutreach/api.js
@@ -76,8 +76,8 @@ export default class Api {
     return await this.api.get('/prm/api/partner/' + partnerId);
   }
 
-  async getForms() {
-    return await this.api.get('/prm/api/nonuseroutreach/forms');
+  async getForms(outreachId) {
+    return await this.api.get('/prm/api/nonuseroutreach/forms?outreachId=' + outreachId);
   }
 
   async submitContactRecord(request, validateOnly) {

--- a/gulp/src/nonuseroutreach/components/ProcessRecordPage.jsx
+++ b/gulp/src/nonuseroutreach/components/ProcessRecordPage.jsx
@@ -122,11 +122,12 @@ class ProcessRecordPage extends Component {
     dispatch(resetSearchOrAddAction('CONTACT'));
   }
 
-  handleChoosePartner(obj) {
+  async handleChoosePartner(obj) {
     const {dispatch} = this.props;
 
     dispatch(choosePartnerAction(obj.value, obj.display));
     this.resetSearches();
+    await(dispatch(doSubmit(true)));
     dispatch(determineProcessStateAction());
   }
 
@@ -138,6 +139,7 @@ class ProcessRecordPage extends Component {
     }
     dispatch(chooseContactAction(obj.value, obj.display));
     this.resetSearches();
+    await(dispatch(doSubmit(true)));
     dispatch(determineProcessStateAction());
   }
 

--- a/gulp/src/nonuseroutreach/reducers/process-outreach-reducer.js
+++ b/gulp/src/nonuseroutreach/reducers/process-outreach-reducer.js
@@ -56,6 +56,7 @@ export default handleActions({
       blankForms,
       forms: {
         contacts: [],
+        outreach_record: blankForms.outreach_record,
       },
       outreach,
     };

--- a/mypartners/tests/test_api.py
+++ b/mypartners/tests/test_api.py
@@ -195,7 +195,7 @@ class NonUserOutreachTestCase(MyPartnersTestCase):
         """
         tag = Tag.objects.create(company=self.company, name="This Tag")
 
-        response = self.client.get(reverse('api_get_nuo_forms'))
+        response = self.client.get(reverse('api_get_nuo_forms')+'?outreachId=%s' % self.outreach_record.pk)
         payload = json.loads(response.content)
         tag_displays = [
             t['display']

--- a/mypartners/views.py
+++ b/mypartners/views.py
@@ -1898,10 +1898,13 @@ def merge_contact_forms(contact_forms, company):
 @requires("convert outreach record")
 def api_get_nuo_forms(request):
     company = get_company_or_404(request)
+    outreach_pk = request.GET.get('outreachId', None)
+    outreach_instance = OutreachRecord.objects.get(pk=outreach_pk)
+
     forms = {
         'partner': NuoPartnerForm(company=company),
         'communication_record': NuoCommunicationRecordForm(company=company),
-        'outreach_record': NuoOutreachRecordForm(),
+        'outreach_record': NuoOutreachRecordForm(instance=outreach_instance),
     }
 
     payload = {


### PR DESCRIPTION
This populates the `outreach_record` form from the beginning to avoid error messages or missing form erros.