### PR TITLE
[2664] Replacing the PNG logo with the SVG version

### DIFF
--- a/static/images/dotJobsLogo.svg
+++ b/static/images/dotJobsLogo.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1352" height="738" viewBox="0 0 1352 738">
+  <defs>
+    <style>
+      .cls-1 {
+        font-size: 72px;
+        fill: #3a4153;
+        font-family: "Avenir Next";
+        font-weight: 800;
+      }
+    </style>
+  </defs>
+  <text id="_.jobs" data-name=".jobs" class="cls-1" transform="translate(-25.247 566.814) scale(7.466 9.885)">.jobs</text>
+</svg>

--- a/templates/seo_base_bootstrap3.html
+++ b/templates/seo_base_bootstrap3.html
@@ -81,13 +81,13 @@
                         {% with site_heading|case_insensitive_cut:" Jobs" as site_heading_base2 %}
                           {%if site_heading_base2 == site_heading %}
                             <h1 class="logo-text noDotJobs">
-                              <img class="logo" src="{{ STATIC_URL }}images/dotJobsLogo.png" id="page_logo" alt="" width="150" height="90">
+                              <img class="logo" src="{{ STATIC_URL }}images/dotJobsLogo.svg" id="page_logo" alt="" width="150" height="90">
                               {{site_heading}}
                             </h1>
                               {% else %}
                             <h1 class="logo-text">
                               <a class="location-logo-text"  href="/">
-                                <img class="logo" src="{{ STATIC_URL }}images/dotJobsLogo.png" id="page_logo" alt="" width="150" height="90">
+                                <img class="logo" src="{{ STATIC_URL }}images/dotJobsLogo.svg" id="page_logo" alt="" width="150" height="90">
                                 {%if site_heading_base2 == "My"%}
                                 {%else%}
                                   {{site_heading_base2}}
@@ -99,7 +99,7 @@
                       {% else %}
                         <h1 class="logo-text">
                           <a class="location-logo-text"  href="/">
-                            <img class="logo" src="{{ STATIC_URL }}images/dotJobsLogo.png" id="page_logo" alt="" width="150" height="90">
+                            <img class="logo" src="{{ STATIC_URL }}images/dotJobsLogo.svg" id="page_logo" alt="" width="150" height="90">
                             {{site_heading_base}}
                           </a>
                         </h1>


### PR DESCRIPTION
Replacing the PNG logo with the SVG version in the static files and base template.
You can test by pulling down the V2 homepage template in Admin, seeing the logo and inspecting element. Or you can see the change in the code files as well which are the Static/Images/dotJobsLogo.svg and the Seo_base_bootstrap3.html file with the dotJobsLogo.svg image in it