### PR TITLE
PD-2733, refactored v2 seo base templates to prevent double filters

### DIFF
--- a/gulp/src/sass/seo_base_styles.scss
+++ b/gulp/src/sass/seo_base_styles.scss
@@ -1482,9 +1482,7 @@ margin-bottom: 50px;
   .mobile-search-criteria {
     display: none;
   }
-  .mobile-search-facets.show-mobile-search-facets {
-    display: none;
-  }
+
   .facets {
     display: block;
   }

--- a/gulp/src/sass/seo_base_styles.scss
+++ b/gulp/src/sass/seo_base_styles.scss
@@ -436,6 +436,14 @@ a.direct_optionsLess {
   }
 }
 
+.mobile-search-btn {
+  background-color: $btn-gray;
+  color: $primary-navy-blue;
+  padding: 10px 20px;
+  border: none;
+  border-radius: 2px;
+}
+
 .filter-box {
   border: 1px solid $extra-light-gray;
   background-color: $medium-gray;
@@ -1163,9 +1171,8 @@ margin-bottom: 50px;
     display: none;
   }
   #mobile_social_media {
-    padding-top: 50px;
-    margin: 0 auto;
-    width: 63%;
+    margin: 5rem auto 7rem auto;
+    width: 76%;
   }
 
   .mobile-search-facets {
@@ -1178,21 +1185,12 @@ margin-bottom: 50px;
   .mobile-search-facets.show-mobile-search-facets {
     display: block;
   }
-  .facets {
-    display: none;
-  }
   .social-media {
     margin-top: 75px;
   }
   .mobile-search-criteria {
     text-align: center;
     padding: 25px 0px;
-  }
-  .mobile-search-btn {
-    background-color: $btn-gray;
-    color: $primary-navy-blue;
-    padding: 10px 20px;
-    border-radius: 2px;
   }
   #main_nav {
     .right-nav {
@@ -1355,6 +1353,10 @@ margin-bottom: 50px;
     display: none;
   }
 
+  .search-section {
+    padding: 0 0 0 2rem;
+  }
+
   #direct_jobListingTitle, .jobs-found {
     margin: 0 auto;
     width: 91%;
@@ -1364,24 +1366,13 @@ margin-bottom: 50px;
     display: block;
   }
 
-  .facets {
-    display: none;
-  }
-
   .social-media {
     margin-top: 75px;
   }
 
   .mobile-search-criteria {
     text-align: center;
-    padding: 25px 0px;
-  }
-
-  .mobile-search-btn {
-    background-color: $btn-gray;
-    color: $primary-navy-blue;
-    padding: 10px 20px;
-    border-radius: 2px;
+    padding: 0 0 1.6rem 0;
   }
 
   .right-content {

--- a/gulp/src/sass/seo_base_styles.scss
+++ b/gulp/src/sass/seo_base_styles.scss
@@ -1353,8 +1353,8 @@ margin-bottom: 50px;
     display: none;
   }
 
