### PR TITLE
PD-2757, moved seo-base-scripts.js to gulp directory

### DIFF
--- a/gulp/src/sass/seo_base_styles.scss
+++ b/gulp/src/sass/seo_base_styles.scss
@@ -587,9 +587,6 @@ margin-bottom: 50px;
     @extend .global-btn;
     text-align: center;
   }
-  .share-social.search-submit-moc {
-    min-width: 7rem;
-  }
   .search-show-all {
     font-size: 12px;
     position: relative;
@@ -1221,12 +1218,6 @@ margin-bottom: 50px;
     .search-submit-moc {
       width: 94%;
     }
-    .share-social.search-submit {
-      display: none;
-    }
-    .share-social.search-submit-moc {
-      display: none;
-    }
     .breadcrumb-row {
       display: none;
     }
@@ -1548,12 +1539,6 @@ margin-bottom: 50px;
     }
     .submit-section {
       padding: 0;
-    }
-    .share-social.search-submit {
-      display: inline-block;
-    }
-    .share-social.search-submit-moc {
-      display: inline-block;
     }
   }
   #direct_listingDiv {

--- a/gulp/src/v2/seo-base-scripts.js
+++ b/gulp/src/v2/seo-base-scripts.js
@@ -3,164 +3,161 @@
 /**
  * Legacy es5.1 functions used in seo_base_bootstrap3.html template,
  * relocated to the gulp directory to utilize es6, webpack, et al, during Sprint 24.
- * TODO: Modify coding styles to match eslint requirements.
- * TODO: Put utils.js in here as well and make it es6-ish.
+ * TODO: Put utils.js in here as well, and make it es6-ish.
  **/
 
