### PR TITLE
[PD-2741] Hide "Filter Search Criteria" Button in job_detail view

### DIFF
--- a/templates/home_page/home_page_listing_bootstrap3.html
+++ b/templates/home_page/home_page_listing_bootstrap3.html
@@ -56,6 +56,10 @@
 
 {% block directseo_mobile_facets %}
 {% if default_jobs or featured_jobs %}
+<div class="mobile-search-criteria">
+  <a id="mobile_search" class="mobile-search-btn" href="#/">Filter Search Criteria</a>
+</div>
+<div class="mobile-search-facets">
 <div id="mobile_direct_disambiguationDiv" class="mobile-facets direct_rightColBox">
   <div class="filter-box">
     {% for widget in widgets %}
@@ -64,6 +68,7 @@
     {% endif %}
     {% endfor %}
   </div>
+</div>
 </div>
 {% endif %}
 {% endblock directseo_mobile_facets %}

--- a/templates/seo_base_bootstrap3.html
+++ b/templates/seo_base_bootstrap3.html
@@ -121,12 +121,8 @@
             {% else %}
               {% include 'v2/includes/search_box_widget.html' %}
             {% endif %}
-            <div class="mobile-search-criteria">
-              <a id="mobile_search" class="mobile-search-btn" href="#/">Filter Search Criteria</a>
-            </div>
-            <div class="mobile-search-facets">
-              {% block directseo_mobile_facets %}{% endblock directseo_mobile_facets %}
-            </div>
+
+            {% block directseo_mobile_facets %}{% endblock directseo_mobile_facets %}
             {% block directseo_main_content %}{% endblock %}
             <div id="mobile_save_email_search">
               {% block mobile_directseo_save_email %}{% endblock %}

--- a/templates/v2/job_listing.html
+++ b/templates/v2/job_listing.html
@@ -85,6 +85,10 @@
 {% endblock %}
 
 {% block directseo_mobile_facets %}
+<div class="mobile-search-criteria">
+  <a id="mobile_search" class="mobile-search-btn" href="#/">Filter Search Criteria</a>
+</div>
+<div class="mobile-search-facets">
 <div id="mobile_direct_disambiguationDiv" class="mobile-facets direct_rightColBox" role="menu">
   <div class="filter-box">
     {# If clear_breadcrumb exists, we know at least one search term that can be removed has been applied, so include the breadbox #}
@@ -97,6 +101,7 @@
         {% endfor %}
     {% endif %}
   </div>
+</div>
 </div>
 {% endblock %}
 


### PR DESCRIPTION
## Overview

The "Filter Search Criteria" button was displaying on job detail views. This was a symptom of the element being part of seo_base, rather than the homepage/job_listing templates.

## The Solution!

I moved the button div to the proper templates

## Testing

Ensure that the above button appears on the homepage/job_listing pages (or anywhere else relevant) but not on the job_detail page.