### PR TITLE
PD-2748, remove the 'Filter by' text within the v2 conditional statement

### DIFF
--- a/seo/filters.py
+++ b/seo/filters.py
@@ -253,10 +253,14 @@ class FacetListWidget(object):
         accordion_class = '<h3>'
         if self.version == 'v2':
             accordion_class = '<h3 class="filter-accordion">'
+            column_header = (accordion_class +
+                             '<span class="direct_highlightedText">%s</span></h3>')
+            column_header = column_header % self.get_title()
+            return column_header
         column_header = (accordion_class +
+                         '<span class="direct_filterLabel">%s</span> '
                          '<span class="direct_highlightedText">%s</span></h3>')
-        column_header = column_header % self.get_title()
-
+        column_header = column_header % (_("Filter by"), self.get_title())
         return column_header
 
     def _render_lis(self):


### PR DESCRIPTION
Purpose:  Remove the "Filter by" verbiage only within the v2 conditional statement.  Leave v1 alone man!

To test:

1. In v1 template, please ensure that the verbiage "Filter by" precede filter criterias.

2. In v2 template, please ensure that the verbiage "Filter by" is not  preceding the filter criterias.