### PR TITLE
[PD-2692] added DOM id's for mobile bottom navigation bar

### DIFF
--- a/myjobs/templatetags/common_tags.py
+++ b/myjobs/templatetags/common_tags.py
@@ -281,6 +281,7 @@ def get_menus(context):
         "icon": "icon-envelope icon-white",
         "mobile_icon_v2": "glyphicon glyphicon-envelope",
         "iconLabel": str(new_messages.count() if new_messages else 0),
+        "mobile_submenuId": "mobile-messages",
         "submenus": [
             {
                 "id": "menu-inbox-all",
@@ -295,6 +296,7 @@ def get_menus(context):
             "label": "Beta",
             "id": "beta-menu",
             "mobile_icon_v2": "glyphicon glyphicon-flag",
+            "mobile_submenuId": "mobile-beta",
         })
 
         try:
@@ -368,6 +370,7 @@ def get_menus(context):
         "id": "profile_mobile_v2",
         "mobile_icon_v2": "glyphicon glyphicon-user",
         "label_mobile_v2": "Profile",
+        "mobile_submenuId": "mobile-profile",
         "submenus": [
             {
                 "id": "profile-tab",

--- a/templates/includes/topbar_v2.html
+++ b/templates/includes/topbar_v2.html
@@ -64,7 +64,7 @@
         <ul class="mob-nav-section">
             {% for menu in menus %}
                 <li class="col-xs-3 mob-nav-content mobile-trigger" {% if menu.submenus %}class=""{% endif %}>
-                  <a id="{{ menu.id }}" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
+                  <a id="{{ menu.id }}-mobile" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
                       {% if menu.mobile_icon_v2 %}
                           <i class="{{ menu.mobile_icon_v2 }}"></i>
                       {% endif %}


### PR DESCRIPTION
Purpose of PR is to lay the groundwork for the scrolling sub-sub menu in Mobile view in PD-2675, I created 3 new DOM ID's for mobile nav and I appended -mobile to a pre-existing ID call: id="{{ menu.id }}, the reason for this last one is because the Desktop view already has an ID call "employer".  I'm creating this PR separate from PD-2675 because there are other areas in the UI that can benefit from this PR.  This PR doesn't change anything visually in the browser, only changes in the DOM structure itself.

To test:

1. Please switch to v2 template and browser mobile simulator view.

2. Please inspect the DOM and ensure that these ID's exists: mobile-messages, mobile-beta, mobile-profile, mobile-employer-apps, and employers-mobile.