### PR TITLE
[PD-2693] Desktop top nav last tab sub menu 

### DIFF
--- a/gulp/src/sass/seo_base_styles.scss
+++ b/gulp/src/sass/seo_base_styles.scss
@@ -227,7 +227,7 @@ a.direct_optionsLess {
   }
 
   .menu-container > ul > li:last-of-type > ul {
-      right: 0;
+      left: 0;
   }
 
   .menu-container > ul > li:hover > ul {


### PR DESCRIPTION
Purpose of PR is to change desktop top nav last tab sub menu from right-aligned to left-aligned for better UX, got approval from Jason Sole for this last week.

To test:

1. Please switch to v2 template.

2. In desktop view, please hover over the last tab on the top nav and ensure that it's left-aligned.