### PR TITLE
Fix data directory

### DIFF
--- a/import_jobs/__init__.py
+++ b/import_jobs/__init__.py
@@ -27,7 +27,7 @@ from import_jobs.solr import add_jobs, chunk, delete_by_guid
 logger = logging.getLogger(__name__)
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
-DATA_DIR = os.path.normpath(os.path.join(BASE_DIR, '../../../data/'))
+DATA_DIR = os.path.normpath('/tmp/data')
 sys.path.insert(0, os.path.join(BASE_DIR))
 sys.path.insert(0, os.path.join(BASE_DIR, '../'))
 FEED_FILE_PREFIX = "dseo_feed_"


### PR DESCRIPTION
The old directory was trying to point at `/home/web/data` via a bunch of indirection, and `/home/web/data` was actually a symlink to `/tmp/data` anyway.  Just point at `/tmp/data` and cut the complexity.