### PR TITLE
[PD-2702] re-style mobile Employers tab company list

### DIFF
--- a/gulp/src/sass/seo_base_styles.scss
+++ b/gulp/src/sass/seo_base_styles.scss
@@ -985,7 +985,6 @@ margin-bottom: 50px;
   }
 
   #mobile_select_company {
-    display: none;
     max-height: 8.1rem;
     max-width: 34rem;
     overflow-y: scroll;

--- a/gulp/src/sass/seo_base_styles.scss
+++ b/gulp/src/sass/seo_base_styles.scss
@@ -964,7 +964,7 @@ margin-bottom: 50px;
   #mobile-employer-apps {
     margin-left: calc(-1 * ((100vw - 100%)));
     width: 100vw !important;
-    left: 86%;
+    left: 84%;
     top: -25.5rem;
 
     li {
@@ -975,6 +975,12 @@ margin-bottom: 50px;
       a {
         color: $primary-navy-blue;
       }
+    }
+
+    /* Rule for the "companies" list in Employers sub menu,
+      creates white background to hide gap when companies are in collapsed state. */
+    #mobile-parent-company-list {
+      height: 12.2rem;
     }
   }
 


### PR DESCRIPTION
Purpose of PR:  hide the gap in mobile view when the Employers tab is triggered and the Companies list is in collapsed state.  This is the look that Jason Sole and I had agreed upon.

To test:

1.  Please switch to v2 template and mobile view.

2. Please enable "companies" role.

3. Please ensure that when the Employers tab is triggered and the Companies list is in expanded state, and when the Companies list is in collapsed state, the background from the end of the list to the top of Nav bar should be white.

Before:
![before](https://cloud.githubusercontent.com/assets/5124153/19693296/fd2b2982-9aa8-11e6-9246-470248613ea4.png)



After:
![after](https://cloud.githubusercontent.com/assets/5124153/19700365/0e469474-9ac5-11e6-8fe0-1dcb6933d29e.png)

