### PR TITLE
[PD-2673] changed mobile breakpoint to 768px, added tablet view

### DIFF
--- a/gulp/src/sass/seo_base_styles.scss
+++ b/gulp/src/sass/seo_base_styles.scss
@@ -214,7 +214,7 @@ a.direct_optionsLess {
   margin-bottom: 25px;
 }
 /*MAIN NAVIGATION HEADER STYLES*/
-  /* Legacy Topbar styles, keeping until PD-2630 is completed */
+  /* Topbar styles */
   .menu-container > ul > li:hover > a {
       cursor: pointer;
       background-color: #f5f5f5;
@@ -234,57 +234,7 @@ a.direct_optionsLess {
       display: list-item;
   }
 
-  #logged-in-li {
-      padding: 4px !important;
-  }
-
-  #back-btn {
-      border-right: 1px solid #FFF !important;
-      height: 100% !important;
-  }
-
-  /*
-   * nav id and submenu-dropdown class are used by JavaScript
-   * in topbar.js for legacy mobile view. Will become obsolete when new mobile view
-   * is implemented.
-  */
-
-  #nav.active ul#pop-menu li a:hover,
-  #nav li:hover ul#pop-menu li a:hover {
-      background:#444;
-      color: #fff;
-      text-decoration:none;
-  }
-
-  #nav ul#pop-menu {
-      background:#444;
-      padding: 0;
-      margin: 2px 0 0 -2px;
-      position:absolute;
-      display: none;
-      border-bottom-left-radius: 4px;
-      border-bottom-right-radius: 4px;
-      width: 275px;
-  }
-
-  #nav a {
-      color: #fff;
-  }
-
-  #nav > li {
-      padding: 5px 2px 3px 2px;
-  }
-
-  .menu-container > .desktop_hide {
-      display: none;
-  }
-
-  #menu-inbox ~ ul li > p {
-      color: white;
-      padding-left: 4px;
-  }
-
- /* End legacy Topbar styles*/
+ /* End Topbar styles*/
 
 #last-microsite-name {
   color: $white;
@@ -365,6 +315,8 @@ a.direct_optionsLess {
 #brand_logo {
   .logo {
     position: relative;
+    width: 12rem;
+    height: 8rem;
   }
   .logo-text {
     position: relative;
@@ -681,7 +633,7 @@ margin-bottom: 50px;
     display: inline-block;
     margin: 0 15px 10px 0;
     padding: 9px;
-    font-size: 14px;
+    font-size: 18px;
     border-radius: 3px;
     font-weight: 100;
   }
@@ -954,10 +906,10 @@ margin-bottom: 50px;
 =            Bootstrap 3 Media Queries             =
 ==================================================*/
 
-/*==========  Mobile First Method  ==========*/
+/*==========  Mobile First Approach  ==========*/
 
 /* Custom, iPhone Retina */
-@media only screen and (min-width : 320px) {
+@media only screen and (min-width : 320px) and (max-width: 769px) {
 
   .mob-nav-section .mob-nav-content:nth-of-type(1) .mobile-submenu {
     margin-left: calc(-1 * ((100vw - 100%) / 10));
@@ -1168,7 +1120,6 @@ margin-bottom: 50px;
     }
     .search-submit {
       width: 94%;
-			font-size: 18px;
     }
     .share-social.search-submit {
       display: none;
@@ -1252,26 +1203,23 @@ margin-bottom: 50px;
   #direct_jobListingTitle, .jobs-found {
     width: 95%;
   }
-  #search {
-    .submit-section {
-        padding: 0 14px;
-    }
-  }
+
   #brand_logo {
 
     .location-logo {
       margin: 0 auto;
-      width: 37%;
+      width: 32%;
     }
     .site-name {
       left: 6%;
       bottom: 15px;
+      font-size: 3rem;
     }
   }
 }
 
 /* Small Devices, Tablets */
-@media only screen and (min-width : 768px) {
+@media only screen and (min-width : 769px) {
   .mob-nav-section .mob-nav-content:nth-of-type(1) .mobile-submenu {
     margin-left: calc(-1 * ((100vw - 100%) / 10));
     left: 36%;
@@ -1302,15 +1250,118 @@ margin-bottom: 50px;
        width: 17%;
      }
   }
-  #search {
-    .submit-section {
-        padding: 0 23px;
-    }
-  }
+
 }
 
