### PR TITLE
PD-2778, fix 'Filter Search Criteria' button to be easier to read and…

### DIFF
--- a/gulp/src/sass/seo_base_styles.scss
+++ b/gulp/src/sass/seo_base_styles.scss
@@ -397,7 +397,6 @@ a.direct_optionsLess {
     border-radius: 3px;
     box-sizing: border-box;
     box-shadow: 2px 2px 3px #bbb;
-    margin-top: 75px;
     padding: 0px 10px;
   }
   .search-sent-text {
@@ -444,6 +443,7 @@ a.direct_optionsLess {
   padding: 10px 20px;
   border: none;
   border-radius: 2px;
+  font-weight: 900;
 }
 
 .filter-box {
@@ -772,7 +772,6 @@ margin-bottom: 50px;
     .email-box {
       @extend .gray-section-boxes;
       padding: 10px;
-      margin-top: 75px;
 
       #mobile_enter_email {
         position: relative;


### PR DESCRIPTION
Purpose:  Make the font weight for the "Filter Search Criteria" button easier to read on narrow screens and iPhone 5 type resolution.  Also, remove the huge gap between the "Filter Search Criteria" button and "Save & Email this search" facet in mobile view when you click on the Search Jobs button.

Before 1: font-weight too light
![before1](https://cloud.githubusercontent.com/assets/5124153/20943335/07771a0a-bbcd-11e6-8d20-3b6616cf8c3e.png)

Before 2: Too much margin
![before2](https://cloud.githubusercontent.com/assets/5124153/20943355/20b97742-bbcd-11e6-8bf0-bc0b7b7a5f37.png)

After 1: Made font darker
![after1](https://cloud.githubusercontent.com/assets/5124153/20943383/35a26f42-bbcd-11e6-9982-1ee02836cb9f.png)

After 2: Remove extra margin
![after2](https://cloud.githubusercontent.com/assets/5124153/20943393/42eb5dd0-bbcd-11e6-8be5-06d168eb2e52.png)

To Test: 

1.  In v2 template, please make your browser narrow or switch to mobile browser mode.  Please click on the "Search Jobs" button and verify the "After" screen shots above.