### PR TITLE
[PD-2717] Made dot jobs logo smaller in smaller screens

### DIFF
--- a/gulp/src/sass/seo_base_styles.scss
+++ b/gulp/src/sass/seo_base_styles.scss
@@ -522,6 +522,13 @@ margin-bottom: 50px;
     @extend .global-btn;
     text-align: center;
   }
+  .search-submit-moc {
+    @extend .global-btn;
+    text-align: center;
+  }
+  .share-social.search-submit-moc {
+    min-width: 7rem;
+  }
   .search-show-all {
     font-size: 12px;
     position: relative;
@@ -653,6 +660,14 @@ margin-bottom: 50px;
     }
   }
   .search-submit {
+    display: inline-block;
+    margin: 0 15px 10px 0;
+    padding: 9px;
+    font-size: 18px;
+    border-radius: 3px;
+    font-weight: 100;
+  }
+  .search-submit-moc {
     display: inline-block;
     margin: 0 15px 10px 0;
     padding: 9px;
@@ -932,27 +947,66 @@ margin-bottom: 50px;
 /*==========  Mobile First Approach  ==========*/
 
 /* Custom, iPhone Retina */
-
-@media only screen and (min-width : 320px) and (max-width: 768px) {
-  /** Be default iOS devices hides scroll bar,
-  this makes all devices show scroll bar for nested sub menus **/
+@media only screen and (min-width: 320px) and (max-width: 480px) {
+    /** Be default iOS devices hides scroll bar,
+  this makes all devices show scrollbar for nested sub menus **/
   ::-webkit-scrollbar {
     -webkit-appearance: none;
-    width: 1.8rem;
+    width: 1.5rem;
   }
   ::-webkit-scrollbar-thumb {
-    border-radius: 0.5rem;
-    background-color: rgba(0,0,0,.5);
+    border-radius: 0.2rem;
+    background-color: rgba(0, 0, 0, .5);
   }
 }
 
-@media only screen and (min-width : 320px) {
+@media only screen and (min-width : 320px) and (max-width: 768px) {
+
+  #main_nav {
+    margin-bottom: 3.5rem;
+  }
+
+  #main_content {
+	margin-top: 0px;
+    margin-bottom: 0px;
+  }
+
+  #brand_logo {
+    .logo{
+      width: 100%;
+      height: 4rem;
+    }
+
+    .location-logo {
+      margin-bottom: .2rem;
+    }
+
+    .site-name {
+      font-size: 2.1rem;
+    }
+  }
+
+  #mobile_footer {
+    height: 6.2rem ;
+
+    i {
+      font-size: 2.5rem !important;
+    }
+  }
+
+  .mob-nav-content {
+    padding: .8rem 0 0 0;
+  }
+
+}
+
+@media only screen and (min-width : 320px) and (max-width: 769px) {
 
   .mob-nav-section .mob-nav-content:nth-of-type(1) .mobile-submenu {
     margin-left: calc(-1 * ((100vw - 100%) / 10));
     width: 100vw !important;
     left: 41%;
-    top: -90px;
+    top: -8.1rem;
 
     li {
       text-align: left;
@@ -969,7 +1023,7 @@ margin-bottom: 50px;
 
   #mobile-messages {
     &:nth-of-type(1) {
-       top: -9.2rem;
+       top: -8.1rem;
     }
   }
 
@@ -994,7 +1048,7 @@ margin-bottom: 50px;
 
   #mobile-profile {
     &:last-of-type {
-       top: -21rem;
+       top: -20.3rem;
     }
   }
 
@@ -1002,7 +1056,7 @@ margin-bottom: 50px;
     margin-left: calc(-1 * ((100vw - 100%)));
     width: 100vw !important;
     left: 84%;
-    top: -25.5rem;
+    top: -24.5rem;
 
     li {
       text-align: left;
@@ -1030,8 +1084,8 @@ margin-bottom: 50px;
   .mob-nav-section .mob-nav-content:nth-of-type(4) .mobile-submenu {
       margin-left: calc(-1 * ((100vw - 100%) / 2));
       width: 100vw !important;
-      right: 13%;
-      top: -215px !important;
+      right: 14%;
+      top: -215px;
 
       li {
         text-align: left;
@@ -1094,16 +1148,6 @@ margin-bottom: 50px;
     .location-logo-text, .logo, .site-name {
       display: block;
       text-align: center;
-    }
-    .logo{
-      width: 100%;
-      height: 8rem;
-    }
-    .location-logo {
-      margin-bottom: 20px;
-    }
-    .site-name{
-      font-size: 2.3rem;
     }
 
   }
@@ -1183,7 +1227,13 @@ margin-bottom: 50px;
     .search-submit {
       width: 94%;
     }
+    .search-submit-moc {
+      width: 94%;
+    }
     .share-social.search-submit {
+      display: none;
+    }
+    .share-social.search-submit-moc {
       display: none;
     }
     .breadcrumb-row {
@@ -1237,50 +1287,6 @@ margin-bottom: 50px;
 	}
 }
 
-/* Extra Small Devices, Phones */
-@media only screen and (min-width : 480px) {
-  .mob-nav-section .mob-nav-content:nth-of-type(1) .mobile-submenu {
-    margin-left: calc(-1 * ((100vw - 100%) / 10));
-    left: 40%;
-  }
-  .mob-nav-section .mob-nav-content:nth-of-type(2) .mobile-submenu {
-    margin-left: calc(-1 * ((100vw - 100%) / 2));
-    left: 50%;
-  }
-  .mob-nav-section .mob-nav-content:nth-of-type(3) .mobile-submenu {
-    margin-left: calc(-1 * ((100vw - 100%)));
-    left: 88%;
-  }
-  .mob-nav-section .mob-nav-content:nth-of-type(4) .mobile-submenu {
-      margin-left: calc(-1 * ((100vw - 100%) / 2));
-      right: 12%;
-  }
-
-  #mobile_social_media {
-    padding-top: 50px;
-    margin: 0 auto;
-    width: 52%;
-  }
-
-  #direct_jobListingTitle, .jobs-found {
-    width: 95%;
-  }
-
-  #brand_logo {
-    .logo{
-      width: 100%;
-      height: 8rem;
-    }
-    .location-logo {
-      margin-bottom: 20px;
-    }
-    .site-name{
-      font-size: 2.6rem;
-    }
-
-  }
-}
-
 /* Small Devices, Tablets */
 @media only screen and (min-width : 768px) {
   .mob-nav-section .mob-nav-content:nth-of-type(1) .mobile-submenu {
@@ -1293,7 +1299,7 @@ margin-bottom: 50px;
   }
   .mob-nav-section .mob-nav-content:nth-of-type(3) .mobile-submenu {
     margin-left: calc(-1 * ((100vw - 100%)));
-    left: 93%;
+    left: 93% !important;
   }
   .mob-nav-section .mob-nav-content:nth-of-type(4) .mobile-submenu {
       margin-left: calc(-1 * ((100vw - 100%) / 2));
@@ -1307,26 +1313,26 @@ margin-bottom: 50px;
   #direct_jobListingTitle, .jobs-found {
     width: 95%;
   }
-  #brand_logo {
-    .logo{
-      width: 100%;
-      height: 8rem;
-    }
-    .location-logo {
-      margin-bottom: 30px;
-    }
-    .site-name{
-      font-size: 3rem;
-    }
 
-  }
+  .navbar-nav.navbar-right.right-nav {
+
+      .dropdown {
+        a {
+          font-size: 1.7rem;
+        }
+      }
+    }
 
 }
 
