### PR TITLE
PD-2747, changed save search email placeholder text

### DIFF
--- a/templates/mysearches/saved_search_widget_bootstrap3.html
+++ b/templates/mysearches/saved_search_widget_bootstrap3.html
@@ -8,11 +8,9 @@
 {% endif %}
 {% if not search and not success %}
     <p class="get-title">Get new jobs sent directly to your inbox!</p>
-    <!-- <input placeholder="Your email address" type="text" id="saved-search-email" class="enter-email"  name="saved-search-email" {% if user.email %}value="{{ user.email }}"{% endif %}> -->
     <div class="form-group">
-      <input class="form-control enter-email" id="saved-search-email" type="text" placeholder="clotilde_crooks@gmail.com" name="saved-search-email" {% if user.email %}value="{{ user.email }}"{% endif %}/>
+      <input class="form-control enter-email" id="saved-search-email" type="text" placeholder="Please type your email address here" name="saved-search-email" {% if user.email %}value="{{ user.email }}"{% endif %}/>
     </div>
-    <!-- <input id="saved-search-btn" class="btn btn-default save-email" type="submit" onclick="save_search();" value="Save" /> -->
     <div class="form-group">
       <div class="row">
         <div class="col-xs-12 col-sm-12 col-lg-8">

--- a/templates/mysearches/saved_search_widget_bootstrap3.html
+++ b/templates/mysearches/saved_search_widget_bootstrap3.html
@@ -9,7 +9,7 @@
 {% if not search and not success %}
     <p class="get-title">Get new jobs sent directly to your inbox!</p>
     <div class="form-group">
-      <input class="form-control enter-email" id="saved-search-email" type="text" placeholder="Please type your email address here" name="saved-search-email" {% if user.email %}value="{{ user.email }}"{% endif %}/>
+      <input class="form-control enter-email" id="saved-search-email" type="text" placeholder="Your email address " name="saved-search-email" {% if user.email %}value="{{ user.email }}"{% endif %}/>
     </div>
     <div class="form-group">
       <div class="row">


### PR DESCRIPTION
Purpose: change Save Search email placeholder verbiage to something more intuitive.  Also removed commented out html codes that probably shouldn't be in production.

To test:

1. Please switch to v2 template.

2. Please save a job title search, please ensure that the email placeholder text says "Please type your email address here".

Before:
![before](https://cloud.githubusercontent.com/assets/5124153/20269346/bb44112a-aa50-11e6-8231-7bcda3b5af96.png)

After:
![after](https://cloud.githubusercontent.com/assets/5124153/20269369/cdfb058a-aa50-11e6-9d70-8ea67efc4d2d.png)

