### PR TITLE
[PD-2675] Added 'Companies' sub menu to the 'Employers' mobile sub menu

### DIFF
--- a/gulp/src/sass/seo_base_styles.scss
+++ b/gulp/src/sass/seo_base_styles.scss
@@ -243,21 +243,6 @@ a.direct_optionsLess {
       height: 100% !important;
   }
 
-  #back-btn-li {
-      float: left;
-      width: 40px !important;
-      height: 100%;
-      z-index: 999;
-  }
-
-  .sub-nav-item {
-      margin-left: 40px;
-  }
-
-  #pop-menu .desktop_hide {
-      display: none;
-  }
-
   /*
    * nav id and submenu-dropdown class are used by JavaScript
    * in topbar.js for legacy mobile view. Will become obsolete when new mobile view
@@ -792,8 +777,6 @@ margin-bottom: 50px;
 
   .mobile-submenu {
     position: absolute;
-    top: -180px;
-    width: 75px;
     background-color: $white;
     padding: 0;
   }
@@ -976,7 +959,7 @@ margin-bottom: 50px;
     margin-left: calc(-1 * ((100vw - 100%)));
     width: 100vw !important;
     left: 86%;
-    top: -132px !important;
+    top: -260px !important;
 
     li {
       text-align: left;

--- a/myjobs/templatetags/common_tags.py
+++ b/myjobs/templatetags/common_tags.py
@@ -319,6 +319,7 @@ def get_menus(context):
         "id": "employers",
         "mobile_icon_v2": "glyphicon glyphicon-briefcase",
         "submenuId": "employer-apps",
+        "mobile_submenuId": "mobile-employer-apps",
         "submenus": [
         ]
     } if user.roles.exists() else {}

--- a/static/topbar_v2.js
+++ b/static/topbar_v2.js
@@ -55,19 +55,16 @@ function get_companies() {
     });
 
     var label = document.createElement("a");
-
     // Company id from myjobs_company cookie
     var cid = readCookie("myjobs_company");
-
     var list = document.createElement("ul");
     list.setAttribute("id", "select_company");
 
     // Company name used to show user what current company is selected
     var menu_company_name;
-
     var company_not_found = false;
 
-    // Creating li items for "list" (the ul)
+    // Creating li items for "select_company" ul
     for (var i = 0; i < tools_companies.length; i++) {
         var company = tools_companies[i];
 
@@ -90,7 +87,6 @@ function get_companies() {
         list_item.setAttribute("id", "company_" + String(company.id));
         list_item.innerHTML = "<a>" + company.name + "</a>";
         list_item.onclick = function () {
-            // this.id Format: company_COMPANYID
             var item_id = this.id.split("_")[1];
 
             // 14 = 2 weeks
@@ -116,6 +112,34 @@ function get_companies() {
     var parent_element = document.getElementById("employer-apps"),
         first_child = parent_element.firstChild;
     parent_element.insertBefore(parent_list_item, first_child);
+
+    // ---- Mobile ---- //
+    var mobile_parent_list_item = document.createElement("li"),
+        mobile_link = document.createElement("a");
+    mobile_parent_list_item.setAttribute("id", "mobile-parent-company-list");
+    mobile_parent_list_item.setAttribute("class", "mobile-sub-nav");
+    mobile_link.innerHTML = "<strong>" + menu_company_name + "</strong>";
+    mobile_parent_list_item.appendChild(mobile_link);
+
+    var pop_menu = document.getElementById("mobile-employer-apps");
+    pop_menu.appendChild(mobile_parent_list_item);
+
+    var mobile_list = document.createElement("ul");
+    mobile_list.setAttribute("id", "mobile_select_company");
+    mobile_parent_list_item.appendChild(mobile_list);
+
+    for (var j = 0; j < tools_companies.length; j++) {
+        var mobile_list_item = document.createElement("li");
+        mobile_list_item.setAttribute("id", "mobilecompany_" + tools_companies[j].id);
+        mobile_list_item.innerHTML = "<a>"+ tools_companies[j].name +"</a>";
+        mobile_list_item.onclick = function() {
+            var mobile_item_id = this.id.split("_")[1];
+            set_cookie(mobile_item_id, 14);
+            mobile_parent_list_item.firstChild.innerHTML = "<strong>"+ this.firstChild.innerHTML + "</strong>";
+            process_reload();
+        };
+        mobile_list.appendChild(mobile_list_item);
+    }
 }
 
 function process_reload() {
@@ -135,7 +159,7 @@ function process_reload() {
 
     for (i = 0; i < app_names.length; i++) {
         app_name = app_names[i];
-        if (path.indexOf(app_name) != -1) {
+        if (path.indexOf(app_name) !== -1) {
             if (app_name === "candidates") {
                 // window.location.href used instead of window.location.replace
                 // to simulate a link instead of a redirect.

--- a/templates/includes/topbar_v2.html
+++ b/templates/includes/topbar_v2.html
@@ -29,7 +29,7 @@
                 {% if user.is_authenticated and request.session.keys|length %}
                 <ul class="nav navbar-nav navbar-right right-nav desktop-right-nav">
                   {% for menu in menus %}
-                    <li {% if menu.submenus %}class=" dropdown"{% endif %}>
+                    <li {% if menu.submenus %}class="dropdown"{% endif %}>
                       <a id="{{ menu.id }}" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">{% firstof menu.iconLabel menu.label %}{% if menu.icon %}<div class="{{ menu.icon }}"></div>{% endif %}<span class="caret"></span></a>
                       <ul class=" dropdown-menu" id="{{ menu.submenuId }}">
                         {% for submenu in menu.submenus %}
@@ -76,23 +76,19 @@
                           <p>{% firstof menu.iconLabel menu.label %}</p>
                       {% endif %}
                   </a>
-
-                <!-- Sub-menu -->
-
-                    <ul class="mobile-submenu" id="{{ menu.submenuId }}">
+                    {% comment %} Sub-menus {% endcomment %}
+                    <ul class="mobile-submenu" id="{{ menu.mobile_submenuId }}">
                     {% for submenu in menu.submenus %}
-                      <li class="mobile-sub-nav" id="{{ submenu.id }}">
+                      <li class="mobile-sub-nav" id="{{ submenu.id }}-mobile">
                         <a href="{{ submenu.href }}">{{ submenu.label }}</a>
                       </li>
                     {% endfor %}
                     </ul>
-
                 </li>
             {% endfor %}
             {% is_a_group_member company user "Employer" as group_member %}
             {% get_company_name user as company_name %}
         </ul>
-
       {% else %}
         {% comment %} When logged out {% endcomment %}
         <ul class="mob-nav-section">


### PR DESCRIPTION
Purpose of this PR is to add the "Companies" sub menu to the "Employers" sub menu when in mobile browser mode (tablets, iOS phones up to 6 Plus, Samsung Galaxy S5).

To test:
1. Please enabled "Companies" in dev environment, in the dkm shell, if you haven't already.

2. Please switch to v2 template and home_page_listing_bootstrap3.html home page template in admin.

3. In mobile browser simulator of choice, please switch to mobile view.  Note: Once branch is merged with QC, more in-depth testing will be done in the actual mobile devices.

4. Please click on "Employers" in the bottom mobile nav, ensure that there is a "DirectEmployers Association" mobile link in bold font, and under that, there should be an additional sub menu with 2 testing companies mobile links named: "DirectEmployers Association" and "DirectEmployers Demo - AJ".  Please note that the mobile "Companies" sub menu does not look exactly like the desktop version, (for now), because we need to make the entire link area clickable for our smallest device (iPhone 5c).

5. Please click on the "DirectEmployers Demo - AJ" link, the page will now refresh. Please click on the "Employers" nav again and ensure that the top "Companies" link is  "DirectEmployers Demo - AJ" and it is in bolded font, showing that this company is now selected.  At this time, please click on the "DirectEmployers Association" link and the page will refresh.  Please go to "Employers" nav again and ensure that is now in bold font and at the top of the companies sub-sub menu.  This repetition is to ensure that we can switch between companies in mobile view.  I was told that most of the time, there will only be one company in the companies sub-sub menu.

6. Please click on other mobile nav to ensure they're still working.  Please note that the new templates still links with old templates. 