### PR TITLE
Improve the initial sending of partner saved searches [PD-2682]

### DIFF
--- a/myjobs/tests/test_views.py
+++ b/myjobs/tests/test_views.py
@@ -25,8 +25,8 @@ from mymessages.tests.factories import MessageInfoFactory
 from mypartners.tests.factories import PartnerFactory
 from myprofile.models import Name, Education
 from myprofile.tests.factories import SecondaryEmailFactory
-from mysearches.models import PartnerSavedSearch
 from mysearches.models import SavedSearch, SavedSearchLog
+from mysearches.tests.factories import PartnerSavedSearchFactory
 from registration import signals as custom_signals
 from registration.models import ActivationProfile
 from secrets import options, my_agent_auth
@@ -798,9 +798,9 @@ class MyJobsViewsTests(MyJobsBase):
         # should not have any messages
         self.assertFalse(creator.message_set.all())
 
-        PartnerSavedSearch.objects.create(user=self.user, provider=company,
-                                          created_by=creator,
-                                          partner=partner)
+        PartnerSavedSearchFactory(user=self.user, provider=company,
+                                  created_by=creator,
+                                  partner=partner)
 
         # simulate a user opting out
         self.user.opt_in_myjobs = False
@@ -833,9 +833,9 @@ class MyJobsViewsTests(MyJobsBase):
         # should not have any messages
         self.assertFalse(creator.message_set.all())
 
-        PartnerSavedSearch.objects.create(user=self.user, provider=company,
-                                          created_by=creator,
-                                          partner=partner)
+        PartnerSavedSearchFactory(user=self.user, provider=company,
+                                  created_by=creator,
+                                  partner=partner)
 
         self.client.get(reverse('unsubscribe_all'))
 

--- a/mysearches/models.py
+++ b/mysearches/models.py
@@ -597,7 +597,7 @@ class PartnerSavedSearch(SavedSearch):
         super(PartnerSavedSearch, self).save(*args, **kwargs)
         if new:
             now = datetime.now()
-            after_ten = now.hour >= 10
+            after_ten = now.hour > 10 or (now.hour == 10 and now.minute > 0)
             from tasks import send_search_digest
             if after_ten:
                 if self.frequency == 'D':

--- a/mysearches/models.py
+++ b/mysearches/models.py
@@ -598,15 +598,16 @@ class PartnerSavedSearch(SavedSearch):
         if new:
             now = datetime.now()
             after_ten = now.hour >= 10
+            from tasks import send_search_digest
             if after_ten:
                 if self.frequency == 'D':
-                    self.send_email()
+                    send_search_digest.s(self).apply_async()
                 elif self.frequency == 'W':
                     if int(self.day_of_week) == now.isoweekday():
-                        self.send_email()
+                        send_search_digest.s(self).apply_async()
                 elif self.frequency == 'M':
                     if self.day_of_month == now.day:
-                        self.send_email()
+                        send_search_digest.s(self).apply_async()
 
     def create_record(self, change_msg=None, body=None, failure_message=None):
         """

--- a/mysearches/models.py
+++ b/mysearches/models.py
@@ -582,6 +582,7 @@ class PartnerSavedSearch(SavedSearch):
     last_action_time = models.DateTimeField(default=datetime.now, blank=True)
 
     def save(self, *args, **kwargs):
+        new = not hasattr(self, 'id') or not self.id
         if hasattr(self, 'changed_data') and hasattr(self, 'request'):
             # This save was initiated by a form. Update unsubscriber and send
             # notifications as appropriate.
@@ -594,6 +595,18 @@ class PartnerSavedSearch(SavedSearch):
                     self.unsubscribed = True
                     self.user.send_opt_out_notifications([self])
         super(PartnerSavedSearch, self).save(*args, **kwargs)
+        if new:
+            now = datetime.now()
+            after_ten = now.hour >= 10
+            if after_ten:
+                if self.frequency == 'D':
+                    self.send_email()
+                elif self.frequency == 'W':
+                    if int(self.day_of_week) == now.isoweekday():
+                        self.send_email()
+                elif self.frequency == 'M':
+                    if self.day_of_month == now.day:
+                        self.send_email()
 
     def create_record(self, change_msg=None, body=None, failure_message=None):
         """