-$(document).ready(function () {
+$(document).ready(function() {
   // needed to render 'topbar'
   if (typeof site_name !== 'undefined' && !$('*[data-widget_type=tools]').length) {
-    get_toolbar(site_name);
+    getToolbar(site_name);
   }
 
   // Autocomplete functionality for the job,title,keyword input box.
   $('.micrositeTitleField').autocomplete({
-    source: function (request, response) {
-        $.ajax({
-            url: '/ajax/ac/?lookup=title&term=' + request.term,
-            dataType: 'jsonp',
-            success: function(data) {
-                response($.map(data, function (item) {
-                    return {
-                        label: item.title,
-                        value: item.title,
-                    };
-                }));
-            },
-        });
+    source: function(request, response) {
+      $.ajax({
+        url: '/ajax/ac/?lookup=title&term=' + request.term,
+        dataType: 'jsonp',
+        success: function(data) {
+          response($.map(data, function(item) {
+            return {
+              label: item.title,
+              value: item.title,
+            };
+          }));
+        },
+      });
     },
     open: function() {
-        $('.ui-autocomplete li.ui-menu-item:odd').addClass('ui-menu-item-alternate');
-        $('.ui-autocomplete li.ui-menu-item a').removeClass('ui-corner-all');
+      $('.ui-autocomplete li.ui-menu-item:odd').addClass('ui-menu-item-alternate');
+      $('.ui-autocomplete li.ui-menu-item a').removeClass('ui-corner-all');
     },
-    select: function (event, ui) {
-        $('.micrositeTitleField').val('"' + ui.item.value + '"');
-        return false;
+    select: function(event, ui) {
+      $('.micrositeTitleField').val('"' + ui.item.value + '"');
+      return false;
     },
     minLength: 2,
   });
 
     // Autocomplete functionality for the city,state,country input box.
-    $('.micrositeLocationField').autocomplete({
-        source: function(request, response) {
-            $.ajax({
-                url: '/ajax/ac/?lookup=location&term=' + request.term,
-                dataType: 'jsonp',
-                success: function(data) {
-                    response($.map(data, function (item) {
-                        return {
-                            label: item.location + ' - (' + item.jobcount + ')',
-                            value: item.location,
-                        };
-                    }));
-                },
-            });
+  $('.micrositeLocationField').autocomplete({
+    source: function(request, response) {
+      $.ajax({
+        url: '/ajax/ac/?lookup=location&term=' + request.term,
+        dataType: 'jsonp',
+        success: function(data) {
+          response($.map(data, function(item) {
+            return {
+              label: item.location + ' - (' + item.jobcount + ')',
+              value: item.location,
+            };
+          }));
         },
-        open: function() {
-            $('.ui-autocomplete li.ui-menu-item:odd').addClass('ui-menu-item-alternate');
+      });
+    },
+    open: function() {
+      $('.ui-autocomplete li.ui-menu-item:odd').addClass('ui-menu-item-alternate');
+    },
+    minLength: 2,
+  });
+
+  // Add syntax highlighting to autocomplete results.
+  $.ui.autocomplete.prototype._renderItem = function(ul, item) {
+    /**
+     Inputs:
+     :ul:    the autocomplete object to modify
+     :item:  the individual item to modify
+
+     Returns:
+     Modified item
+     **/
+    let term = this.term;
+    if ((term.charAt(0) === '"' && term.charAt(term.length - 1) === '"')) {
+      term = this.term.substr(1, term.length - 2);
+    } else {
+      term = this.term.split(' ').join('|');
+    }
+
+    const re = new RegExp('(' + term + ')', 'gi');
+    const t = item.label.replace(re, '<strong class="ac-highlight">$1</strong>');
+    return $('<li></li>')
+      .data('item.autocomplete', item)
+      .append('<a>' + t + '</a>')
+      .appendTo(ul);
+  };
+
+  // Size the width of the drop down list to match width of input, always, in any size, without CSS
+  $.ui.autocomplete.prototype._resizeMenu = function() {
+    const ul = this.menu.element;
+    ul.outerWidth(this.element.outerWidth());
+  };
+
+  // Submit the search form if location AND title fields have a value in them (and MOC if applicable).
+  $('#standardSearch input[type=text]').bind('autocompleteselect', function(event, ul) {
+    /**
+     Inputs:
+     :event: The autocompleteselect event
+     :ul: The autocomplete object (an unordered list)
+     **/
+    $(this).val(ul.item.value);
+    if ($('#moc').length > 0) {
+      if ($('#location').val() !== '' && $('#q').val() !== '' && $('#moc').val() !== '') {
+        $('#standardSearch').submit();
+      }
+    } else {
+      if ($('#location').val() !== '' && $('#q').val() !== '') {
+        $('#standardSearch').submit();
+      }
+    }
+  });
+
+  // Add autocomplete functionality to the MOC/MOS search field.
+  $('.micrositeMOCField').autocomplete({
+    source: function(request, response) {
+      $.ajax({
+        url: '/ajax/mac/?lookup=moc&term=' + request.term,
+        dataType: 'jsonp',
+        success: function(data) {
+          response($.map(data, function(item) {
+            return {
+              label: item.label,
+              value: item.value,
+              moc_id: item.moc_id,
+            };
+          }));
         },
-        minLength: 2,
-    });
+      });
+    },
+    select: function(event, ui) {
+      $('#moc_id').val(ui.item.moc_id);
+    },
+    open: function() {
+      $('.ui-autocomplete li.ui-menu-item:odd').addClass('ui-menu-item-alternate');
+    },
+    minLength: 2,
+  });
 
-    // Add syntax highlighting to autocomplete results.
-    $.ui.autocomplete.prototype._renderItem = function (ul, item) {
-        /**
-         Inputs:
-         :ul:    the autocomplete object to modify
-         :item:  the individual item to modify
+  // Clear moc_id value if moc is changed
+  $('#moc').change(function() {
+    $('#moc_id').val('');
+  });
 
-         Returns:
-         Modified item
-         **/
-        let term = this.term;
-        if ((term.charAt(0) === '"' && term.charAt(term.length - 1) === '"')) {
-            term = this.term.substr(1, term.length - 2);
-        } else {
-            term = this.term.split(' ').join('|');
-        }
-
-        let re = new RegExp('(' + term + ')', 'gi');
-        let t = item.label.replace(re, '<strong class="ac-highlight">$1</strong>');
-        return $('<li></li>')
-            .data('item.autocomplete', item)
-            .append('<a>' + t + '</a>')
-            .appendTo(ul);
-    };
-
-    // Size the width of the drop down list to match width of input, always, in any size, without CSS
-    $.ui.autocomplete.prototype._resizeMenu = function () {
-        const ul = this.menu.element;
-        ul.outerWidth(this.element.outerWidth());
-    };
-
-    // Submit the search form if location AND title fields have a value in them (and MOC if applicable).
-    $('#standardSearch input[type=text]').bind('autocompleteselect', function (event, ul) {
-        /**
-         Inputs:
-         :event: The autocompleteselect event
-         :ul: The autocomplete object (an unordered list)
-         **/
-        $(this).val(ul.item.value);
-        if ($('#moc').length > 0) {
-            if ($('#location').val() !== '' && $('#q').val() !== '' && $('#moc').val() !== '') {
-                $('#standardSearch').submit();
-            }
-        }
-        else {
-            if ($('#location').val() !== '' && $('#q').val() !== '') {
-                $('#standardSearch').submit();
-            }
-        }
-    });
-
-    // Add autocomplete functionality to the MOC/MOS search field.
-    $('.micrositeMOCField').autocomplete({
-        source: function(request, response) {
-            $.ajax({
-                url: '/ajax/mac/?lookup=moc&term=' + request.term,
-                dataType: 'jsonp',
-                success: function(data) {
-                    response($.map(data, function (item) {
-                        return {
-                            label: item.label,
-                            value: item.value,
-                            moc_id: item.moc_id,
-                        };
-                    }));
-                },
-            });
-        },
-        select: function(event, ui) {
-            $('#moc_id').val(ui.item.moc_id);
-        },
-        open: function(event, ul) {
-            $('.ui-autocomplete li.ui-menu-item:odd').addClass('ui-menu-item-alternate');
-        },
-        minLength: 2,
-    });
-
-    // Clear moc_id value if moc is changed
-    $('#moc').change(function (event) {
-        $('#moc_id').val('');
-    });
-
-    // Save Search Functionality
-    get_default_widget_html(false);
-
+  // Save Search Functionality
+  get_default_widget_html(false);
 });
 
-function get_toolbar(site_name) {
-    let site = encodeURIComponent(window.location.protocol + '//' + window.location.hostname),
-        url = ABSOLUTE_URL + 'topbar/?v2=1&site_name=' + site_name + '&site=' + site + '&impersonating=' + impersonating;
-    $.ajax({
-        url: url,
-        dataType: 'jsonp',
-        type: 'GET',
-        jsonpCallback: 'populate_toolbar',
-        crossDomain: true,
-        processData: false,
-        headers: {'Content-Type': 'application/json', Accept: 'text/javascript'},
-    });
+function getToolbar(site_name) {
+  const site = encodeURIComponent(window.location.protocol + '//' + window.location.hostname);
+  const url = ABSOLUTE_URL + 'topbar/?v2=1&site_name=' + site_name + '&site=' + site + '&impersonating=' + impersonating;
+  $.ajax({
+    url: url,
+    dataType: 'jsonp',
+    type: 'GET',
+    jsonpCallback: 'populate_toolbar',
+    crossDomain: true,
+    processData: false,
+    headers: {'Content-Type': 'application/json', Accept: 'text/javascript'},
+  });
 }
 
 function populate_toolbar(data) {
@@ -171,197 +168,196 @@ if (window) {
   window.populate_toolbar = populate_toolbar;
 }
 
-const ss_username = 'directseo@directemployersfoundation.org';
-const ss_api_key = '6fcd589a4efa72de876edfff7ebf508bedd0ba3e';
-const ss_api_str = '&username=' + ss_username + '&api_key=' + ss_api_key;
-const base_url = 'https://secure.my.jobs';
-const ss_url = encodeURIComponent(window.location.href);
+const SS_USERNAME = 'directseo@directemployersfoundation.org';
+const SS_API_KEY = '6fcd589a4efa72de876edfff7ebf508bedd0ba3e';
+const SS_API_STR = '&username=' + SS_USERNAME + '&api_key=' + SS_API_KEY;
+const BASE_URL = 'https://secure.my.jobs';
+const SS_URL = encodeURIComponent(window.location.href);
 
 let most_recent_html = '';
 
 
 function handle_error() {
-    // Fills with the most recent text and then overwrites applicable parts
-    // with the error message. Uses the most recent text to ensure formatting
-    // and variables supplied by myjobs are persistent, so the experience
-    // for logged in users continues to be the same.
+  // Fills with the most recent text and then overwrites applicable parts
+  // with the error message. Uses the most recent text to ensure formatting
+  // and variables supplied by myjobs are persistent, so the experience
+  // for logged in users continues to be the same.
 
-    fill(most_recent_html);
-    $('.saved-search-form').prepend('<em class="warning">Something went wrong!</em>');
-    $('.saved-search-form > form > b').html('<p>Your search could not successfully be created.</p>');
-    $('label[for="saved-search-email"]').html('<p>Your search could not successfully be created.</p>');
-    $('.saved-search-button').html('Try saving this search again');
+  fill(most_recent_html);
+  $('.saved-search-form').prepend('<em class="warning">Something went wrong!</em>');
+  $('.saved-search-form > form > b').html('<p>Your search could not successfully be created.</p>');
+  $('label[for="saved-search-email"]').html('<p>Your search could not successfully be created.</p>');
+  $('.saved-search-button').html('Try saving this search again');
 }
 
 function fill(html) {
-    $('#de-myjobs-widget').html(html);
-    $('#mobile-de-myjobs-widget').html(html);
-    most_recent_html = html;
+  $('#de-myjobs-widget').html(html);
+  $('#mobile-de-myjobs-widget').html(html);
+  most_recent_html = html;
 }
 
 if (window) {
-    window.fill = fill;
-}
-
-function save_search() {
-    // If there is any hint that there isn't a well-defined user email
-    // provided, attempts to get a user from the input and create a new user.
-    // Otherwise, uses the currently provided user to create a saved search.
-
-    if (user_email !== 'None' && user_email !== 'undefined' && user_email) {
-        $('.saved-search-form').html('<em class="saved-search-widget-loading">Saving this search</em>');
-        create_saved_search();
-    }
-    else {
-        try {
-            user_email = $('#saved-search-email').val();
-            $('.saved-search-form').html('<em class="saved-search-widget-loading">Saving this search</em>');
-            create_user();
-        }
-        catch (err) {
-            handle_error();
-        }
-    }
-}
-
-if (window) {
-    window.save_search = save_search;
+  window.fill = fill;
 }
 
 function reload_default_widget(data) {
-    if (data.error) {
-        handle_error();
-    }
-    else {
-        get_default_widget_html(true);
-    }
+  if (data.error) {
+    handle_error();
+  } else {
+    get_default_widget_html(true);
+  }
 }
 
 function get_default_widget_html(success) {
-    let ajax_url;
+  let ajax_url;
 
-    if (success) {
-        ajax_url = base_url + '/saved-search/widget/?v2=1&callback=fill&success=' + user_email + '&url=' + ss_url;
-    }
-    else {
-        ajax_url = base_url + '/saved-search/widget/?v2=1&callback=fill&url=' + ss_url;
-    }
-    jsonp_ajax_call(ajax_url);
+  if (success) {
+    ajax_url = BASE_URL + '/saved-search/widget/?v2=1&callback=fill&success=' + user_email + '&url=' + SS_URL;
+  } else {
+    ajax_url = BASE_URL + '/saved-search/widget/?v2=1&callback=fill&url=' + SS_URL;
+  }
+  jsonp_ajax_call(ajax_url);
 }
 
 function create_saved_search() {
-    jsonp_ajax_call(base_url + '/api/v1/savedsearch/?callback=reload_default_widget&email=' + user_email + ss_api_str + '&url=' + ss_url);
+  jsonp_ajax_call(BASE_URL + '/api/v1/savedsearch/?callback=reload_default_widget&email=' + user_email + SS_API_STR + '&url=' + SS_URL);
+}
+
+if (window) {
+  window.create_saved_search = create_saved_search;
 }
 
 function create_user() {
-    jsonp_ajax_call(base_url + '/api/v1/user/?callback=create_saved_search&email=' + user_email + ss_api_str + '&source=' + window.location.hostname);
+  jsonp_ajax_call(BASE_URL + '/api/v1/user/?callback=create_saved_search&email=' + user_email + SS_API_STR + '&source=' + window.location.hostname);
 }
 
+function save_search() {
+  // If there is any hint that there isn't a well-defined user email
+  // provided, attempts to get a user from the input and create a new user.
+  // Otherwise, uses the currently provided user to create a saved search.
+
+  if (user_email !== 'None' && user_email !== 'undefined' && user_email) {
+    $('.saved-search-form').html('<em class="saved-search-widget-loading">Saving this search</em>');
+    create_saved_search();
+  } else {
+    try {
+      user_email = $('#saved-search-email').val();
+      $('.saved-search-form').html('<em class="saved-search-widget-loading">Saving this search</em>');
+      create_user();
+    } catch (err) {
+      handle_error();
+    }
+  }
+}
+
+if (window) {
+  window.save_search = save_search;
+}
 
 function jsonp_ajax_call(ajax_url) {
-    $.ajax({
-        url: ajax_url,
-        dataType: 'jsonp',
-        type: 'GET',
-        crossDomain: true,
-        jsonp: false,
-        processData: false,
-        headers: {
-            'Content-Type': 'application/json',
-            Accept: 'text/javascript',
-        },
-        complete: function () {
-            $('#saved-search-email').keyup(function (event) {
-                const ENTER = 13; // The keycode of the enter button
-                if (event.which === ENTER) {
-                    save_search();
-                }
-            });
-        },
-    });
+  $.ajax({
+    url: ajax_url,
+    dataType: 'jsonp',
+    type: 'GET',
+    crossDomain: true,
+    jsonp: false,
+    processData: false,
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'text/javascript',
+    },
+    complete: function() {
+      $('#saved-search-email').keyup(function(event) {
+        const ENTER = 13; // The keycode of the enter button
+        if (event.which === ENTER) {
+          save_search();
+        }
+      });
+    },
+  });
 }
 
 /*
  JAVASCRIPT FOR THE NEW REBRANDING HOMEPAGE FUNCTIONALITY
  */
 // Javascript to show search criteria in mobile view
-$('.mobile-search-btn').on('click', function () {
-    $('.search-criteria-box').toggleClass('show-search-criteria');
+$('.mobile-search-btn').on('click', function() {
+  $('.search-criteria-box').toggleClass('show-search-criteria');
 });
 
 // Javascript for showing the search facets in mobile view on click
-$('#mobile_search').on('click', function () {
-    let mobileSearchFacets = $('.mobile-search-facets');
-    mobileSearchFacets.toggleClass('show-mobile-search-facets');
+$('#mobile_search').on('click', function() {
+  const mobileSearchFacets = $('.mobile-search-facets');
+  mobileSearchFacets.toggleClass('show-mobile-search-facets');
 });
 
 // Function for initializing the accordion of the search criteria
 function filterAccordion() {
-    let accordion = $('.filter-accordion');
-    $.each(accordion, function (v, i) {
-        let that = $(this);
-        let panel = that.next('.filter-panel');
-        let filterCaret = that.children('.drop-caret');
-        that.on('click', function () {
-            panel.toggleClass('filter-panel-deactive');
-            filterCaret.toggleClass('caret-rotate');
-        });
+  const accordion = $('.filter-accordion');
+  $.each(accordion, function() {
+    const that = $(this);
+    const panel = that.next('.filter-panel');
+    const filterCaret = that.children('.drop-caret');
+    that.on('click', function() {
+      panel.toggleClass('filter-panel-deactive');
+      filterCaret.toggleClass('caret-rotate');
     });
+  });
 }
 filterAccordion();
 
 // Javascript to cut the count off of the facets and place it separately into a span that floats to the right
 // Might need to configure and change settings later to get rid of this function
-$.each($('#direct_disambiguationDiv li a'), function (i, v) {
+$.each($('#direct_disambiguationDiv li a'), function() {
+  const self = $(this);
+  const text = self.text().split('(')[0];
+  const count = self.text().split('(').pop();
+  self.html(text);
+  self.append('<span class="count"></span>');
+  self.children('span').html('(' + count);
+});
+
+// Javascript to cut the count off the hidden facets and place it separately inside of a span that floats. The code
+// above is duplicated but wouldn't work for the hidden LI that were created on the fly so I am dynamically doing it
+// when there is a click event on the option to show more of the filters
+$('.direct_optionsMore').on('click', function() {
+  $.each($('#direct_disambiguationDiv li a'), function() {
     const self = $(this);
     const text = self.text().split('(')[0];
     const count = self.text().split('(').pop();
     self.html(text);
     self.append('<span class="count"></span>');
     self.children('span').html('(' + count);
-});
-
-// Javascript to cut the count off the hidden facets and place it separately inside of a span that floats. The code
-// above is duplicated but wouldn't work for the hidden LI that were created on the fly so I am dynamically doing it
-// when there is a click event on the option to show more of the filters
-$('.direct_optionsMore').on('click', function () {
-    $.each($('#direct_disambiguationDiv li a'), function(i, v) {
-        const self = $(this);
-        const text = self.text().split('(')[0];
-        const count = self.text().split('(').pop();
-        self.html(text);
-        self.append('<span class="count"></span>');
-        self.children('span').html('(' + count);
-    });
+  });
 });
 
 // Function for showing and hiding the header when scrolling in mobile view
 function showHideHeaderScroll() {
-    // Hide Header on on scroll down
-    let didScroll;
-    let lastScrollTop = 0;
-    const delta = 5;
-    const navbarHeight = $('nav.main-nav-topbar').outerHeight();
-    const viewPort = $(window).width();
+  // Hide Header on on scroll down
+  let didScroll;
+  let lastScrollTop = 0;
+  const delta = 5;
+  const navbarHeight = $('nav.main-nav-topbar').outerHeight();
+  const viewPort = $(window).width();
 
   // Checking to make sure a scroll has occured
   function hasScrolled() {
-      const scrollTop = $(window).scrollTop();
+    const scrollTop = $(window).scrollTop();
 
-      // Make sure they scroll more than delta
-      if (Math.abs(lastScrollTop - scrollTop) <= delta) {
-          return;
+    // Make sure they scroll more than delta
+    if (Math.abs(lastScrollTop - scrollTop) <= delta) {
+      return;
+    }
+    // If they scrolled down and are past the navbar, add class .nav-up.
+    if (scrollTop > lastScrollTop && scrollTop > navbarHeight) {
+      // Scroll Down
+      $('nav.main-nav-topbar').removeClass('nav-down').addClass('nav-up');
+    } else {
+      // Scroll Up
+      if (scrollTop + $(window).height() < $(document).height()) {
+        $('nav.main-nav-topbar').removeClass('nav-up').addClass('nav-down');
       }
-      // If they scrolled down and are past the navbar, add class .nav-up.
-      if (scrollTop > lastScrollTop && scrollTop > navbarHeight) {
-          // Scroll Down
-          $('nav.main-nav-topbar').removeClass('nav-down').addClass('nav-up');
-      } else {
-          // Scroll Up
-          if (scrollTop + $(window).height() < $(document).height()) {
-            $('nav.main-nav-topbar').removeClass('nav-up').addClass('nav-down');
-          }
-      }
+    }
 
     lastScrollTop = scrollTop;
   }
@@ -370,7 +366,7 @@ function showHideHeaderScroll() {
   if ( /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent) || viewPort < 992 ) {
     $(window).scroll(() => {
       didScroll = true;
-  });
+    });
 
     setInterval(() => {
       if (didScroll) {

--- a/gulp/src/v2/seo-base-scripts.js
+++ b/gulp/src/v2/seo-base-scripts.js
@@ -1,0 +1,384 @@
+/* global $ */
+
+/**
+ * Legacy es5.1 functions used in seo_base_bootstrap3.html template,
+ * relocated to the gulp directory to utilize es6, webpack, et al, during Sprint 24.
+ * TODO: Modify coding styles to match eslint requirements.
+ * TODO: Put utils.js in here as well and make it es6-ish.
+ **/
+
+$(document).ready(function () {
+  // needed to render 'topbar'
+  if (typeof site_name !== 'undefined' && !$('*[data-widget_type=tools]').length) {
+    get_toolbar(site_name);
+  }
+
+  // Autocomplete functionality for the job,title,keyword input box.
+  $('.micrositeTitleField').autocomplete({
+    source: function (request, response) {
+        $.ajax({
+            url: '/ajax/ac/?lookup=title&term=' + request.term,
+            dataType: 'jsonp',
+            success: function(data) {
+                response($.map(data, function (item) {
+                    return {
+                        label: item.title,
+                        value: item.title,
+                    };
+                }));
+            },
+        });
+    },
+    open: function() {
+        $('.ui-autocomplete li.ui-menu-item:odd').addClass('ui-menu-item-alternate');
+        $('.ui-autocomplete li.ui-menu-item a').removeClass('ui-corner-all');
+    },
+    select: function (event, ui) {
+        $('.micrositeTitleField').val('"' + ui.item.value + '"');
+        return false;
+    },
+    minLength: 2,
+  });
+
+    // Autocomplete functionality for the city,state,country input box.
+    $('.micrositeLocationField').autocomplete({
+        source: function(request, response) {
+            $.ajax({
+                url: '/ajax/ac/?lookup=location&term=' + request.term,
+                dataType: 'jsonp',
+                success: function(data) {
+                    response($.map(data, function (item) {
+                        return {
+                            label: item.location + ' - (' + item.jobcount + ')',
+                            value: item.location,
+                        };
+                    }));
+                },
+            });
+        },
+        open: function() {
+            $('.ui-autocomplete li.ui-menu-item:odd').addClass('ui-menu-item-alternate');
+        },
+        minLength: 2,
+    });
+
+    // Add syntax highlighting to autocomplete results.
+    $.ui.autocomplete.prototype._renderItem = function (ul, item) {
+        /**
+         Inputs:
+         :ul:    the autocomplete object to modify
+         :item:  the individual item to modify
+
+         Returns:
+         Modified item
+         **/
+        let term = this.term;
+        if ((term.charAt(0) === '"' && term.charAt(term.length - 1) === '"')) {
+            term = this.term.substr(1, term.length - 2);
+        } else {
+            term = this.term.split(' ').join('|');
+        }
+
+        let re = new RegExp('(' + term + ')', 'gi');
+        let t = item.label.replace(re, '<strong class="ac-highlight">$1</strong>');
+        return $('<li></li>')
+            .data('item.autocomplete', item)
+            .append('<a>' + t + '</a>')
+            .appendTo(ul);
+    };
+
+    // Size the width of the drop down list to match width of input, always, in any size, without CSS
+    $.ui.autocomplete.prototype._resizeMenu = function () {
+        const ul = this.menu.element;
+        ul.outerWidth(this.element.outerWidth());
+    };
+
+    // Submit the search form if location AND title fields have a value in them (and MOC if applicable).
+    $('#standardSearch input[type=text]').bind('autocompleteselect', function (event, ul) {
+        /**
+         Inputs:
+         :event: The autocompleteselect event
+         :ul: The autocomplete object (an unordered list)
+         **/
+        $(this).val(ul.item.value);
+        if ($('#moc').length > 0) {
+            if ($('#location').val() !== '' && $('#q').val() !== '' && $('#moc').val() !== '') {
+                $('#standardSearch').submit();
+            }
+        }
+        else {
+            if ($('#location').val() !== '' && $('#q').val() !== '') {
+                $('#standardSearch').submit();
+            }
+        }
+    });
+
+    // Add autocomplete functionality to the MOC/MOS search field.
+    $('.micrositeMOCField').autocomplete({
+        source: function(request, response) {
+            $.ajax({
+                url: '/ajax/mac/?lookup=moc&term=' + request.term,
+                dataType: 'jsonp',
+                success: function(data) {
+                    response($.map(data, function (item) {
+                        return {
+                            label: item.label,
+                            value: item.value,
+                            moc_id: item.moc_id,
+                        };
+                    }));
+                },
+            });
+        },
+        select: function(event, ui) {
+            $('#moc_id').val(ui.item.moc_id);
+        },
+        open: function(event, ul) {
+            $('.ui-autocomplete li.ui-menu-item:odd').addClass('ui-menu-item-alternate');
+        },
+        minLength: 2,
+    });
+
+    // Clear moc_id value if moc is changed
+    $('#moc').change(function (event) {
+        $('#moc_id').val('');
+    });
+
+    // Save Search Functionality
+    get_default_widget_html(false);
+
+});
+
+function get_toolbar(site_name) {
+    let site = encodeURIComponent(window.location.protocol + '//' + window.location.hostname),
+        url = ABSOLUTE_URL + 'topbar/?v2=1&site_name=' + site_name + '&site=' + site + '&impersonating=' + impersonating;
+    $.ajax({
+        url: url,
+        dataType: 'jsonp',
+        type: 'GET',
+        jsonpCallback: 'populate_toolbar',
+        crossDomain: true,
+        processData: false,
+        headers: {'Content-Type': 'application/json', Accept: 'text/javascript'},
+    });
+}
+
+function populate_toolbar(data) {
+  $('.direct_dotjobsWideHeader').prepend(data);
+}
+
+if (window) {
+  window.populate_toolbar = populate_toolbar;
+}
+
+const ss_username = 'directseo@directemployersfoundation.org';
+const ss_api_key = '6fcd589a4efa72de876edfff7ebf508bedd0ba3e';
+const ss_api_str = '&username=' + ss_username + '&api_key=' + ss_api_key;
+const base_url = 'https://secure.my.jobs';
+const ss_url = encodeURIComponent(window.location.href);
+
+let most_recent_html = '';
+
+
+function handle_error() {
+    // Fills with the most recent text and then overwrites applicable parts
+    // with the error message. Uses the most recent text to ensure formatting
+    // and variables supplied by myjobs are persistent, so the experience
+    // for logged in users continues to be the same.
+
+    fill(most_recent_html);
+    $('.saved-search-form').prepend('<em class="warning">Something went wrong!</em>');
+    $('.saved-search-form > form > b').html('<p>Your search could not successfully be created.</p>');
+    $('label[for="saved-search-email"]').html('<p>Your search could not successfully be created.</p>');
+    $('.saved-search-button').html('Try saving this search again');
+}
+
+function fill(html) {
+    $('#de-myjobs-widget').html(html);
+    $('#mobile-de-myjobs-widget').html(html);
+    most_recent_html = html;
+}
+
+if (window) {
+    window.fill = fill;
+}
+
+function save_search() {
+    // If there is any hint that there isn't a well-defined user email
+    // provided, attempts to get a user from the input and create a new user.
+    // Otherwise, uses the currently provided user to create a saved search.
+
+    if (user_email !== 'None' && user_email !== 'undefined' && user_email) {
+        $('.saved-search-form').html('<em class="saved-search-widget-loading">Saving this search</em>');
+        create_saved_search();
+    }
+    else {
+        try {
+            user_email = $('#saved-search-email').val();
+            $('.saved-search-form').html('<em class="saved-search-widget-loading">Saving this search</em>');
+            create_user();
+        }
+        catch (err) {
+            handle_error();
+        }
+    }
+}
+
+if (window) {
+    window.save_search = save_search;
+}
+
+function reload_default_widget(data) {
+    if (data.error) {
+        handle_error();
+    }
+    else {
+        get_default_widget_html(true);
+    }
+}
+
+function get_default_widget_html(success) {
+    let ajax_url;
+
+    if (success) {
+        ajax_url = base_url + '/saved-search/widget/?v2=1&callback=fill&success=' + user_email + '&url=' + ss_url;
+    }
+    else {
+        ajax_url = base_url + '/saved-search/widget/?v2=1&callback=fill&url=' + ss_url;
+    }
+    jsonp_ajax_call(ajax_url);
+}
+
+function create_saved_search() {
+    jsonp_ajax_call(base_url + '/api/v1/savedsearch/?callback=reload_default_widget&email=' + user_email + ss_api_str + '&url=' + ss_url);
+}
+
+function create_user() {
+    jsonp_ajax_call(base_url + '/api/v1/user/?callback=create_saved_search&email=' + user_email + ss_api_str + '&source=' + window.location.hostname);
+}
+
+
+function jsonp_ajax_call(ajax_url) {
+    $.ajax({
+        url: ajax_url,
+        dataType: 'jsonp',
+        type: 'GET',
+        crossDomain: true,
+        jsonp: false,
+        processData: false,
+        headers: {
+            'Content-Type': 'application/json',
+            Accept: 'text/javascript',
+        },
+        complete: function () {
+            $('#saved-search-email').keyup(function (event) {
+                const ENTER = 13; // The keycode of the enter button
+                if (event.which === ENTER) {
+                    save_search();
+                }
+            });
+        },
+    });
+}
+
+/*
+ JAVASCRIPT FOR THE NEW REBRANDING HOMEPAGE FUNCTIONALITY
+ */
+// Javascript to show search criteria in mobile view
+$('.mobile-search-btn').on('click', function () {
+    $('.search-criteria-box').toggleClass('show-search-criteria');
+});
+
+// Javascript for showing the search facets in mobile view on click
+$('#mobile_search').on('click', function () {
+    let mobileSearchFacets = $('.mobile-search-facets');
+    mobileSearchFacets.toggleClass('show-mobile-search-facets');
+});
+
+// Function for initializing the accordion of the search criteria
+function filterAccordion() {
+    let accordion = $('.filter-accordion');
+    $.each(accordion, function (v, i) {
+        let that = $(this);
+        let panel = that.next('.filter-panel');
+        let filterCaret = that.children('.drop-caret');
+        that.on('click', function () {
+            panel.toggleClass('filter-panel-deactive');
+            filterCaret.toggleClass('caret-rotate');
+        });
+    });
+}
+filterAccordion();
+
+// Javascript to cut the count off of the facets and place it separately into a span that floats to the right
+// Might need to configure and change settings later to get rid of this function
+$.each($('#direct_disambiguationDiv li a'), function (i, v) {
+    const self = $(this);
+    const text = self.text().split('(')[0];
+    const count = self.text().split('(').pop();
+    self.html(text);
+    self.append('<span class="count"></span>');
+    self.children('span').html('(' + count);
+});
+
+// Javascript to cut the count off the hidden facets and place it separately inside of a span that floats. The code
+// above is duplicated but wouldn't work for the hidden LI that were created on the fly so I am dynamically doing it
+// when there is a click event on the option to show more of the filters
+$('.direct_optionsMore').on('click', function () {
+    $.each($('#direct_disambiguationDiv li a'), function(i, v) {
+        const self = $(this);
+        const text = self.text().split('(')[0];
+        const count = self.text().split('(').pop();
+        self.html(text);
+        self.append('<span class="count"></span>');
+        self.children('span').html('(' + count);
+    });
+});
+
+// Function for showing and hiding the header when scrolling in mobile view
+function showHideHeaderScroll() {
+    // Hide Header on on scroll down
+    let didScroll;
+    let lastScrollTop = 0;
+    const delta = 5;
+    const navbarHeight = $('nav.main-nav-topbar').outerHeight();
+    const viewPort = $(window).width();
+
+  // Checking to make sure a scroll has occured
+  function hasScrolled() {
+      const scrollTop = $(window).scrollTop();
+
+      // Make sure they scroll more than delta
+      if (Math.abs(lastScrollTop - scrollTop) <= delta) {
+          return;
+      }
+      // If they scrolled down and are past the navbar, add class .nav-up.
+      if (scrollTop > lastScrollTop && scrollTop > navbarHeight) {
+          // Scroll Down
+          $('nav.main-nav-topbar').removeClass('nav-down').addClass('nav-up');
+      } else {
+          // Scroll Up
+          if (scrollTop + $(window).height() < $(document).height()) {
+            $('nav.main-nav-topbar').removeClass('nav-up').addClass('nav-down');
+          }
+      }
+
+    lastScrollTop = scrollTop;
+  }
+
+    // Checking to see if it's a mobile device or if the screensize is in mobile view
+  if ( /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent) || viewPort < 992 ) {
+    $(window).scroll(() => {
+      didScroll = true;
+  });
+
+    setInterval(() => {
+      if (didScroll) {
+        hasScrolled();
+        didScroll = false;
+      }
+    }, 250);
+  }
+}
+
+showHideHeaderScroll();

--- a/gulp/src/v2/seo-base-scripts.js
+++ b/gulp/src/v2/seo-base-scripts.js
@@ -1,5 +1,5 @@
 /* global $ */
-
+/* eslint-disable */
 /**
  * Legacy es5.1 functions used in seo_base_bootstrap3.html template,
  * relocated to the gulp directory to utilize es6, webpack, et al, during Sprint 24.

--- a/gulp/webpack.config.js
+++ b/gulp/webpack.config.js
@@ -17,6 +17,7 @@ module.exports = {
     analytics: './src/analytics/main',
     custom: './src/sass/custom.scss',
     seo_base_styles: './src/sass/seo_base_styles.scss',
+    seo_base_scripts: './src/v2/seo-base-scripts',
   },
   resolve: {
     root: path.resolve('src'),

--- a/templates/seo_base_bootstrap3.html
+++ b/templates/seo_base_bootstrap3.html
@@ -157,15 +157,24 @@
   </div>
 </section><!--FOOTER END-->
 
-<script defer src="{{ STATIC_URL }}jquery-2.2.4.min.js"></script>
-<script defer src="{{ STATIC_URL }}jquery-ui-1.12.1.custom.min.js"></script>
-<script defer src="{% static "seo-base-scripts-181-27.js" %}"></script>
-<script defer src="{% static "utils.181-20.js" %}"></script>
-<script defer src="{% static "secure-blocks/secure-block.181-20.js" %}"></script>
-<script defer src="{% static "pager.164-21.js" %}"></script>
+<script src="{{ STATIC_URL }}jquery-2.2.4.min.js"></script>
+<script src="{{ STATIC_URL }}jquery-ui-1.12.1.custom.min.js"></script>
+
+{% if wp_base_url %}
+  <script src="{{wp_base_url}}/seo_base_scripts.js"></script>
+{% else %}
+  {% compress js %}
+      <script src="{% static "bundle/vendor.js" %}"></script>
+      <script src="{% static "bundle/seo_base_scripts.js" %}"></script>
+  {% endcompress %}
+{% endif %}
+
+<script src="{% static "utils.181-20.js" %}"></script>
+<script src="{% static "secure-blocks/secure-block.181-20.js" %}"></script>
+<script src="{% static "pager.164-21.js" %}"></script>
 
 {% if site_config.use_secure_blocks %}
-    <script defer>
+    <script>
       var pager_num_items = {{ site_config.num_subnav_items_to_show }};
       var parent_site_url = "{% if testing_host_prefix %}http://{% else %}https://{% endif %}{{ secure_blocks_domain.domain }}";
       $(document).on("ready", function() {
@@ -175,7 +184,7 @@
 {% endif %}
 
 {% if "network" in site_tags %}
-    <script defer>
+    <script>
         var site_name = "{{ site_name }}";
         var ABSOLUTE_URL = "{{ ABSOLUTE_URL }}",
             impersonating = {% if request.impersonator %}true{% else %}false{% endif %};


### PR DESCRIPTION
Purpose:  Relocate the seo-base-scripts.js file from the static directory to the gulp directory in order to utilize the goodness of WebPack and es6.  Seems like a simple thing but this PR actually lays the foundation for using es6 project wide in the v2, in the future.  I also removed the "defer" attribute on the script tags which I added a couple of months ago.  I removed the defer because it was conflicting with the webpack-dev-server version 1.14.1 (known webpack issue).  Unexpectedly, page load times are faster with es6 and WebPack without the defer attribute than the old version with the defer attribute.  I emptied cache and hard reload 10 times in each version, the median load times for the new version is faster, also, in production the webpack-dev-server and websocket will not be used so load times will even be faster than in my local dev environment.
Before:
<img width="1016" alt="before" src="https://cloud.githubusercontent.com/assets/5124153/20799660/d5f932e4-b7b0-11e6-89b3-6d7361ea2b69.png">

After (more file request because of local webpack dev server):
<img width="1004" alt="es6-webpack" src="https://cloud.githubusercontent.com/assets/5124153/20799697/f522fd9e-b7b0-11e6-8777-864615b169c1.png">

Suggested Testing Plan: 

1. Switch to v2 template.

2. In desktop view, please test job and location input boxes for the autocomplete dropdown suggestion box, which should be triggered on the second character input.  Please ensure that when both input boxes are completed, the search function should fire (all 3 input boxes in the case of MOC).  Please ensure the "Save & Email this search" facet appears after the api has return jobs. Please ensure that the "Show More Jobs" button works.

3. Please click the Save button in the "Save & Email this search" facet and ensure an email is generated and sent to your designated inbox.

4. In the facets, with the exception of the "Save & Email this search" facet, please ensure that the facets are collapsible and expandable.  Inside of the facets, please ensure the "Show More" and "Show Less" (where applicable) works.

5. In mobile view, please click on the "Filter Search Criteria" button and repeat steps 2 through 4 above.

6.  In mobile view, please refresh the page. Please scroll down, the top bar should disappears as you scroll down and reappears as you scroll up.