### PR TITLE
[PD-2724] Removed reference to v1 Javascript file and CSS, not needed

### DIFF
--- a/gulp/src/sass/seo_base_styles.scss
+++ b/gulp/src/sass/seo_base_styles.scss
@@ -1520,7 +1520,6 @@ margin-bottom: 50px;
      }
   }
   #direct-saved-search-box {
-    margin-bottom: -31px;
 
     .email-box {
       margin-top: 0px;

--- a/templates/v2/job_listing.html
+++ b/templates/v2/job_listing.html
@@ -1,5 +1,4 @@
 {% extends "seo_base_bootstrap3.html" %}
-{% load i18n %}
 {% load seo_extras %}
 {% load job_setup %}
 {% load cache %}
@@ -12,7 +11,6 @@
 {% block seo_description %}{% endblock %}
 {% block directseo_bodySchema %}itemscope itemtype="http://schema.org/ItemCollection"{% endblock %}
 {% block direct_extraHeaderContent %}
-<link rel="stylesheet" href="/style/def.ui.dotjobs.results.css" type="text/css">
 {%endblock%}
 
 {% block rss_feed %}
@@ -36,10 +34,9 @@
 {% endblock %}
 
 {% block directseo_main_content %}
-<!-- <a href="#filters" class="direct_mobileJumpLink">{% blocktrans %}Jump to Filters{% endblocktrans %}</a> -->
 <h3 class="jobs-found direct_highlightedText">
 {% if not count_heading %}
-    {% blocktrans %}All Jobs{% endblocktrans %}
+    All Jobs
 {% else %}
     {% if breadbox.company_breadcrumb %}
         <span class="direct_jobListingCompany">{{ breadbox.company_breadcrumb.display_title }} Careers</span>
@@ -61,7 +58,6 @@
         {% if site_config.use_secure_blocks %}
         <div data-secure_block_id="saved_search"></div>
         {% else %}
-        <script src="//d2e48ltfsb5exy.cloudfront.net/myjobs/tools/def.myjobs.widget.153-05.js"></script>
         <div id="direct-saved-search-box" class="facets direct_rightColBox direct-action-box">
           <div class="email-box">
             <h3 class="get-email-title">Save &amp; Email this search</h3>
@@ -110,7 +106,6 @@
         {% if site_config.use_secure_blocks %}
         <div data-secure_block_id="saved_search"></div>
         {% else %}
-        <script src="//d2e48ltfsb5exy.cloudfront.net/myjobs/tools/def.myjobs.widget.153-05.js"></script>
         <div id="mobile_direct-saved-search-box" class="direct_rightColBox direct-action-box">
           <div class="email-box">
             <h3 class="get-email-title">Save &amp; Email this search</h3>


### PR DESCRIPTION
Purpose of PR:  Remove reference to v1 JavaScript file and v1 CSS file in v2 template called "job_listing.html" in templates > v2, this template is extending the "seo_base_bootstrap3.html", and as such inherits the "seo-base-scripts-181-27.js" file which has the exact same methods as the old v1 JavaScript file.

I also fixed a small UI bug for the "Save Search" DOM element in desktop view, screen shots below.
Before: 
![before](https://cloud.githubusercontent.com/assets/5124153/19904843/c1c5140a-a04a-11e6-957d-19622bf47755.png)


After:
![after](https://cloud.githubusercontent.com/assets/5124153/19904555/6fe88726-a049-11e6-9eff-fab3f5379352.png)

To test:

1. Please switch to v2 template.

2. In desktop view, please go to www.my.jobs and/or veterans.jobs, ensure list of jobs renders.  Please type a job title in the jobs input box and click Search, please ensure jobs list shows up, unless it's a really odd job like underwater basket weaver, which should trigger the default "0 Jobs Found" view with "Clear All" button etc.

3. Please type in a legit job title then click the Search button, ensure the Save Search element shows up and the text "Cancel Anytime" is readable in desktop view.