### PR TITLE
[PD 2681] Editing the mobile hyperlinks to extend 100 percent width of the clic…

### DIFF
--- a/gulp/src/sass/seo_base_styles.scss
+++ b/gulp/src/sass/seo_base_styles.scss
@@ -949,6 +949,8 @@ margin-bottom: 50px;
 
       a {
         color: $primary-navy-blue;
+        display: inline-block;
+        width: 100%;
       }
     }
   }
@@ -965,6 +967,8 @@ margin-bottom: 50px;
 
       a {
         color: $primary-navy-blue;
+        display: inline-block;
+        width: 100%;
       }
     }
   }
@@ -981,6 +985,8 @@ margin-bottom: 50px;
 
       a {
         color: $primary-navy-blue;
+        display: inline-block;
+        width: 100%;
       }
     }
   }
@@ -997,6 +1003,8 @@ margin-bottom: 50px;
 
         a {
           color: $primary-navy-blue;
+          display: inline-block;
+          width: 100%;
         }
       }
   }


### PR DESCRIPTION
Editing the hyperlinks in the mobile view to extend 100 percent across the link.

Test:

To test, in mobile view for the popup links in the footer, you should be able to click the entire bar link itself and be sent to the page that is associated with the link. If you inspect element you can see that the anchor tag has been extended to be 100% width.