### PR TITLE
PD-2736, made 'show more' and 'show less' look like buttons

### DIFF
--- a/gulp/src/sass/seo_base_styles.scss
+++ b/gulp/src/sass/seo_base_styles.scss
@@ -130,6 +130,19 @@ legend{
   border-radius: 3px;
   font-weight: 100;
 }
+
+.show-more {
+  @extend .global-btn;
+  font-weight: 400;
+  color: $white !important;
+  text-decoration: none;
+  padding: 0.8rem;
+  margin-right: 0.3rem;
+}
+.show-less {
+  @extend .show-more;
+  background-color: orangered !important;
+}
 /*NEED TO ORGANIZE THIS CSS*/
 .no-scroll {
   overflow: hidden;
@@ -196,10 +209,7 @@ legend{
     }
   }
 }
-.more-less-facet-filter{
-  color: $primary-navy-blue;
-  padding-right: 10px;
-}
+
 .site-name {
   color: #3a4135;
   position: relative;
@@ -699,7 +709,7 @@ margin-bottom: 50px;
 /*RIGHT SIDE SEARCH RESULTS STYLES*/
   .right-content {
     .show-more-jobs {
-      float: right;
+      float: left;
       margin-top: 25px;
       @extend .global-btn;
     }
@@ -1579,7 +1589,7 @@ margin-bottom: 50px;
     padding: 0;
 
     .show-more-jobs {
-      float: right !important;
+      float: left;
     }
     .job-location-information {
       color: $primary-navy-blue;

--- a/seo/filters.py
+++ b/seo/filters.py
@@ -310,10 +310,10 @@ class FacetListWidget(object):
                          'data-total-items="%(total_items)s" '
                          'data-offset="%(offset)s">'
 
-                         '<a class="more-less-facet-filter direct_optionsMore" '
+                         '<a class="show-more more-less-facet-filter direct_optionsMore" '
                          'href="#" rel="nofollow">%(more)s</a>'
 
-                         '<a class="more-less-facet-filter direct_optionsLess" href="#" '
+                         '<a class="show-less more-less-facet-filter direct_optionsLess" href="#" '
                          'rel="nofollow">%(less)s</a>'
 
                          '</span>')
@@ -321,8 +321,8 @@ class FacetListWidget(object):
             more_less = more_less % dict(num_items=self.num_to_show,
                                          type=self.selector_type,
                                          total_items=self._num_items_rendered,
-                                         more=_("(show more)"),
-                                         less=_("(show less)"),
+                                         more=_("Show More +"),
+                                         less=_("Show Less -"),
                                          offset=self.offset)
         else:
             more_less = ('<span id="direct_moreLessLinks_%(type)sDisambig" '


### PR DESCRIPTION
Purpose:  Convert the Show More/Show Less into buttons.  Left align Show More Jobs buttons.

To test:

1.  Switch to v2 template.

2. In desktop and mobile view, please ensure the Show More / Show Less links are now buttons and hopefully working as buttons.

3. Show More Jobs buttons should now be left aligned.
