### PR TITLE
[PD-2610] Replace HTTP with HTTPS for Redirect Links

### DIFF
--- a/mysearches/helpers.py
+++ b/mysearches/helpers.py
@@ -167,7 +167,7 @@ def parse_feed(feed_url, frequency='W', num_items=100, offset=0,
 
     # ensure we use https for any request to redirect
     feed_url = feed_url.replace('http://my.jobs', 'https://my.jobs')
-    
+
     if feed_url.find('?') > -1:
         separator = '&'
     else:

--- a/mysearches/helpers.py
+++ b/mysearches/helpers.py
@@ -164,6 +164,10 @@ def parse_feed(feed_url, frequency='W', num_items=100, offset=0,
                     Second index is the total job count
     """
     return_items = return_items or num_items
+
+    # ensure we use https for any request to redirect
+    feed_url = feed_url.replace('http://my.jobs', 'https://my.jobs')
+    
     if feed_url.find('?') > -1:
         separator = '&'
     else:

--- a/mysearches/templatetags/email_tags.py
+++ b/mysearches/templatetags/email_tags.py
@@ -35,7 +35,7 @@ def get_all_jobs_link(saved_search):
     """
     url = saved_search.url
 
-    if url.startswith('http://my.jobs'):
+    if url.startswith('http://my.jobs') or url.startswith('https://my.jobs'):
         feed = saved_search.feed
         if feed:
             url = feed.replace('/feed/rss', '')

--- a/redirect/middleware.py
+++ b/redirect/middleware.py
@@ -14,7 +14,7 @@ class MyJobsRedirectMiddleware(object):
         if host and not any(domain in host
                             for domain in settings.ALLOWED_HOSTS):
             return HttpResponsePermanentRedirect(
-                'http://my.jobs' + request.get_full_path())
+                'https://my.jobs' + request.get_full_path())
 
 
 class ExcludedViewSourceMiddleware:

--- a/redirect/models.py
+++ b/redirect/models.py
@@ -145,7 +145,7 @@ class BaseRedirect(models.Model):
         """Generates the redirected link for a redirect object."""
         # Handle the fact that guid is has leading/trailing braces and dashes.
         # '{XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX}'
-        return "http://my.jobs/%s" % self.guid[1:-1].replace('-', '') + '10'
+        return "https://my.jobs/%s" % self.guid[1:-1].replace('-', '') + '10'
 
 
 class Redirect(BaseRedirect):

--- a/redirect/templatetags/redirect_urls.py
+++ b/redirect/templatetags/redirect_urls.py
@@ -1,0 +1,14 @@
+from django import template
+
+register = template.Library()
+
+
+@register.filter
+def swap_http_with_https(url, arg=""):
+    """
+    swap http://<arg> with https://<arg>
+    :param url: url to check/swap
+    :param arg: additional argument string to increase specificity of match
+    :return: url with https (if applicable)
+    """
+    return url.replace("http://" + arg, "https://" + arg)

--- a/redirect/tests/test_middleware.py
+++ b/redirect/tests/test_middleware.py
@@ -20,4 +20,4 @@ class MyJobsMiddlewareTests(RedirectBase):
             request = self.factory.get(path,
                                        HTTP_HOST='jcnlx.com')
             response = self.middleware.process_request(request)
-            self.assertEqual(response['Location'], 'http://my.jobs' + path)
+            self.assertEqual(response['Location'], 'https://my.jobs' + path)

--- a/redirect/tests/test_views.py
+++ b/redirect/tests/test_views.py
@@ -1317,5 +1317,5 @@ class RedirectViewTests(RedirectBase):
         response = self.client.get(path,
                                    HTTP_HOST='my.jobs', follow=True)
         self.assertEqual(response['Location'],
-                         'http://my.jobs' + path.replace('%2B', '+'))
+                         'https://my.jobs' + path.replace('%2B', '+'))
         self.assertEqual(response.status_code, 301)

