### PR TITLE
[ST-3226] Made auto-complete drop down list same size always

### DIFF
--- a/gulp/src/sass/seo_base_styles.scss
+++ b/gulp/src/sass/seo_base_styles.scss
@@ -93,7 +93,6 @@ legend{
   max-height: 20rem;
   overflow-y: auto;
   background: $white;
-  width: 29rem;
   border: 1px solid #999;
   font-size: 1.5rem;
 }
@@ -1332,10 +1331,6 @@ margin-bottom: 50px;
 
   #main_content {
     margin-top: 0;
-  }
-
-  .ui-autocomplete {
-    width: 25rem;
   }
 
   .ui-menu-item a:hover, .ui-menu-item-alternate a:hover {

--- a/static/seo-base-scripts-181-27.js
+++ b/static/seo-base-scripts-181-27.js
@@ -1,5 +1,5 @@
 /**
- * Legacy es5.1 functions used in seo_base.html template
+ * Legacy es5.1 functions used in seo_base_bootstrap3.html template
 **/
 
 $(document).ready(function() {
@@ -42,7 +42,6 @@ $(document).ready(function() {
                 url: "/ajax/ac/?lookup=location&term="+request.term,
                 dataType: "jsonp",
                 success: function( data ) {
-                    //alert(data[1].label);
                     response( $.map( data, function( item ) {
                         return {
                             label: item.location + " - (" + item.jobcount + ")",
@@ -83,18 +82,18 @@ $(document).ready(function() {
             .appendTo( ul );
   };
 
-  // Submit the search form if location AND title fields have a value in them.
+  // Size the width of the drop down list to match width of input, always, in any size, without CSS
+  $.ui.autocomplete.prototype._resizeMenu = function() {
+      var ul = this.menu.element;
+      ul.outerWidth(this.element.outerWidth());
+  };
+
+  // Submit the search form if location AND title fields have a value in them (and MOC if applicable).
   $("#standardSearch input[type=text]").bind("autocompleteselect", function(event, ul) {
         /**
-            This applies to the MOC, Location, and Title fields on the
-            standardSearch form.
-
             Inputs:
             :event: The autocompleteselect event
             :ul: The autocomplete object (an unordered list)
-
-            Returns:
-            Nothing (but does submit search form if both fields have values)
          **/
         $(this).val(ul.item.value);
         if ($('#moc').length > 0) {


### PR DESCRIPTION
Purpose of PR:  To address J. Sole user testing feedback. I made the autocomplete drop down list the same size as the input box for all screen size.

To test:

1. Please switch to v2 template.

2. Please try the autocomplete functionality in various screen sizes, the drop down list should  match the width of the input boxes that they are triggered from.

Before Fix (size not matching):
![before_oh_noes](https://cloud.githubusercontent.com/assets/5124153/19899761/9edacd6c-a037-11e6-8a76-b91a8aa6a122.png)

After (input and drop down match regardless of screen size):
![after](https://cloud.githubusercontent.com/assets/5124153/19899806/c978d320-a037-11e6-9e96-8d17b0ac601d.png)

