### PR TITLE
Updates django-ajax-selects to 1.5.1 [PD-2659]

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -55,7 +55,7 @@ Markdown==2.4
 xlrd==0.9.3
 Sphinx==1.3.3
 XlsxWriter==0.8.4
-django-ajax-selects==1.4.2
+django-ajax-selects==1.5.1
 git+https://github.com/DirectEmployers/django-remote-forms.git
 django-impersonate==0.9.2  # 0.9.2 is the last version with Django 1.6 support
 pymongo==3.2.2


### PR DESCRIPTION
1.5.1 removes instances of document.write.