--- a/seo/tests/test_integration.py
+++ b/seo/tests/test_integration.py
@@ -125,7 +125,7 @@ class SiteTestCase(DirectSEOBase):
             resp = self.client.get(job['url'], HTTP_HOST=self.site.domain,
                                    follow=False)
             self.assertEqual(resp.status_code, 302)
-            expected = 'http://my.jobs/%s%d?my.jobs.site.id=%s' %\
+            expected = 'https://my.jobs/%s%d?my.jobs.site.id=%s' %\
                        (job['guid'],
                         settings.FEED_VIEW_SOURCES['json'],
                         str(self.site.pk))

--- a/seo/views/search_views.py
+++ b/seo/views/search_views.py
@@ -461,7 +461,8 @@ def job_detail_by_title_slug_job_id(request, job_id, title_slug=None,
             url = ''
             path = ''
         else:
-            url = urlparse(the_job.link)
+            url = urlparse(the_job.link.replace("http://my.jobs",
+                                                "https://my.jobs"))
             path = url.path.replace("/", "")
             # use the override view source
             if settings.VIEW_SOURCE and url.scheme != "mailto":
@@ -1864,7 +1865,7 @@ def urls_redirect(request, guid, vsid=None, debug=None):
     qs = QueryDict(request.META['QUERY_STRING'], mutable=True)
     qs['my.jobs.site.id'] = site.pk
     qs = qs.urlencode()
-    return HttpResponseRedirect('http://my.jobs/%s%s%s?%s' %
+    return HttpResponseRedirect('https://my.jobs/%s%s%s?%s' %
                                 (guid, vsid, debug, qs))
 
 

--- a/templates/job_detail.html
+++ b/templates/job_detail.html
@@ -1,6 +1,7 @@
 {% extends "seo_base.html" %}
 {% load i18n %}
 {% load seo_extras %}
+{% load redirect_urls %}
 {% block direct_extraHeaderContent %}
 <link rel="stylesheet" href="/style/def.ui.dotjobs.results.css" type="text/css">
 
@@ -79,7 +80,7 @@
         </div>
         <div class='direct-action-btn' id="direct_applyButtonBottom">
             {% if the_job.link %}
-            <a href="{{the_job.link}}" onclick="goalClick('/G/apply-click', this.href); return false;">{% blocktrans %}Apply Now{% endblocktrans %}</a>
+            <a href="{{the_job.link|swap_http_with_https:"my.jobs"}}" onclick="goalClick('/G/apply-click', this.href); return false;">{% blocktrans %}Apply Now{% endblocktrans %}</a>
             {% elif the_job.apply_info %}
             <div id="apply-block">{{ the_job.apply_info }}</div>
             {% endif %}
@@ -99,7 +100,7 @@
 <div id="direct_applyDiv" class="direct_rightColBox">
     <div id="direct_applyButton" class="direct-action-btn" role="menu">
         {% if the_job.link %}
-        <a href="{{the_job.link}}" onclick="goalClick('/G/apply-click', this.href); return false;">{% blocktrans %}Apply Now{% endblocktrans %}</a>
+        <a href="{{the_job.link|swap_http_with_https:"my.jobs"}}" onclick="goalClick('/G/apply-click', this.href); return false;">{% blocktrans %}Apply Now{% endblocktrans %}</a>
         {% elif the_job.apply_info %}
         <br/>
         <div id="apply-block">{{ the_job.apply_info }}</div>

--- a/templates/myblocks/blocks/applylink.html
+++ b/templates/myblocks/blocks/applylink.html
@@ -1,6 +1,7 @@
+{% load redirect_urls %}
 <div class='direct-action-btn' id="direct_applyButtonBottom">
     {% if requested_job.link %}
-        <a href="{{ requested_job.link }}" onclick="goalClick('/G/apply-click', this.href); return false;">{% blocktrans %}Apply Now{% endblocktrans %}</a>
+        <a href="{{ requested_job.link|swap_http_with_https:"my.jobs" }}" onclick="goalClick('/G/apply-click', this.href); return false;">{% blocktrans %}Apply Now{% endblocktrans %}</a>
     {% elif requested_job.apply_info %}
         <div id="apply-block">{{ requested_job.apply_info }}</div>
     {% endif %}

--- a/templates/redirect/email/job_exists.html
+++ b/templates/redirect/email/job_exists.html
@@ -3,9 +3,9 @@
 
 <p>We have forwarded your email to the hiring organization.
     {% if description %}
-        In the meantime, here is the description for <a href="http://my.jobs/{{guid}}">{{title}}</a>, about which you inquired:
+        In the meantime, here is the description for <a href="https://my.jobs/{{guid}}">{{title}}</a>, about which you inquired:
     {%else%}
-        The job about which you enquired (<a href="http://my.jobs/{{guid}}">{{title}}</a>) has expired.
+        The job about which you enquired (<a href="https://my.jobs/{{guid}}">{{title}}</a>) has expired.
     {%endif%}
 </p>
 {% else %}

--- a/templates/redirect/opengraph.html
+++ b/templates/redirect/opengraph.html
@@ -8,5 +8,5 @@
     <meta property='og:site_name' content='My.jobs' />
     <meta property='og:title' content='My.jobs - {{ title }} - {{ company }}' />
     <meta property='og:type' content='article' />
-    <meta property='og:url' content='http://my.jobs/{{ guid }}{{ vs }}' />
+    <meta property='og:url' content='https://my.jobs/{{ guid }}{{ vs }}' />
 </head>

--- a/templates/terms.html
+++ b/templates/terms.html
@@ -165,7 +165,7 @@ Where My.jobs has provided you with a translation of the English language versio
 
 <h2>Notices and Service of Process</h2>
 <p>
-In addition to "Notices and Service Messages", we may notify you via postings on http://my.jobs. You may <a href="{% url 'contact_faq' %}">contact us</a> here. Or via mail or courier at: DirectEmployers Association ATTN: Legal, 9002 North Purdue Road, Suite 100, Indianapolis, IN 46268. Additionally, My.jobs accepts service of process at this address. Any notices that you provide without compliance with this section shall have no legal effect.
+In addition to "Notices and Service Messages", we may notify you via postings on https://my.jobs. You may <a href="{% url 'contact_faq' %}">contact us</a> here. Or via mail or courier at: DirectEmployers Association ATTN: Legal, 9002 North Purdue Road, Suite 100, Indianapolis, IN 46268. Additionally, My.jobs accepts service of process at this address. Any notices that you provide without compliance with this section shall have no legal effect.
 </p>
 
 <h2>Entire Terms of Use</h2>
@@ -174,7 +174,7 @@ You agree that the Terms of Use constitutes the entire, complete and exclusive a
 </p>
 
 <h2>Amendments to Terms of Use</h2>
-<p>We reserve the right to modify, supplement, or replace the Terms of Use, effective prospectively upon posting at http://my.jobs or notifying you otherwise. For example, we may present a banner on the Services when we have amended this Terms of Use or the <a href="{% url 'privacy' %}">Privacy Policy</a> so that you may access and review the changes prior to your continued use of the site. If you do not want to agree to changes, you can terminate your account at any time.
+<p>We reserve the right to modify, supplement, or replace the Terms of Use, effective prospectively upon posting at https://my.jobs or notifying you otherwise. For example, we may present a banner on the Services when we have amended this Terms of Use or the <a href="{% url 'privacy' %}">Privacy Policy</a> so that you may access and review the changes prior to your continued use of the site. If you do not want to agree to changes, you can terminate your account at any time.
 </p>
 
 <h2>No informal waivers, agreements or representations</h2>


### PR DESCRIPTION
## Overview

To assist with tracking the refer(r)er values within analytics, we need to cause links to redirect to be sent via HTTPS.

This PR covers logic to force HTTPS on apply links on microsites, as well as overwriting some hardcoded values

## Testing

To test the apply links, simply load the branch and view the target of the links

To test the hardcoded values, navigate to a view containing them.

## Further work

This represents my current best stab at tracking down links to http://my.jobs. Any input toward other places to look would be appreciated.