### PR TITLE
Allow unicode in the list of users for a given company [ST-3034]

### DIFF
--- a/seo/forms/admin_forms.py
+++ b/seo/forms/admin_forms.py
@@ -103,10 +103,10 @@ class TableWidget(forms.Widget):
 
     def make_row(self, values, cell_tag='td'):
         text_values = [smart_text(value) for value in values]
-        cells = ''
+        cells = u''
         for cell in text_values:
-            cells += "<{tag}>{value}</{tag}>".format(tag=cell_tag, value=cell)
-        return '<tr class="form-row {0}">{1}</tr>'.format(self.row_class.next(), cells)
+            cells += u"<{tag}>{value}</{tag}>".format(tag=cell_tag, value=cell)
+        return u'<tr class="form-row {0}">{1}</tr>'.format(self.row_class.next(), cells)
 
     def render(self, value, name, attrs=None):
         table = '<table>'


### PR DESCRIPTION
Verified with Xerox.


# Testing
- Using Manage Users, create roles and users. Include unicode wherever you want.
- Go to the Django admin for that company
- Verify that you didn't receive a 500