--- a/mysearches/tests/test_models.py
+++ b/mysearches/tests/test_models.py
@@ -7,6 +7,7 @@ from django.conf import settings
 from django.core import mail
 
 from bs4 import BeautifulSoup
+from freezegun import freeze_time
 from mock import patch, Mock
 
 from myjobs.tests.setup import MyJobsBase
@@ -262,7 +263,7 @@ class SavedSearchModelsTests(MyJobsBase):
         search.send_email()
         record = ContactRecord.objects.get(tags__name=tag.name)
         self.assertTrue(record.contactlogentry.successful)
-
+  
     @patch('mysearches.models.send_email')
     def test_send_pss_fails(self, mock_send_email):
         """
@@ -597,6 +598,52 @@ class PartnerSavedSearchTests(MyJobsBase):
             'last_sent__isnull': True,
         }
         self.assertEqual(SavedSearch.objects.filter(**kwargs).count(), 0)
+
+    @freeze_time("2016-10-01 11:00:00")
+    def test_send_pss_after_10(self):
+        """
+        Ensures that partner saved searches that are created and scheduled for
+        today are sent immediately if they are saved after the batch sending
+        process begins.
+        """
+        company = CompanyFactory()
+        partner = PartnerFactory(owner=company)
+
+        communication_records = ContactRecord.objects.count()
+
+        # The act of creating a daily partner saved search after 10 AM should
+        # send the saved search being created.
+        PartnerSavedSearchFactory(user=self.user, created_by=self.user,
+                                  provider=company, partner=partner,
+                                  frequency='D')
+
+        self.assertEqual(ContactRecord.objects.count(),
+                         communication_records + 1,
+                         msg=("No communication record after "
+                              "daily search creation"))
+
+        today = datetime.date.today()
+
+        # Creating a weekly partner saved search with a day_of_week of today
+        # should send the saved search on save.
+        PartnerSavedSearchFactory(user=self.user, created_by=self.user,
+                                  provider=company, partner=partner,
+                                  frequency='W',
+                                  day_of_week=today.isoweekday())
+
+        self.assertEqual(ContactRecord.objects.count(),
+                         communication_records + 2,
+                         msg=("No communication record after "
+                              "weekly search creation"))
+
+        PartnerSavedSearchFactory(user=self.user, created_by=self.user,
+                                  provider=company, partner=partner,
+                                  frequency='M', day_of_month=today.day)
+
+        self.assertEqual(ContactRecord.objects.count(),
+                         communication_records + 3,
+                         msg=("No communication record after "
+                              "monthly search creation"))
 
 
 class SavedSearchSendingTests(MyJobsBase):

--- a/mysearches/tests/test_models.py
+++ b/mysearches/tests/test_models.py
@@ -599,7 +599,7 @@ class PartnerSavedSearchTests(MyJobsBase):
         }
         self.assertEqual(SavedSearch.objects.filter(**kwargs).count(), 0)
 
-    @freeze_time("2016-10-01 11:00:00")
+    @freeze_time("2016-10-01 10:01:00")
     def test_send_pss_after_10(self):
         """
         Ensures that partner saved searches that are created and scheduled for

--- a/requirements.txt
+++ b/requirements.txt
@@ -61,3 +61,4 @@ django-impersonate==0.9.2  # 0.9.2 is the last version with Django 1.6 support
 pymongo==3.2.2
 html5lib==0.999 #Put in place because as of 2016-07-18 bleach depends on html5lib>=0.999 and the latest version of html5lib is screwed up.
 python-dateutil==2.4.2
+freezegun==0.3.7


### PR DESCRIPTION
Some criteria need to be met for this to occur:

* You're creating a partner saved search that should be sent today (today is Thursday, Oct 20 and your search matches one of the following: daily, weekly on Thrusday, monthly on the 20th)
* It's after 10:00 AM

If both of those are true, the search will be queued immediately for sending.

Testing:
* If it's before 10:00 AM, wait until that is no longer the case
* Create a partner saved search scheduled for today
* ???
* Profit!