### PR TITLE
[PD-2690] my.jobs - new templates - logo alignment can't handle long names

### DIFF
--- a/gulp/src/sass/seo_base_styles.scss
+++ b/gulp/src/sass/seo_base_styles.scss
@@ -315,8 +315,8 @@ a.direct_optionsLess {
 #brand_logo {
   .logo {
     position: relative;
-    width: 12rem;
-    height: 8rem;
+    width: 17rem;
+    height: 9rem;
   }
   .logo-text {
     position: relative;
@@ -1242,9 +1242,9 @@ margin-bottom: 50px;
       width: 32%;
     }
     .site-name {
-      left: 6%;
+      left: 10%;
       bottom: 15px;
-      font-size: 3rem;
+      font-size: 2.8rem;
     }
   }
 }

--- a/static/seo-base-scripts.js
+++ b/static/seo-base-scripts.js
@@ -244,3 +244,14 @@ JAVASCRIPT FOR THE NEW REBRANDING HOMEPAGE FUNCTIONALITY
   }
 
   showHideHeaderScroll();
+
+(function(){
+  var siteName = $('.site-name').text();
+
+  if(siteName.length > 10){
+    var currentPosLeft = 0;
+    var newLength = siteName.length - 10;
+    var posLeft = newLength * 4;
+    $('.site-name').css('left', currentPosLeft - posLeft + '%');
+  }
+})();


### PR DESCRIPTION
Editing the logo so it is centered with longer names and doesn't wrap.

Test:
You will have to pick a name in the admin panel that is a long .jobs name. I was using PhiladelphiaEngineering.jobs and also PhiladelphiaMedicalAssistant.jobs. When you configure inside of admin, make sure it's Version 2 as well as using the home_page_listing_bootstrap3.html template. Will have to check with Jason Sole to make sure this is somewhat of how they want it for the logo instead of having it wrap it will be dynamically centered depending on the length of the text.