### PR TITLE
ST-3339, hot fix for filter by verbiage

### DIFF
--- a/seo/filters.py
+++ b/seo/filters.py
@@ -254,8 +254,9 @@ class FacetListWidget(object):
         if self.version == 'v2':
             accordion_class = '<h3 class="filter-accordion">'
         column_header = (accordion_class +
+                         '<span class="direct_filterLabel">%s</span> '
                          '<span class="direct_highlightedText">%s</span></h3>')
-        column_header = column_header % self.get_title()
+        column_header = column_header % (_("Filter by"), self.get_title())
 
         return column_header
 


### PR DESCRIPTION
To test:

In v1 template the text "Filter by" should precede filter name.