### PR TITLE
PD-2776, remove vendor.js file and references to it

### DIFF
--- a/gulp/gulpfile.js
+++ b/gulp/gulpfile.js
@@ -14,9 +14,6 @@ process.on('SIGINT', function() {
 
 // This build produces several javascript bundles.
 //
-//     In production this bundle also contains whatever code webpack deemed
-//     as common to all app bundles.
-//
 // * reporting.js, [other-apps].js, etc. - These contain mostly only code
 //     used in a specific application. There should be one for each "app"
 //     in our site.

--- a/gulp/gulpfile.js
+++ b/gulp/gulpfile.js
@@ -13,10 +13,6 @@ process.on('SIGINT', function() {
 });
 
 // This build produces several javascript bundles.
-// * vendor.js - Contains all the libraries we use, bundled and minified.
-//     This code is shared by all other app bundles. It is expected to be
-//     larger than app bundles and shared by all pages needing this
-//     infrastructure.
 //
 //     In production this bundle also contains whatever code webpack deemed
 //     as common to all app bundles.

--- a/gulp/webpack.config.js
+++ b/gulp/webpack.config.js
@@ -70,14 +70,6 @@ module.exports = {
     new webpack.DefinePlugin({
       'process.env.NODE_ENV': '"production"',
     }),
-    // Factor common code in to vendor.js.
-    // This also establishes the parent relationship between the vendor
-    // and app chunks.
-    new webpack.optimize.CommonsChunkPlugin({
-      name: 'vendor',
-      filename: 'vendor.js',
-      minChunks: 2,
-    }),
     // Dedupe slightly decreases output size.
     new webpack.optimize.DedupePlugin(),
     // Webpack docs recommend using this plugin.

--- a/templates/analytics/analytics_main.html
+++ b/templates/analytics/analytics_main.html
@@ -15,7 +15,6 @@
   <script src="{{wp_base_url}}/analytics.js"></script>
 {% else %}
   {% compress js %}
-      <script src="{% static "bundle/vendor.js" %}"></script>
       <script src="{% static "bundle/analytics.js" %}"></script>
   {% endcompress %}
 {% endif %}

--- a/templates/manageusers/index.html
+++ b/templates/manageusers/index.html
@@ -24,7 +24,6 @@
       <script src="{{wp_base_url}}/manageusers.js"/></script>
     {% else %}
       {% compress js %}
-          <script src="{% static "bundle/vendor.js" %}"></script>
           <script src="{% static "bundle/manageusers.js" %}"></script>
       {% endcompress %}
     {% endif %}

--- a/templates/myprofile/react_edit.html
+++ b/templates/myprofile/react_edit.html
@@ -32,7 +32,6 @@
   <script src="{{wp_base_url}}/myprofile.js"/></script>
 {% else %}
   {% compress js %}
-  <script src="{% static "bundle/vendor.js" %}"></script>
   <script src="{% static "bundle/myprofile.js" %}"></script>
   {% endcompress %}
 {% endif %}

--- a/templates/myreports/dynamicreports.html
+++ b/templates/myreports/dynamicreports.html
@@ -21,7 +21,6 @@
   <script src="{{wp_base_url}}/reporting.js"></script>
 {% else %}
   {% compress js %}
-      <script src="{% static "bundle/vendor.js" %}"></script>
       <script src="{% static "bundle/reporting.js" %}"></script>
   {% endcompress %}
 {% endif %}

--- a/templates/nonuseroutreach/nuo_main.html
+++ b/templates/nonuseroutreach/nuo_main.html
@@ -62,7 +62,6 @@
       <script src="{{wp_base_url}}/nonuseroutreach.js"/></script>
     {% else %}
       {% compress js %}
-      <script src="{% static "bundle/vendor.js" %}"></script>
       <script src="{% static "bundle/nonuseroutreach.js" %}"></script>
       {% endcompress %}
     {% endif %}

--- a/templates/seo_base_bootstrap3.html
+++ b/templates/seo_base_bootstrap3.html
@@ -164,7 +164,6 @@
   <script src="{{wp_base_url}}/seo_base_scripts.js"></script>
 {% else %}
   {% compress js %}
-      <script src="{% static "bundle/vendor.js" %}"></script>
       <script src="{% static "bundle/seo_base_scripts.js" %}"></script>
   {% endcompress %}
 {% endif %}


### PR DESCRIPTION
Purpose:  Remove the vendor.js file and all references to it because it was no longer being used, furthermore, it was adding 830K of extra weight to the load time.

To Test:

1.  Please switch to the v2 template.

2. In the dev tool network tab, please ensure that the seo_base_scripts.js file isn't 800k or more in size.  In the actual QC env, this file might be call 4bb123434566.js.

3. Please also do a functionality check of NUO, the profile page, dynamic reports, and  analytics. 