### PR TITLE
PD-2735, moved global saved search style properties to the root scope

### DIFF
--- a/gulp/src/sass/seo_base_styles.scss
+++ b/gulp/src/sass/seo_base_styles.scss
@@ -360,24 +360,60 @@ a.direct_optionsLess {
 }
 
 #mobile_direct-saved-search-box, #direct-saved-search-box {
+  padding: 0 15px;
+  margin-bottom: -3.1rem;
 
+  h3 {
+    @extend .facet-header;
+    margin: -1px -15px;
+    font-size: 20px;
+  }
   form {
     padding: 15px 0px 0px 0px;
   }
-  h3 {
-    @extend .facet-header;
-  }
-
   .enter-email {
     border: 2px solid $primary-navy-blue;
   }
   .email-frequency {
     border: 2px solid $primary-navy-blue;
   }
-	.get-title {
-		text-align: center;
-	}
+  .email-box {
+    border: 1px solid $extra-light-gray;
+    background-color: $medium-gray;
+    margin-bottom: 30px;
+    border-top: none;
+    border-radius: 3px;
+    box-sizing: border-box;
+    box-shadow: 2px 2px 3px #bbb;
+    margin-top: 75px;
+    padding: 0px 10px;
+  }
+  .search-sent-text {
+      text-align: center;
+  }
+  .direct-action-btn {
+      margin: 20px 0;
+      text-align: center;
+
+      a {
+          background-color: $btn-gray;
+          color: $white;
+          padding: 10px;
+          border-radius: 3px;
+      }
+  }
+  .save-email {
+    margin-top: 15px;
+    width: 100%;
+    background-color: $primary-navy-blue;
+    color: $white;
+
+    &:hover {
+      background-color: $btn-gray;
+    }
+  }
 }
+
 #direct_disambiguationDiv {
   h3 {
     @extend .facet-header;
@@ -1163,50 +1199,6 @@ margin-bottom: 50px;
       text-align: center;
     }
 
-  }
-  #mobile_direct-saved-search-box, #direct-saved-search-box {
-    padding: 0 15px;
-    margin-bottom: -40px;
-
-    h3 {
-      margin: -1px -15px;
-			font-size: 20px;
-    }
-    .email-box {
-      border: 1px solid $extra-light-gray;
-      background-color: $medium-gray;
-      margin-bottom: 30px;
-      border-top: none;
-      border-radius: 3px;
-      box-sizing: border-box;
-      box-shadow: 2px 2px 3px #bbb;
-      margin-top: 75px;
-      padding: 0px 10px;
-    }
-		.search-sent-text {
-			text-align: center;
-		}
-		.direct-action-btn {
-			margin: 20px 0;
-			text-align: center;
-
-			a {
-				background-color: $btn-gray;
-				color: $white;
-				padding: 10px;
-				border-radius: 3px;
-			}
-		}
-    .save-email {
-      margin-top: 15px;
-      width: 100%;
-      background-color: $primary-navy-blue;
-      color: $white;
-
-      &:hover {
-        background-color: $btn-gray;
-      }
-    }
   }
 
   #search {


### PR DESCRIPTION
Purpose:  Fix broken styles for the Saved Search element.

To test: 

1. Please switch to v2 template.

2. Please search for a job without location nor MOC, to trigger the rendering of the Save Search "box".

3. If things goes correctly, the Saved Search box should no longer look like a naked poodle.  Please compare with before and after pics.

Before:
![before](https://cloud.githubusercontent.com/assets/5124153/20191228/a189abe2-a752-11e6-945b-06c32ccfaa27.png)

After:
![after](https://cloud.githubusercontent.com/assets/5124153/20191245/ae6354f8-a752-11e6-86ab-03df5e652f27.png)
