### PR TITLE
[PD-2620], scroll to the top of form if there is an error in the form

### DIFF
--- a/gulp/src/nonuseroutreach/actions/process-outreach-actions.js
+++ b/gulp/src/nonuseroutreach/actions/process-outreach-actions.js
@@ -247,6 +247,7 @@ export function doSubmit(validateOnly, onSuccess) {
         }
         if (e.data.forms) {
           dispatch(noteFormsAction(formsFromApi(e.data)));
+          document.body.scrollTop = document.documentElement.scrollTop = 0;
         }
       } else {
         dispatch(errorAction(e.message));

--- a/gulp/src/nonuseroutreach/actions/process-outreach-actions.js
+++ b/gulp/src/nonuseroutreach/actions/process-outreach-actions.js
@@ -226,17 +226,9 @@ function formsToApi(record, newTags) {
 }
 
 /**
- * On a form that is taller than the view window,
- * when there is a form error, scroll to the top.
- */
-function scrollToTop() {
-  document.body.scrollTop = document.documentElement.scrollTop = 0;
-}
-
-/**
  * Submit data to create a communication record.
  */
-export function doSubmit(validateOnly, onSuccess, onFormErrors) {
+export function doSubmit(validateOnly, onFormErrors, onSuccess) {
   return async (dispatch, getState, {api}) => {
     const process = getState().process;
     const forms = formsToApi(process.record, process.newTags);
@@ -255,7 +247,9 @@ export function doSubmit(validateOnly, onSuccess, onFormErrors) {
         }
         if (e.data.forms) {
           dispatch(noteFormsAction(formsFromApi(e.data)));
-          onFormErrors(scrollToTop());
+          if (onFormErrors) {
+            onFormErrors();
+          }
         }
       } else {
         dispatch(errorAction(e.message));

--- a/gulp/src/nonuseroutreach/actions/process-outreach-actions.js
+++ b/gulp/src/nonuseroutreach/actions/process-outreach-actions.js
@@ -226,9 +226,17 @@ function formsToApi(record, newTags) {
 }
 
 /**
+ * On a form that is taller than the view window,
+ * when there is a form error, scroll to the top.
+ */
+function scrollToTop() {
+  document.body.scrollTop = document.documentElement.scrollTop = 0;
+}
+
+/**
  * Submit data to create a communication record.
  */
-export function doSubmit(validateOnly, onSuccess) {
+export function doSubmit(validateOnly, onSuccess, onFormErrors) {
   return async (dispatch, getState, {api}) => {
     const process = getState().process;
     const forms = formsToApi(process.record, process.newTags);
@@ -247,7 +255,7 @@ export function doSubmit(validateOnly, onSuccess) {
         }
         if (e.data.forms) {
           dispatch(noteFormsAction(formsFromApi(e.data)));
-          document.body.scrollTop = document.documentElement.scrollTop = 0;
+          onFormErrors(scrollToTop());
         }
       } else {
         dispatch(errorAction(e.message));

--- a/gulp/src/nonuseroutreach/components/ProcessRecordPage.jsx
+++ b/gulp/src/nonuseroutreach/components/ProcessRecordPage.jsx
@@ -154,7 +154,7 @@ class ProcessRecordPage extends Component {
   async handleSavePartner() {
     const {dispatch} = this.props;
 
-    await dispatch(doSubmit(true));
+    await dispatch(doSubmit(true, () => this.scrollToTop()));
     this.resetSearches();
     dispatch(determineProcessStateAction());
   }
@@ -162,7 +162,7 @@ class ProcessRecordPage extends Component {
   async handleSaveContact() {
     const {dispatch} = this.props;
 
-    await dispatch(doSubmit(true));
+    await dispatch(doSubmit(true, () => this.scrollToTop()));
     this.resetSearches();
     dispatch(determineProcessStateAction());
   }
@@ -170,7 +170,7 @@ class ProcessRecordPage extends Component {
   async handleSaveCommunicationRecord() {
     const {dispatch} = this.props;
 
-    await dispatch(doSubmit(true));
+    await dispatch(doSubmit(true, () => this.scrollToTop()));
     this.resetSearches();
     dispatch(determineProcessStateAction());
   }
@@ -178,8 +178,12 @@ class ProcessRecordPage extends Component {
   async handleSubmit() {
     const {dispatch, history} = this.props;
     dispatch(cleanUpOrphanTags());
-    await dispatch(doSubmit(false, () => history.pushState(null, '/records')));
+    await dispatch(doSubmit(false, () => this.scrollToTop(), () => history.pushState(null, '/records')));
     this.resetSearches();
+  }
+
+  scrollToTop() {
+    document.body.scrollTop = document.documentElement.scrollTop = 0;
   }
 
   renderCard(title, children) {


### PR DESCRIPTION
To test:

In NUO > Communication Record, in the "Communication Type *" drop down, if you leave that drop down option to the default option of "------" and click on the "Add Record" button, the browser should return to the top of the page to show the end user where the error is.