### PR TITLE
[PD-2675] Added companies to Employers sub menu in mobile view

### DIFF
--- a/gulp/src/sass/seo_base_styles.scss
+++ b/gulp/src/sass/seo_base_styles.scss
@@ -947,11 +947,11 @@ margin-bottom: 50px;
       }
     }
   }
-  .mob-nav-section .mob-nav-content:nth-of-type(3) .mobile-submenu {
+  #mobile-employer-apps {
     margin-left: calc(-1 * ((100vw - 100%)));
     width: 100vw !important;
     left: 86%;
-    top: -260px !important;
+    top: -25.5rem;
 
     li {
       text-align: left;
@@ -960,11 +960,28 @@ margin-bottom: 50px;
 
       a {
         color: $primary-navy-blue;
-        display: inline-block;
-        width: 100%;
       }
     }
   }
+
+  #mobile_select_company {
+    display: none;
+    max-height: 8.1rem;
+    max-width: 34rem;
+    overflow-y: scroll;
+  }
+
+  /** Be default iOS devices hides scroll bar, this makes all devices show scroll bar for nested sub menus **/
+  ::-webkit-scrollbar {
+    -webkit-appearance: none;
+    width: 2.7rem;
+  }
+  ::-webkit-scrollbar-thumb {
+    border-radius: 0.5rem;
+    background-color: rgba(0,0,0,.5);
+    -webkit-box-shadow: 0 0 1px rgba(255,255,255,.5);
+  }
+
   .mob-nav-section .mob-nav-content:nth-of-type(4) .mobile-submenu {
       margin-left: calc(-1 * ((100vw - 100%) / 2));
       width: 100vw !important;

--- a/static/topbar_v2.js
+++ b/static/topbar_v2.js
@@ -1,4 +1,3 @@
-//TODO: as time permits, figure what's truly needed in here
 var readCookie = utils.readCookie;
 
 $(window).ready(function () {
@@ -9,6 +8,10 @@ $(window).ready(function () {
     $.each($('li.mobile-trigger'), function(i) {
       var self = $(this);
       var currentListItem = self.children('.mobile-submenu').children('.mobile-sub-nav');
+      currentListItem.on('click', function(e) {
+        e.stopPropagation();
+      });
+
       self.on('click', function(e) {
         e.stopPropagation();
         $('.mobile-submenu').children('.mobile-sub-nav').not(currentListItem).removeClass('mobile-list-open');
@@ -118,7 +121,18 @@ function get_companies() {
         mobile_link = document.createElement("a");
     mobile_parent_list_item.setAttribute("id", "mobile-parent-company-list");
     mobile_parent_list_item.setAttribute("class", "mobile-sub-nav");
-    mobile_link.innerHTML = "<strong>" + menu_company_name + "</strong>";
+    // This is for the toggling of Employers list of companies
+    $(mobile_parent_list_item).bind("click", function (event) {
+        event.preventDefault();
+        var mobile_li_last_child = mobile_parent_list_item.lastChild;
+
+        if (mobile_li_last_child.currentStyle ? mobile_li_last_child.currentStyle.display : getComputedStyle(mobile_li_last_child, null).display === "none")
+            mobile_li_last_child.style.display = "block";
+        else
+            mobile_li_last_child.style.display = "none";
+    });
+
+    mobile_link.innerHTML = "<strong><span class='glyphicon glyphicon-triangle-bottom'></span> " + menu_company_name + "</strong>";
     mobile_parent_list_item.appendChild(mobile_link);
 
     var pop_menu = document.getElementById("mobile-employer-apps");


### PR DESCRIPTION
Purpose of PR is to add a listing of expandable/collapsible companies as a sub menu under the Employers tab in mobile view to match the desktop view.

To test:

1. Please switch to v2 template in admin and switch to mobile device view in browser.

2. Please switch to Super User and "modify" your roles so that you have as many companies as possible under the Employers tab.  Important for testing scrolling later.

3. Please click on Employers tab in bottom nav, the name of 1 company should appear in bold font with a "down caret" icon to the left of it, under Manage Users. By default the sub sub menu should be in collapsed state.  Please click on the "down caret" icon or name of company to expand/collapse.

4. When companies list is expanded, please test the scrolling of the list (I have 6 companies in my profile).

5. Please click on any company in the list and note the name of the company that you clicked on, at this point, the page will refresh.  Once browser refresh is done, please go back to Employers tab and ensure that the name of the company matches the name of the company that you clicked on previously.  Please do this with as many companies as you have in  your list, unless you have over 20 companies.