### PR TITLE
PD-2771, change placeholder verbiage to make for sense

### DIFF
--- a/gulp/src/sass/seo_base_styles.scss
+++ b/gulp/src/sass/seo_base_styles.scss
@@ -1318,7 +1318,7 @@ margin-bottom: 50px;
     }
 
   ::-webkit-input-placeholder {
-    font-size: 1.1rem;
+    font-size: 1.2rem;
   }
 }
 

--- a/gulp/src/sass/seo_base_styles.scss
+++ b/gulp/src/sass/seo_base_styles.scss
@@ -615,9 +615,9 @@ margin-bottom: 50px;
 
     i {
       position: absolute;
-      left: 10px;
-			font-size: 24px;
-			top: 10px;
+      left: .45rem;
+      font-size: 24px;
+      top: 10px;
       color: $blue;
     }
     .helptext {
@@ -632,7 +632,7 @@ margin-bottom: 50px;
     #q{
       @extend .search-input-boxes;
       width: 100%;
-      padding: 0 0 0 40px;
+      padding: 0 0 0 3rem;
 
       &::-webkit-input-placeholder {
         color: $blue;
@@ -655,9 +655,9 @@ margin-bottom: 50px;
 
     i {
       position: absolute;
-      left: 10px;
-			font-size: 24px;
-			top: 10px;
+      left: .45rem;
+      font-size: 24px;
+      top: 10px;
       color: $blue;
     }
     .helptext {
@@ -672,7 +672,7 @@ margin-bottom: 50px;
     #location {
       @extend .search-input-boxes;
       width: 100%;
-      padding: 0 0 0 40px;
+      padding: 0 0 0 3rem;
 
       &::-webkit-input-placeholder {
         color: $blue;
@@ -695,9 +695,9 @@ margin-bottom: 50px;
 
     i {
       position: absolute;
-      left: 10px;
-			font-size: 24px;
-			top: 10px;
+      left: .45rem;
+      font-size: 24px;
+      top: 10px;
       color: $blue;
     }
     .helptext {
@@ -712,7 +712,7 @@ margin-bottom: 50px;
     #moc {
       @extend .search-input-boxes;
       width: 100%;
-      padding: 0 0 0 40px;
+      padding: 0 0 0 2.9rem;
 
       &::-webkit-input-placeholder {
         color: $blue;
@@ -1021,7 +1021,7 @@ margin-bottom: 50px;
 
 /* Custom, iPhone Retina */
 @media only screen and (min-width: 320px) and (max-width: 480px) {
-    /** Be default iOS devices hides scroll bar,
+    /** Be default iOS devices hides scroll bar,                                                                              g
   this makes all devices show scrollbar for nested sub menus **/
   ::-webkit-scrollbar {
     -webkit-appearance: none;
@@ -1317,6 +1317,9 @@ margin-bottom: 50px;
       }
     }
 
+  ::-webkit-input-placeholder {
+    font-size: 1.1rem;
+  }
 }
 
 @media only screen and (min-width: 769px) {
@@ -1599,16 +1602,6 @@ margin-bottom: 50px;
           width: 35%;
       }
   }
-}
-
-/* The M.O.C. place holder text is long,
-    this makes it easier to read at certain screen sizes. */
-@media only screen and (min-width : 769px) and (max-width: 1290px){
-
-  #moc::-webkit-input-placeholder {
-    font-size: 1.1rem;
-  }
-
 }
 
 /* Large Devices, Wide Screens */

--- a/templates/v2/includes/search_box_vets_widget.html
+++ b/templates/v2/includes/search_box_vets_widget.html
@@ -12,13 +12,13 @@
           <div class="row">
             <div class="col-xs-12 col-sm-3 col-md-3">
               <span class="what-section">
-                <input title="Search Phrase" type="text" name="q" id="q" class="micrositeTitleField what" {% if title_term != "\*" %}value="{{ title_term }}"{% endif %} {% if site_config.what_placeholder %}placeholder="{{ site_config.what_placeholder }}"{% endif %} placeholder="job,title,keyword" />
+                <input title="Search Phrase" type="text" name="q" id="q" class="micrositeTitleField what" {% if title_term != "\*" %}value="{{ title_term }}"{% endif %} {% if site_config.what_placeholder %}placeholder="{{ site_config.what_placeholder }}"{% endif %} placeholder="job title, keyword, company" />
                 <i class="glyphicon glyphicon-search" aria-hidden="true"></i>
               </span>
             </div>
               <div class="col-xs-12 col-sm-3 col-md-3">
                 <span class="where-section">
-                  <input title="Search Location" type="text" name="location" id="location" class="micrositeLocationField where" {% if location_term != "\*" %}value="{{ location_term }}"{% endif %} {% if site_config.where_placeholder %}placeholder="{{ site_config.where_placeholder }}"{% endif %} placeholder="city,state,country" />
+                  <input title="Search Location" type="text" name="location" id="location" class="micrositeLocationField where" {% if location_term != "\*" %}value="{{ location_term }}"{% endif %} {% if site_config.where_placeholder %}placeholder="{{ site_config.where_placeholder }}"{% endif %} placeholder="city, state, country" />
                   <i class="glyphicon glyphicon-map-marker" aria-hidden="true"></i>
                 </span>
               </div>

--- a/templates/v2/includes/search_box_widget.html
+++ b/templates/v2/includes/search_box_widget.html
@@ -13,13 +13,13 @@
           <div class="row">
             <div class="col-xs-12 col-sm-4 col-md-4">
               <span class="what-section">
-                <input title="Search Phrase" type="text" name="q" id="q" class="micrositeTitleField what" {% if title_term != "\*" %}value="{{ title_term }}"{% endif %} {% if site_config.what_placeholder %}placeholder="{{ site_config.what_placeholder }}"{% endif %} placeholder="job,title,keyword" />
+                <input title="Search Phrase" type="text" name="q" id="q" class="micrositeTitleField what" {% if title_term != "\*" %}value="{{ title_term }}"{% endif %} {% if site_config.what_placeholder %}placeholder="{{ site_config.what_placeholder }}"{% endif %} placeholder="job title, keyword, company" />
                 <i class="glyphicon glyphicon-search" aria-hidden="true"></i>
               </span>
             </div>
               <div class="col-xs-12 col-sm-4 col-md-4">
                 <span class="where-section">
-                  <input title="Search Location" type="text" name="location" id="location" class="micrositeLocationField where" {% if location_term != "\*" %}value="{{ location_term }}"{% endif %} {% if site_config.where_placeholder %}placeholder="{{ site_config.where_placeholder }}"{% endif %} placeholder="city,state,country" />
+                  <input title="Search Location" type="text" name="location" id="location" class="micrositeLocationField where" {% if location_term != "\*" %}value="{{ location_term }}"{% endif %} {% if site_config.where_placeholder %}placeholder="{{ site_config.where_placeholder }}"{% endif %} placeholder="city, state, country" />
                   <i class="glyphicon glyphicon-map-marker" aria-hidden="true"></i>
                 </span>
               </div>


### PR DESCRIPTION
Purpose:  Change the placeholder text in the "job title" input box to make more sense and a little easier to read, especially in MOC where there are 3 input boxes.

To Test: 

1. Please switch to v2 template.

2. Please ensure the "what" placeholder text in www.my.jobs and MOC sites says: "job title, keyword, company"