### PR TITLE
[PD-2679] Adding in the MOC Searchbox for veteran pages

### DIFF
--- a/gulp/src/sass/seo_base_styles.scss
+++ b/gulp/src/sass/seo_base_styles.scss
@@ -652,6 +652,46 @@ margin-bottom: 50px;
       }
     }
   }
+  .moc-section {
+    display:inline-block;
+    position: relative;
+    width: 100%;
+
+    i {
+      position: absolute;
+      left: 10px;
+			font-size: 24px;
+			top: 10px;
+      color: $blue;
+    }
+    .helptext {
+      position: absolute;
+      bottom: 12px;
+      color: $blue;
+      left: 15%;
+    }
+    label {
+      display: none;
+    }
+    #moc {
+      @extend .search-input-boxes;
+      width: 100%;
+      padding: 0 0 0 40px;
+
+      &::-webkit-input-placeholder {
+        color: $blue;
+      }
+      &::-moz-placeholder {
+        color: $blue;
+      }
+      &:-ms-input-placeholder {
+        color: $blue;
+      }
+      &:-moz-placeholder {
+        color: $blue;
+      }
+    }
+  }
   .search-submit {
     display: inline-block;
     margin: 0 15px 10px 0;
@@ -1128,6 +1168,10 @@ margin-bottom: 50px;
       width: 93% !important;
       margin-bottom: 20px;
     }
+    .moc-section {
+      width: 93% !important;
+      margin-bottom: 20px;
+    }
     .submit-section {
       padding: 0 12px;
     }
@@ -1383,6 +1427,10 @@ margin-bottom: 50px;
       margin-bottom: 0px;
     }
     .where-section {
+      width: 100% !important;
+      margin-bottom: 0px;
+    }
+    .moc-section {
       width: 100% !important;
       margin-bottom: 0px;
     }

--- a/templates/seo_base_bootstrap3.html
+++ b/templates/seo_base_bootstrap3.html
@@ -117,9 +117,9 @@
       <div class="col-xs-12 col-md-8">
         <div class="right-content">
             {% if site_config.browse_moc_show %}
-            {% include "search_box_vets.html" %}
+              {% include "v2/includes/search_box_vets_widget.html" %}
             {% else %}
-            {% include 'v2/includes/search_box_widget.html' %}
+              {% include 'v2/includes/search_box_widget.html' %}
             {% endif %}
             <div class="mobile-search-criteria">
               <a id="mobile_search" class="mobile-search-btn" href="#/">Filter Search Criteria</a>

--- a/templates/v2/includes/search_box_vets_widget.html
+++ b/templates/v2/includes/search_box_vets_widget.html
@@ -1,0 +1,58 @@
+{% load i18n %}
+{% load humanize %}
+{% load seo_extras %}
+
+<section id="search">
+  {% if search_url %}
+      <form id="standardSearch" class="text-center" action="{{ search_url }}">
+    {% else %}
+      <form id="standardSearch" class="text-center" action="/jobs/">
+  {% endif %}
+        <div class="search-section">
+          <div class="row">
+            <div class="col-xs-12 col-md-3">
+              <span class="what-section">
+                <input title="Search Phrase" type="text" name="q" id="q" class="micrositeTitleField what" {% if title_term != "\*" %}value="{{ title_term }}"{% endif %} {% if site_config.what_placeholder %}placeholder="{{ site_config.what_placeholder }}"{% endif %} placeholder="job,title,keyword" />
+                <i class="glyphicon glyphicon-search" aria-hidden="true"></i>
+              </span>
+            </div>
+              <div class="col-xs-12 col-md-3">
+                <span class="where-section">
+                  <input title="Search Location" type="text" name="location" id="location" class="micrositeLocationField where" {% if location_term != "\*" %}value="{{ location_term }}"{% endif %} {% if site_config.where_placeholder %}placeholder="{{ site_config.where_placeholder }}"{% endif %} placeholder="city,state,country" />
+                  <i class="glyphicon glyphicon-map-marker" aria-hidden="true"></i>
+                </span>
+              </div>
+              <div class="col-xs-12 col-md-3">
+                <span class="moc-section">
+                  <input title="Search MOC" type="text" name="moc" id="moc" class="micrositeMOCField moc" {% if moc_term != "\*" %}value="{{ moc_term }}"{% endif %} {% if site_config.moc_placeholder %}placeholder="{{ site_config.moc_placeholder }}"{% endif %} placeholder="military job title or code"/>
+                  <i class="glyphicon glyphicon-search" aria-hidden="true"></i>
+                  <input type="hidden" name="moc_id" id="moc_id" {% if moc_id_term != "\*" %}value="{{ moc_id_term }}"{% endif %}/>
+                </span>
+              </div>
+              <div class="col-xs-12 col-md-3 text-left">
+                <span class="submit-section">
+                  <input alt="Submit Search" class="search-submit" type="submit" value="Search" />
+                  <a class="share-social search-submit" href="#"><img class="share-icon" src="{{ STATIC_URL }}images/share-icon.png" alt="share" /></a>
+                </span>
+              </div>
+          </div>
+        </div>
+        <div class="row breadcrumb-row">
+          <div class="col-sm-7 col-md-7">
+            <div class="breadcrumb-tags">
+              {% if breadbox.clear_breadcrumb %}
+                  {% include 'v2/includes/breadbox.html' %}
+              {% endif %}
+            </div>
+          </div>
+          <div class="col-xs-12 col-sm-5 col-md-5">
+            <div class="social-media">
+              <div id="direct_shareDiv" role="menu">
+                  {% include 'v2/includes/add_this.html' %}<!--replace with my.jobs sharing when ready. JPS 10-4-12-->
+              </div>
+              <span class="caret-up"></span>
+            </div>
+          </div>
+        </div>
+      </form>
+</section>


### PR DESCRIPTION
Adding the re-branding styling to the sites that utilize the MOC Searchbox for 3 search boxes at the top of the screen.

Test:
To Test this task, change over to veterans.jobs or another domain inside of admin that utilizes the MOC search box. Make sure to switch over the homepage template to be home_page_listing_bootstrap3.html along with switching the version over to version 2. You should see the new design style along with a 3rd search box that's for the military title or code next to the original search boxes you would see on my.jobs.