### PR TITLE
Tweak config and move custom.css.

### DIFF
--- a/gulp/webpack.config.js
+++ b/gulp/webpack.config.js
@@ -14,7 +14,7 @@ module.exports = {
     manageusers: './src/manageusers/main',
     nonuseroutreach: './src/nonuseroutreach/main',
     myprofile: './src/myprofile/main',
-    sass: './src/sass/custom.scss'
+    custom: './src/sass/custom.scss',
   },
   resolve: {
     root: path.resolve('src'),
@@ -83,6 +83,6 @@ module.exports = {
     // In development it can be useful to see this output to verify that
     // dead code removal is doing something sane.
     new webpack.optimize.UglifyJsPlugin({compress: {warnings: false}}),
-    new ExtractTextPlugin('../custom.css', {allChunks: true}),
+    new ExtractTextPlugin('[name].css'),
   ],
 };

--- a/gulp/webpack.dev.config.js
+++ b/gulp/webpack.dev.config.js
@@ -1,7 +1,10 @@
 var prodConfig = require('./webpack.config.js');
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
 
-prodConfig.plugins = [new ExtractTextPlugin('custom.css', {allChunks: true})];
+// In development we want css extracted but no other plugins to run.
+// Keep the production plugin so these two files don't get out of sync.
+prodConfig.plugins = prodConfig.plugins.filter(
+  p => p instanceof ExtractTextPlugin);
 
 // In development we still want our modules built even when eslint is
 // complaining.

--- a/templates/base-react.html
+++ b/templates/base-react.html
@@ -26,7 +26,7 @@
         {% else %}
             {% compress css %}
                 <link rel="stylesheet" href="{% static "bootstrap-3/css/bootstrap.min.css" %}" rel="stylesheet" type="text/css">
-                <link rel="stylesheet" href="{% static "custom.css" %}" rel="stylesheet" type="text/css">
+                <link rel="stylesheet" href="{% static "bundle/custom.css" %}" rel="stylesheet" type="text/css">
                 <link rel="stylesheet" href="{% static "react-bootstrap-table.min.css" %}" type="text/css">
             {% endcompress %}
         {% endif %}

--- a/templates/postajob/form.html
+++ b/templates/postajob/form.html
@@ -15,7 +15,7 @@
 {% else %}
     {% compress css %}
         <link rel="stylesheet" href="{% static "bootstrap-3/css/bootstrap.min.css" %}" rel="stylesheet" type="text/css">
-        <link rel="stylesheet" href="{% static "custom.css" %}" rel="stylesheet" type="text/css">
+        <link rel="stylesheet" href="{% static "bundle/custom.css" %}" rel="stylesheet" type="text/css">
         <link rel="stylesheet" href="{% static "bootstrap/bootstrap-modal.css" %}" type="text/css">
         <link rel="stylesheet" href="{% static "postajob.css" %}" rel="stylesheet" type="text/css">    {% endcompress %}
 {% endif %}

--- a/templates/postajob/job_form.html
+++ b/templates/postajob/job_form.html
@@ -3,6 +3,7 @@
 {% load common_tags %}
 {% load postajob_tags %}
 {% load compress %}
+{% load staticfiles %}
 
 
 {% block directseo_main_content %}
@@ -10,7 +11,7 @@
 {{ form.media }}
 {% compress css %}
 <link rel="stylesheet" href="{{ STATIC_URL }}bootstrap-3/css/bootstrap.min.css" rel="stylesheet" type="text/css">
-<link rel="stylesheet" href="{{ STATIC_URL }}custom.css" rel="stylesheet" type="text/css">
+<link rel="stylesheet" href="{% static "bundle/custom.css" %}" rel="stylesheet" type="text/css">
 {% endcompress %}
 <div id="job-form" class="container-fluid">
     <form action="?" method="post">


### PR DESCRIPTION
For microsites we need to be able to use sass and generate a css bundle independent of `custom.css`.

## Test

1. Unset `WEBPACK_DEV_SERVER_BASE_URL` in `dev_settings.py`
2. Delete `static/custom.css`
3. Run `gulp` with no parameters or `dkgg` if you can run gulp with the docker aliases. This generates production bundles.
4. Verify that the following look ok: a react app, such as reporting or NUO, postajob product edit form, postajob job form. (All used `custom.css`)

Assuming you are configured for postajob, these urls worked for me:

* NUO https://secure.my.jobs/prm/view/nonuseroutreach/
* postajob product edit form http://directemployers.jobs/posting/product/purchase/add/1/
* postajob job form http://directemployers.jobs/posting/job/add/


## Review

* `webpack.dev.config.js` is improved to inherit it's extract text plugin from production.
* Webpack can now can generate multiple independent css bundles and output them to `static/bundle/`.
* Webpack also generates a useless `*.js` file for each css bundle. We don't use them.


