### PR TITLE
[PD-2551] correct erroneous titles

### DIFF
--- a/seo/helpers.py
+++ b/seo/helpers.py
@@ -296,7 +296,7 @@ def job_breadcrumbs(job, company=False):
         # template; if not, the city value -- ordinarily JUST the cityname --
         # will be set to the "City, ST" location field on the job document.
         if display != "None":
-            up_slug = "/".join([attrs.get(k, {}).get('path', 'unknown') for k in dropmap[f]])
+            up_slug = "/".join([attrs.get(k, {}).get('path', '') for k in dropmap[f]])
             breadcrumbs[f] = {'path': "/" + up_slug + "/",
                               'display': display or getattr(job, f)}
     return breadcrumbs

--- a/seo/helpers.py
+++ b/seo/helpers.py
@@ -296,7 +296,7 @@ def job_breadcrumbs(job, company=False):
         # template; if not, the city value -- ordinarily JUST the cityname --
         # will be set to the "City, ST" location field on the job document.
         if display != "None":
-            up_slug = "/".join([attrs[k]['path'] for k in dropmap[f]])
+            up_slug = "/".join([attrs.get(k, {}).get('path', 'unknown') for k in dropmap[f]])
             breadcrumbs[f] = {'path': "/" + up_slug + "/",
                               'display': display or getattr(job, f)}
     return breadcrumbs
@@ -312,7 +312,7 @@ def _page_title(crumbs):
         info_part = " ".join([crumbs['company']['display'],
                               crumbs['title']['display']])
     else:
-        info_part = crumbs['title']['display']
+        info_part = crumbs.get('title', {}).get('display', '')
 
     return " in ".join([info_part, loc_part])
 
@@ -772,7 +772,7 @@ def get_widgets(request, site_config, facet_counts, custom_facets,
 
     """
     filters = filters or {}
-
+    # facet_counts is occasionally an empty list. do not allow this.
     moc_field = 'mapped_moc' if settings.SITE_BUIDS else 'moc'
     if featured:
         types = [('featured', 1),
@@ -792,10 +792,10 @@ def get_widgets(request, site_config, facet_counts, custom_facets,
 
     num_items = site_config.num_filter_items_to_show
     widgets = []
-
     for _type in types:
         w = FacetListWidget(request, site_config, _type[0],
-                            facet_counts['%s_slab' % _type[0]][0:num_items*2],
+                            facet_counts.get('%s_slab' % _type[0],
+                                             [])[0:num_items*2],
                             filters)
         w.precedence = _type[1]
         widgets.append(w)

--- a/seo/search_backend.py
+++ b/seo/search_backend.py
@@ -37,7 +37,6 @@ class DESearchQuerySet(SearchQuerySet):
 
         facet_counts1 = self.facet_counts()
         facet_counts2 = sqs2.facet_counts()
-        import ipdb; ipdb.set_trace()
         # field_counts = {facet_field: [(facet_field_value, count), ...], ...}
         field_counts1 = facet_counts1.get('fields', {})
         field_counts2 = facet_counts2.get('fields', {})
@@ -54,7 +53,8 @@ class DESearchQuerySet(SearchQuerySet):
             field_counts1[facet_field] = field_dict.items()
             # Sort the list of field count tuples by count
             # (2nd value in each tuple)
-            field_counts1[facet_field].sort(key=lambda tup: tup[1], reverse=True)
+            field_counts1[facet_field].sort(key=lambda tup: tup[1],
+                                            reverse=True)
 
         facet_counts1['fields'] = field_counts1
         return facet_counts1

--- a/seo/search_backend.py
+++ b/seo/search_backend.py
@@ -37,10 +37,10 @@ class DESearchQuerySet(SearchQuerySet):
 
         facet_counts1 = self.facet_counts()
         facet_counts2 = sqs2.facet_counts()
-
+        import ipdb; ipdb.set_trace()
         # field_counts = {facet_field: [(facet_field_value, count), ...], ...}
-        field_counts1 = facet_counts1.get('fields', [])
-        field_counts2 = facet_counts2.get('fields', [])
+        field_counts1 = facet_counts1.get('fields', {})
+        field_counts2 = facet_counts2.get('fields', {})
 
         for facet_field in field_counts2:
             # field_dict = {facet_field_value: count, ...}

--- a/seo/views/search_views.py
+++ b/seo/views/search_views.py
@@ -447,10 +447,11 @@ def job_detail_by_title_slug_job_id(request, job_id, title_slug=None,
     # in the url, then we want whoever clicks the link to be directed to the
     # canonical (and correctly spelled/no typo) version.
 
-    def nvl(i, s):
+    def replace_none(i, s):
         return i if i else s
 
-    if (nvl(title_slug, 'na') == nvl(the_job.title_slug, 'na') and
+    if (replace_none(title_slug, 'na') ==
+            replace_none(the_job.title_slug, 'na') and
             location_slug == slugify(the_job.location)) \
             and not search_type == 'uid':
         ga = settings.SITE.google_analytics.all()

--- a/seo/views/search_views.py
+++ b/seo/views/search_views.py
@@ -442,12 +442,15 @@ def job_detail_by_title_slug_job_id(request, job_id, title_slug=None,
         company_data = None
 
     # This check is to make sure we're at the canonical job detail url.
-
     # We only need the job id to be in the url, but we also put the title.
     # The offshoot of that is that if someone mistypes or mispells the title
     # in the url, then we want whoever clicks the link to be directed to the
     # canonical (and correctly spelled/no typo) version.
-    if (title_slug == the_job.title_slug and
+
+    def nvl(i, s):
+        return i if i else s
+
+    if (nvl(title_slug, 'na') == nvl(the_job.title_slug, 'na') and
             location_slug == slugify(the_job.location)) \
             and not search_type == 'uid':
         ga = settings.SITE.google_analytics.all()
@@ -573,7 +576,7 @@ def job_detail_by_title_slug_job_id(request, job_id, title_slug=None,
         # job with the passed in id.
         kwargs = {
             'location_slug': slugify(the_job.location),
-            'title_slug': the_job.title_slug,
+            'title_slug': the_job.title_slug or 'na',
             'job_id': the_job.guid
         }
         redirect_url = reverse(

--- a/templates/job_detail.html
+++ b/templates/job_detail.html
@@ -123,11 +123,13 @@
             </a>
           </li>
           {% endif %}
+          {% if crumbs.title %}
           <li>
             <a href="{{ crumbs.title.path }}" title="Remove {{ crumbs.title.display }}">
               {{ crumbs.title.display|smart_truncate }}
             </a>
           </li>
+          {% endif %}
           {# if crumbs.city.display #}
           <li>
             <a href="{{ crumbs.city.path }}" title="Remove {{ crumbs.city.display }}">


### PR DESCRIPTION
## Overview

In the slug field for titles, certain characters are automatically trimmed. A few examples are '?', '.' and ','

If a title is erroneously created to contain ONLY those special characters, the job title slug will be saved as blank. This PR covers modifying the code slightly to handle blank titles

This also fixes a small bug that happens when you try to load job search results when there are no jobs in solr.

## Testing

The easiest way to load a job into the system with erroneous characters is to create one via postajob. If you have postajob set up on your system, simply create a job with a title such as "..." and view that job. It should work fine. On QC branch, it will raise a 500.

PostAJob docs
http://directemployers.github.io/MyJobs/developers/postajob/index.html