### PR TITLE
Preserve newlines in NormalizedModelForm [PD-2602]

### DIFF
--- a/mypartners/forms.py
+++ b/mypartners/forms.py
@@ -205,21 +205,16 @@ class NewPartnerForm(NormalizedModelForm):
     def save(self, commit=True):
         # self.instance is a Contact instance
         company_id = self.data['company_id']
-        partner_url = self.data.get('partnerurl', '')
-        partner_source = self.data.get('partnersource', '')
+        partner_url = self.cleaned_data.get('partnerurl', '')
+        partner_source = self.cleaned_data.get('partnersource', '')
 
         status = Status.objects.create(approved_by=self.user)
-        partner = Partner.objects.create(name=self.data['partnername'],
+        partner = Partner.objects.create(name=self.cleaned_data['partnername'],
                                          uri=partner_url, owner_id=company_id,
                                          data_source=partner_source,
                                          approval_status=status)
         log_change(partner, self, self.user, partner, partner.name,
                    action_type=ADDITION)
-
-        self.data = remove_partner_data(self.data,
-                                        ['partnername', 'partnerurl',
-                                         'csrfmiddlewaretoken', 'company',
-                                         'company_id', 'ct'])
 
         create_contact = any(self.cleaned_data.get(field)
                              for field in self.__CONTACT_FIELDS

--- a/mypartners/tests/test_api.py
+++ b/mypartners/tests/test_api.py
@@ -394,14 +394,11 @@ class NUOConversionAPITestCase(MyPartnersTestCase):
         self.contact.save()
         response = self.client.post(
             reverse('api_convert_outreach_record'),
-            data = {'request': json.dumps(self.request_data)}
+            data={'request': json.dumps(self.request_data)}
         )
         self.check_status_code_and_objects(response, 200, 8)
         self.contact = Contact.objects.get(id=self.contact.id)
-        # This is how we wish this could be written. Can be fixed along with
-        # PD-2602: universal.NormalizedModelForm removes all new lines
-        # self.assertEqual(self.contact.notes, "first part\nnew notes")
-        self.assertEqual(self.contact.notes, "first part new notes")
+        self.assertEqual(self.contact.notes, "first part\nnew notes")
 
     def test_outreach_api_no_data(self):
         """

--- a/universal/forms.py
+++ b/universal/forms.py
@@ -1,5 +1,4 @@
 from django.forms import ModelForm
-from django.conf import settings
 
 from universal.helpers import get_company
 
@@ -19,9 +18,12 @@ class NormalizedModelForm(ModelForm):
     """
 
     def clean(self):
-        self.cleaned_data = {key: ' '.join(value.split())
-                             # I don't see us porting to Python 3 any time soon
-                             if isinstance(value, basestring) else value
-                             for key, value in self.cleaned_data.items()}
-
-        return super(NormalizedModelForm, self).clean()
+        super(NormalizedModelForm, self).clean()
+        self.cleaned_data = {
+            key: '\n'.join(' '.join(line.split())
+                           for line in value.splitlines())
+            if isinstance(value, basestring)
+            else value
+            for key, value in self.cleaned_data.items()
+        }
+        return self.cleaned_data


### PR DESCRIPTION
# Testing
- Go to the "Add Partner" page
- Enter stuff containing multiple spaces
- In the notes textarea, include newlines in your input
- Save
- Verify that newlines were preserved