-  .search-section {
-    padding: 0 0 0 2rem;
+  .search-section, .breadcrumb-tags {
+    padding: 1rem 0 0 2rem;
   }
 
   #direct_jobListingTitle, .jobs-found {

--- a/static/seo-base-scripts-181-27.js
+++ b/static/seo-base-scripts-181-27.js
@@ -266,12 +266,12 @@ function jsonp_ajax_call(ajax_url) {
 JAVASCRIPT FOR THE NEW REBRANDING HOMEPAGE FUNCTIONALITY
 */
   //Javascript to show search criteria in mobile view
-  $(".mobile-search-btn").on("click", function(e) {
+  $(".mobile-search-btn").on("click", function() {
     $(".search-criteria-box").toggleClass("show-search-criteria");
   });
 
   //Javascript for showing the search facets in mobile view on click
-  $("#mobile_search").on("click", function(e) {
+  $("#mobile_search").on("click", function() {
     var mobileSearchFacets = $(".mobile-search-facets");
     mobileSearchFacets.toggleClass("show-mobile-search-facets");
   });

--- a/templates/home_page/home_page_listing_bootstrap3.html
+++ b/templates/home_page/home_page_listing_bootstrap3.html
@@ -39,6 +39,10 @@
 {% endblock directseo_main_content %}
 
 {% block directseo_right_hand_column %}
+<section class="mobile-search-criteria">
+    <button id="mobile_search" class="mobile-search-btn">Filter Search Criteria</button>
+</section>
+<section class="mobile-search-facets">
 {% if default_jobs or featured_jobs %}
 <div id="direct_disambiguationDiv" class="facets direct_rightColBox">
   <div class="filter-box">
@@ -50,6 +54,7 @@
   </div>
 </div>
 {% endif %}
+</section>
 {% endblock directseo_right_hand_column %}
 
 {% block directseo_off_site_links %}

--- a/templates/home_page/home_page_listing_bootstrap3.html
+++ b/templates/home_page/home_page_listing_bootstrap3.html
@@ -5,7 +5,6 @@
 {% cache 600 joblisting %}
 
 {% block direct_extraHeaderContent %}
-<link rel="stylesheet" href="/style/def.ui.dotjobs.results.css" type="text/css">
 
 {% endblock direct_extraHeaderContent %}
 
@@ -41,7 +40,6 @@
 
 {% block directseo_right_hand_column %}
 {% if default_jobs or featured_jobs %}
-<a name="filters"></a>
 <div id="direct_disambiguationDiv" class="facets direct_rightColBox">
   <div class="filter-box">
     {% for widget in widgets %}
@@ -53,25 +51,6 @@
 </div>
 {% endif %}
 {% endblock directseo_right_hand_column %}
-
-{% block directseo_mobile_facets %}
-{% if default_jobs or featured_jobs %}
-<div class="mobile-search-criteria">
-  <a id="mobile_search" class="mobile-search-btn" href="#/">Filter Search Criteria</a>
-</div>
-<div class="mobile-search-facets">
-<div id="mobile_direct_disambiguationDiv" class="mobile-facets direct_rightColBox">
-  <div class="filter-box">
-    {% for widget in widgets %}
-    {% if widget.render %}
-    {{ widget.render }}
-    {% endif %}
-    {% endfor %}
-  </div>
-</div>
-</div>
-{% endif %}
-{% endblock directseo_mobile_facets %}
 
 {% block directseo_off_site_links %}
     {% if site_config.show_home_social_footer %}

--- a/templates/seo_base_bootstrap3.html
+++ b/templates/seo_base_bootstrap3.html
@@ -69,12 +69,8 @@
     <div id="direct_innerContainer">
       <section id="main_content">
         <div class="row">
-          <div class="hidden-xs col-md-1"></div>
-          <div class="col-xs-12 col-md-3">
-            <div class="left-content">
-              <section id="brand_logo" class="text-center">
-                <div class="row">
-                  <div class="col-xs-12 col-md-12">
+            <article class="col-xs-12 col-md-3">
+                <section id="brand_logo" class="text-center">
                     <div class="location-logo">
                     {% with site_heading|cut:".jobs" as site_heading_base %}
                       {%if site_heading_base == site_heading %}
@@ -107,34 +103,40 @@
                       {% endif %}
                     {% endwith %}
                     </div>
-                  </div>
-                </div>
-              </section>
-                {% block directseo_right_hand_column %}{% endblock directseo_right_hand_column %}
+                </section>
+            </article>
+            <article class="col-xs-12 col-md-9">
+                {% if site_config.browse_moc_show %}
+                  {% include "v2/includes/search_box_vets_widget.html" %}
+                {% else %}
+                  {% include 'v2/includes/search_box_widget.html' %}
+                {% endif %}
+            </article>
         </div>
-      </div>
+        <div class="row">
+            <article class="col-xs-12 col-md-3 col-md-offset-1">
+                <section class="mobile-search-criteria">
+                    <button id="mobile_search" class="mobile-search-btn">Filter Search Criteria</button>
+                </section>
+                <section class="mobile-search-facets">
+                    {% block directseo_right_hand_column %}{% endblock directseo_right_hand_column %}
+                </section>
+            </article>
+            <article class="col-xs-12 col-md-8">
+                <section class="right-content">
+                    {% block directseo_main_content %}{% endblock %}
 
-      <div class="col-xs-12 col-md-8">
-        <div class="right-content">
-            {% if site_config.browse_moc_show %}
-              {% include "v2/includes/search_box_vets_widget.html" %}
-            {% else %}
-              {% include 'v2/includes/search_box_widget.html' %}
-            {% endif %}
-
-            {% block directseo_mobile_facets %}{% endblock directseo_mobile_facets %}
-            {% block directseo_main_content %}{% endblock %}
-            <div id="mobile_save_email_search">
-              {% block mobile_directseo_save_email %}{% endblock %}
-            </div>
-            <div id="mobile_social_media">
-              {% include 'v2/includes/add_this.html' %}
-            </div>
+                    <div id="mobile_save_email_search">
+                      {% block mobile_directseo_save_email %}{% endblock %}
+                    </div>
+                    <div id="mobile_social_media">
+                      {% include 'v2/includes/add_this.html' %}
+                    </div>
+                </section>
+            </article>
         </div>
-      </div>
-    </div>
     </section><!-- main_content -->
-    {% endblock directseo_outer_container %}
+ {% endblock directseo_outer_container %}
 
     </div><!-- direct_innerContainer -->
   </section><!-- direct_container -->

--- a/templates/seo_base_bootstrap3.html
+++ b/templates/seo_base_bootstrap3.html
@@ -120,10 +120,6 @@
             <article class="col-xs-12 col-md-8">
                 <section class="right-content">
                     {% block directseo_main_content %}{% endblock %}
-
-                    <div id="mobile_save_email_search">
-                      {% block mobile_directseo_save_email %}{% endblock %}
-                    </div>
                     <div id="mobile_social_media">
                       {% include 'v2/includes/add_this.html' %}
                     </div>

--- a/templates/seo_base_bootstrap3.html
+++ b/templates/seo_base_bootstrap3.html
@@ -115,12 +115,7 @@
         </div>
         <div class="row">
             <article class="col-xs-12 col-md-3 col-md-offset-1">
-                <section class="mobile-search-criteria">
-                    <button id="mobile_search" class="mobile-search-btn">Filter Search Criteria</button>
-                </section>
-                <section class="mobile-search-facets">
-                    {% block directseo_right_hand_column %}{% endblock directseo_right_hand_column %}
-                </section>
+                {% block directseo_right_hand_column %}{% endblock directseo_right_hand_column %}
             </article>
             <article class="col-xs-12 col-md-8">
                 <section class="right-content">

--- a/templates/v2/job_detail.html
+++ b/templates/v2/job_detail.html
@@ -91,11 +91,13 @@
 {% endblock %}
 
 {% block directseo_right_hand_column %}
+<section class="mobile-search-facets">
 {% if company %}
 <div id="direct_companyModule" class="direct_rightColBox" role="menu">
   {% include 'v2/includes/company_module.html'%}
 </div>
 {% endif %}
+</section>
 {% endblock %}
 {% block extra-js %}
     <script>

--- a/templates/v2/job_listing.html
+++ b/templates/v2/job_listing.html
@@ -48,6 +48,10 @@
 {% endblock %}
 
 {% block directseo_right_hand_column %}
+<section class="mobile-search-criteria">
+    <button id="mobile_search" class="mobile-search-btn">Filter Search Criteria</button>
+</section>
+<section class="mobile-search-facets">
 {% if company %}
 <div id="direct_companyModule" class="facets direct_rightColBox" role="menu">
   {% include 'v2/includes/company_module.html'%}
@@ -82,6 +86,7 @@
     {% endif %}
   </div>
 </div>
+</section>
 {% endblock %}
 
 {% block directseo_mobile_facets %}


### PR DESCRIPTION
Purpose:  Render 1 filter list for both desktop and mobile through responsive design, rather than 2 filter lists for the exact same code like it is currently.

1.  Please switch to v2 template.

2.  In the desktop and mobile views, please use web developer tool to inspect the DOM and ensure that the direct_disambiguationDiv element only appears once.  Everything else should look exactly the same.

Before fix, notice 2 filter DOM elements performing the exact same work:
![before](https://cloud.githubusercontent.com/assets/5124153/20312917/20299b1e-ab23-11e6-88b2-fa2ec9a8d63e.png)


After, 1 filter element for desktop and mobile:
![after](https://cloud.githubusercontent.com/assets/5124153/20312942/3f0e4f0c-ab23-11e6-8331-aa4e782f5748.png)
