### PR TITLE
Add endpoint for grabbing all view sources

### DIFF
--- a/seo/urls/settings_urls.py
+++ b/seo/urls/settings_urls.py
@@ -3,10 +3,11 @@ from django.conf.urls import patterns, url
 from seo.views import settings_views
 
 urlpatterns = patterns(
-    '',
+    'seo.views.settings_views',
 
     # SeoSites Domain
     url(r'^site/domain',
         settings_views.EmailDomainFormView.as_view(),
-        name='seosites_settings_email_domain_edit')
+        name='seosites_settings_email_domain_edit'),
+    url(r'^view_sources', 'get_view_sources', name='get_view_sources'),
 )


### PR DESCRIPTION
PD-2519 has a requirement that we do stuff with view sources. As we don't want to add db connection info there, we're doing an endpoint that we can hit.

Requirements:
* Username and password of a staff user

Testing:
* Add some view sources if you don't have any
* `curl -H "Content-Type: application/json" -d '{"un": "<user email>", "pw": "<user password>"}' <link_to_microsite>/settings/view_sources`