### PR TITLE
[PD-2729] remove the 'Filter by' text in the facets per J. Sole's request

### DIFF
--- a/seo/filters.py
+++ b/seo/filters.py
@@ -255,7 +255,7 @@ class FacetListWidget(object):
             accordion_class = '<h3 class="filter-accordion">'
         column_header = (accordion_class +
                          '<span class="direct_highlightedText">%s</span></h3>')
-        column_header = column_header % (self.get_title())
+        column_header = column_header % self.get_title()
 
         return column_header
 

--- a/seo/filters.py
+++ b/seo/filters.py
@@ -254,9 +254,8 @@ class FacetListWidget(object):
         if self.version == 'v2':
             accordion_class = '<h3 class="filter-accordion">'
         column_header = (accordion_class +
-                         '<span class="direct_filterLabel">%s</span> '
                          '<span class="direct_highlightedText">%s</span></h3>')
-        column_header = column_header % (_("Filter by"), self.get_title())
+        column_header = column_header % (self.get_title())
 
         return column_header
 


### PR DESCRIPTION
Purpose of PR: remove the "Filter by" verbiage in the facets.

To test:

1. Please switch to v2 template.

2. In desktop and mobile views for my.jobs and veterans.jobs (MOC), please ensure that the facet header does not contain the words "Filter by", it should only have words like: City, State, Title, Country, Military Titles, Bacon (just kidding, not bacon).