-/* DirectEmployers Mobile Break Point iPad */
+/* Newer Higher Res Tablets */
 @media only screen
   and (min-width: 769px)
   and (max-width: 991px) {
+
+  #main_content {
+    margin-top: 0;
+  }
 
   .ui-autocomplete {
     width: 25rem;
@@ -1389,6 +1395,11 @@ margin-bottom: 50px;
       padding: 0.9rem 2rem;
     }
 
+    .search-submit-moc {
+      margin: 0;
+      padding: 0.9rem 1rem 0.9rem 1rem;
+    }
+
     .submit-section {
       padding: 0;
     }
@@ -1426,7 +1437,7 @@ margin-bottom: 50px;
 
       .dropdown {
         a {
-          font-size: 1.8rem;
+          font-size: 1.7rem;
         }
       }
     }
@@ -1443,13 +1454,13 @@ margin-bottom: 50px;
   #brand_logo {
     .logo{
       width: 100%;
-      height: 8rem;
+      height: 5rem;
     }
     .location-logo {
-      margin-bottom: 30px;
+      margin-bottom: 1.5rem;
     }
     .site-name{
-      font-size: 3rem;
+      font-size: 2.7rem;
     }
 
   }
@@ -1534,6 +1545,9 @@ margin-bottom: 50px;
     .search-submit {
       width: 32%;
     }
+    .search-submit-moc {
+      width: auto;
+    }
     .caret-up {
       left: 63%;
     }
@@ -1557,6 +1571,9 @@ margin-bottom: 50px;
       padding: 0;
     }
     .share-social.search-submit {
+      display: inline-block;
+    }
+    .share-social.search-submit-moc {
       display: inline-block;
     }
   }
@@ -1603,6 +1620,16 @@ margin-bottom: 50px;
 			width: 35%;
 		}
 	}
+}
+
+/* The M.O.C. place holder text is long,
+    this makes it easier to read at certain screen sizes. */
+@media only screen and (min-width : 769px) and (max-width: 1290px){
+
+  #moc::-webkit-input-placeholder {
+    font-size: 1.1rem;
+  }
+
 }
 
 /* Large Devices, Wide Screens */

