### PR TITLE
[PD-2728] Filter box UI bug fixed

### DIFF
--- a/gulp/src/sass/seo_base_styles.scss
+++ b/gulp/src/sass/seo_base_styles.scss
@@ -383,11 +383,25 @@ a.direct_optionsLess {
     @extend .facet-header;
   }
 }
+
 #mobile_direct_disambiguationDiv {
   h3 {
     @extend .facet-header;
   }
 }
+
+.filter-box {
+  border: 1px solid $extra-light-gray;
+  background-color: $medium-gray;
+  margin-bottom: 30px;
+  border-top: none;
+  border-radius: 3px;
+  box-sizing: border-box;
+  box-shadow: 2px 2px 3px #bbb;
+  padding: 0px 10px;
+  margin: 0 15px;
+}
+
 .filter-panel {
   display: block;
 	margin: 10px 0;
@@ -1194,17 +1208,7 @@ margin-bottom: 50px;
       }
     }
   }
-	.filter-box {
-		border: 1px solid $extra-light-gray;
-    background-color: $medium-gray;
-    margin-bottom: 30px;
-    border-top: none;
-    border-radius: 3px;
-    box-sizing: border-box;
-    box-shadow: 2px 2px 3px #bbb;
-    padding: 0px 10px;
-		margin: 0 15px;
-	}
+
   #search {
     margin-bottom: 0;
 


### PR DESCRIPTION
Purpose of PR:  To fix UI bug in the Filter section.  The background and border was lost, I restored it by moving the style from the small screen scope to the root scope so it can be inherited in all screen sizes.

To test:

1. Please switch to the v2 template for www.my.jobs.

2. In the desktop and mobile views, please ensure that the Filter section has the light gray background and border like in the "After" screen shot.

Before: no background nor border
![before](https://cloud.githubusercontent.com/assets/5124153/19942283/9412ae54-a109-11e6-9b82-42f8ffa25e18.png)


After:
![after](https://cloud.githubusercontent.com/assets/5124153/19942294/a15bbcc2-a109-11e6-8f81-9b8ab6b03360.png)