-/* DirectEmployers Mobile Break Point */
-@media only screen and (max-width : 991px) {
+/* DirectEmployers Mobile Break Point iPad */
+@media only screen
+  and (min-width: 769px)
+  and (max-width: 991px) {
+
+
+  #direct_companyModule {
+    display: none;
+  }
+  #mobile_social_media {
+    display: none;
+  }
+
+  .mobile-search-facets {
+    display: none;
+  }
+
+  #direct_jobListingTitle, .jobs-found {
+    margin: 0 auto;
+    width: 91%;
+  }
+
+  .mobile-search-facets.show-mobile-search-facets {
+    display: block;
+  }
+
+  .facets {
+    display: none;
+  }
+
+  .social-media {
+    margin-top: 75px;
+  }
+
+  .mobile-search-criteria {
+    text-align: center;
+    padding: 25px 0px;
+  }
+
+  .mobile-search-btn {
+    background-color: $btn-gray;
+    color: $primary-navy-blue;
+    padding: 10px 20px;
+    border-radius: 2px;
+  }
+
+  .right-content {
+    padding-left: 5rem;
+  }
+
+  #search {
+    margin-bottom: 0;
+
+    .search-submit {
+      margin: 0 1rem 0 0;
+      padding: 0.9rem 2rem;
+    }
+
+    .submit-section {
+      padding: 0;
+    }
+  }
+
+  #menu-inbox > div.icon-envelope {
+      display: none;
+  }
+
+  #menu-inbox::before {
+    content: "Inbox ";
+  }
+
+  #mobile_footer {
+    display: none;
+  }
+
+  #footer_mobile {
+    display: none;
+  }
+
+  #main_nav {
+
+    .main-nav-topbar {
+      min-height: 0;
+      height: 5rem;
+    }
+
+    .left-logo {
+      padding-top: 0.5rem;
+      font-size: 1.6rem;
+    }
+
+    .navbar-nav.navbar-right.right-nav {
+
+      .dropdown {
+        a {
+          font-size: 1.8rem;
+        }
+      }
+    }
+
+  }
+
+  #footer {
+    .footer-content li {
+      display: inline-block;
+      font-size: 1.8rem;
+      padding: 1rem;
+    }
+  }
 
 }
 

--- a/templates/seo_base_bootstrap3.html
+++ b/templates/seo_base_bootstrap3.html
@@ -81,13 +81,13 @@
                         {% with site_heading|case_insensitive_cut:" Jobs" as site_heading_base2 %}
                           {%if site_heading_base2 == site_heading %}
                             <h1 class="logo-text noDotJobs">
-                              <img class="logo" src="{{ STATIC_URL }}images/dotJobsLogo.svg" id="page_logo" alt="" width="150" height="90">
+                              <img class="logo" src="{{ STATIC_URL }}images/dotJobsLogo.svg" id="page_logo" alt="dot jobs logo">
                               {{site_heading}}
                             </h1>
                               {% else %}
                             <h1 class="logo-text">
                               <a class="location-logo-text"  href="/">
-                                <img class="logo" src="{{ STATIC_URL }}images/dotJobsLogo.svg" id="page_logo" alt="" width="150" height="90">
+                                <img class="logo" src="{{ STATIC_URL }}images/dotJobsLogo.svg" id="page_logo" alt="dot jobs logo">
                                 {%if site_heading_base2 == "My"%}
                                   <span class="site-name">Network</span>
                                 {%else%}
@@ -100,7 +100,7 @@
                       {% else %}
                         <h1 class="logo-text">
                           <a class="location-logo-text"  href="/">
-                            <img class="logo" src="{{ STATIC_URL }}images/dotJobsLogo.svg" id="page_logo" alt="" width="150" height="90">
+                            <img class="logo" src="{{ STATIC_URL }}images/dotJobsLogo.svg" id="page_logo" alt="dot jobs logo">
                             {{site_heading_base}}
                           </a>
                         </h1>

--- a/templates/v2/includes/search_box_widget.html
+++ b/templates/v2/includes/search_box_widget.html
@@ -11,19 +11,19 @@
   {% endif %}
         <div class="search-section">
           <div class="row">
-            <div class="col-xs-12 col-md-4">
+            <div class="col-xs-12 col-sm-4 col-md-4">
               <span class="what-section">
                 <input title="Search Phrase" type="text" name="q" id="q" class="micrositeTitleField what" {% if title_term != "\*" %}value="{{ title_term }}"{% endif %} {% if site_config.what_placeholder %}placeholder="{{ site_config.what_placeholder }}"{% endif %} placeholder="job,title,keyword" />
                 <i class="glyphicon glyphicon-search" aria-hidden="true"></i>
               </span>
             </div>
-              <div class="col-xs-12 col-md-4">
+              <div class="col-xs-12 col-sm-4 col-md-4">
                 <span class="where-section">
                   <input title="Search Location" type="text" name="location" id="location" class="micrositeLocationField where" {% if location_term != "\*" %}value="{{ location_term }}"{% endif %} {% if site_config.where_placeholder %}placeholder="{{ site_config.where_placeholder }}"{% endif %} placeholder="city,state,country" />
                   <i class="glyphicon glyphicon-map-marker" aria-hidden="true"></i>
                 </span>
               </div>
-              <div class="col-xs-12 col-md-4 text-left">
+              <div class="col-xs-12 col-sm-4 col-md-4 text-left">
                 <span class="submit-section">
                   <input alt="Submit Search" class="search-submit" type="submit" value="Search" />
                   <a class="share-social search-submit" href="#"><img class="share-icon" src="{{ STATIC_URL }}images/share-icon.png" alt="share" /></a>


### PR DESCRIPTION
Purpose of this PR is to gracefully transition from desktop view to iPhone 5 sized devices view.  End users will get the "full Monty" at screen size 992px and greater.  Between 991px and 769px, end users get a larger tablet view with smaller versions of the top bar and smaller footer.  At 768px and below, end users will get the full mobile web interface.

To test:

1.  Please switch to v2 template.

2. Navigate in desktop view, not much change here.

3. Decrease browser size to less than 991px but greater than 768px, please ensure that there is a "Filter Search Criteria" button, please click on it, this will toggle the visibility of the filter facets.  Please ensure search functionality still works.

4. Decrease browser size to less than 768px or use Chrome's mobile device simulator tools for a specific mobile device.  Please ensure the mobile view shows up, this is the same mobile view that is already in Quality Control now.