--- a/templates/includes/topbar_v2.html
+++ b/templates/includes/topbar_v2.html
@@ -59,7 +59,6 @@
 {% get_menus as menus %}
 <nav id="mobile_footer" class="menu-container" role="menu">
   <div class="row">
-    <div>
       {% if user.is_authenticated and request.session.keys|length %}
         <ul class="mob-nav-section">
             {% for menu in menus %}
@@ -106,7 +105,7 @@
             </li>
         </ul>
       {% endif %}
-    </div>
+
   </div>
 </nav>
 

--- a/templates/v2/includes/search_box_vets_widget.html
+++ b/templates/v2/includes/search_box_vets_widget.html
@@ -10,29 +10,29 @@
   {% endif %}
         <div class="search-section">
           <div class="row">
-            <div class="col-xs-12 col-md-3">
+            <div class="col-xs-12 col-sm-3 col-md-3">
               <span class="what-section">
                 <input title="Search Phrase" type="text" name="q" id="q" class="micrositeTitleField what" {% if title_term != "\*" %}value="{{ title_term }}"{% endif %} {% if site_config.what_placeholder %}placeholder="{{ site_config.what_placeholder }}"{% endif %} placeholder="job,title,keyword" />
                 <i class="glyphicon glyphicon-search" aria-hidden="true"></i>
               </span>
             </div>
-              <div class="col-xs-12 col-md-3">
+              <div class="col-xs-12 col-sm-3 col-md-3">
                 <span class="where-section">
                   <input title="Search Location" type="text" name="location" id="location" class="micrositeLocationField where" {% if location_term != "\*" %}value="{{ location_term }}"{% endif %} {% if site_config.where_placeholder %}placeholder="{{ site_config.where_placeholder }}"{% endif %} placeholder="city,state,country" />
                   <i class="glyphicon glyphicon-map-marker" aria-hidden="true"></i>
                 </span>
               </div>
-              <div class="col-xs-12 col-md-3">
+              <div class="col-xs-12 col-sm-3 col-md-3">
                 <span class="moc-section">
                   <input title="Search MOC" type="text" name="moc" id="moc" class="micrositeMOCField moc" {% if moc_term != "\*" %}value="{{ moc_term }}"{% endif %} {% if site_config.moc_placeholder %}placeholder="{{ site_config.moc_placeholder }}"{% endif %} placeholder="military job title or code"/>
                   <i class="glyphicon glyphicon-search" aria-hidden="true"></i>
                   <input type="hidden" name="moc_id" id="moc_id" {% if moc_id_term != "\*" %}value="{{ moc_id_term }}"{% endif %}/>
                 </span>
               </div>
-              <div class="col-xs-12 col-md-3 text-left">
+              <div class="col-xs-12 col-sm-3 col-md-3 text-left">
                 <span class="submit-section">
-                  <input alt="Submit Search" class="search-submit" type="submit" value="Search" />
-                  <a class="share-social search-submit" href="#"><img class="share-icon" src="{{ STATIC_URL }}images/share-icon.png" alt="share" /></a>
+                  <input alt="Submit Search" class="search-submit-moc" type="submit" value="Search" />
+                  <a class="share-social search-submit-moc" href="#"><img class="share-icon" src="{{ STATIC_URL }}images/share-icon.png" alt="share" /></a>
                 </span>
               </div>
           </div>


### PR DESCRIPTION
Purpose of PR:  Reduce the size of the dot jobs logo in smaller screen sizes to make room for jobs related elements in v2.  Also restyled MOC v2 template because the search elements was difficult to use in smaller screen sizes.

Before:
![before_1](https://cloud.githubusercontent.com/assets/5124153/19862073/43c5120c-9f65-11e6-8df9-0633c789c55a.png)

After:
![after_1](https://cloud.githubusercontent.com/assets/5124153/19862095/556bec24-9f65-11e6-85d0-4a8b984dfd07.png)

Before (missing nav in tablet view):
![before_2_tablet](https://cloud.githubusercontent.com/assets/5124153/19862108/5e41d034-9f65-11e6-91b8-d08c9110802e.png)

After (fixed):
![after_2_tablet](https://cloud.githubusercontent.com/assets/5124153/19862114/665cc79c-9f65-11e6-94f0-eaabb58f6c68.png)

Before (MOC place holder and button text hard to read):
![before_3_buttons](https://cloud.githubusercontent.com/assets/5124153/19862127/6dc7fc36-9f65-11e6-9098-d0ad2d092784.png)

After (fixed):
![after_3_buttons](https://cloud.githubusercontent.com/assets/5124153/19862132/7586e2fc-9f65-11e6-9908-a920c1723589.png)


To test: 

1. Please switch to v2.

2.  Shrink screen size to see dot jobs logo getting smaller.  If all is well on the client side, the screen should look like the "after" pics.