### PR TITLE
[PD-2762] analytics start api

### DIFF
--- a/analytics/tests/test_api.py
+++ b/analytics/tests/test_api.py
@@ -1,0 +1,303 @@
+import json
+
+from myjobs.tests.setup import MyJobsBase
+import myreports.models as myreports_models
+
+from django.core.urlresolvers import reverse
+
+from analytics.api import get_available_analytics, get_report_info
+
+
+class TestApi(MyJobsBase):
+    def setUp(self):
+        super(TestApi, self).setUp()
+        self.maxDiff = 10000
+        self.role.add_activity("view analytics")
+        self.rit_analytics = myreports_models.ReportingType.objects.create(
+            reporting_type="web-analytics",
+            description="Web Analytics",
+            is_active=True)
+
+        self.rt_job_titles = myreports_models.ReportType.objects.create(
+            report_type="job-titles",
+            description="Job Titles",
+            is_active=True)
+        self.rt_job_found_on = myreports_models.ReportType.objects.create(
+            report_type="job-found-on",
+            description="Site Found On",
+            is_active=True)
+        self.rt_job_locations = myreports_models.ReportType.objects.create(
+            report_type="job-locations",
+            description="Job Locations",
+            is_active=True)
+
+        myreports_models.ReportingTypeReportTypes.objects.create(
+            reporting_type=self.rit_analytics,
+            report_type=self.rt_job_titles,
+            is_active=True)
+        myreports_models.ReportingTypeReportTypes.objects.create(
+            reporting_type=self.rit_analytics,
+            report_type=self.rt_job_found_on,
+            is_active=True)
+        myreports_models.ReportingTypeReportTypes.objects.create(
+            reporting_type=self.rit_analytics,
+            report_type=self.rt_job_locations,
+            is_active=True)
+
+        unagg = myreports_models.DataType.objects.create(
+                data_type="Unaggregated")
+
+        self.config_job_titles = myreports_models.Configuration.objects.create(
+            name="Job Titles",
+            is_active=True)
+        self.config_found_on = myreports_models.Configuration.objects.create(
+            name="Found On",
+            is_active=True)
+        self.config_job_locations = (
+            myreports_models.Configuration.objects.create(
+                name="Job Locations",
+                is_active=True))
+
+        self.rtdt_job_titles = (
+            myreports_models.ReportTypeDataTypes.objects.create(
+                report_type=self.rt_job_titles,
+                data_type=unagg,
+                is_active=True,
+                configuration=self.config_job_titles))
+        self.rtdt_job_found_on = (
+            myreports_models.ReportTypeDataTypes.objects.create(
+                report_type=self.rt_job_found_on,
+                data_type=unagg,
+                is_active=True,
+                configuration=self.config_found_on))
+        self.rtdt_job_locations = (
+            myreports_models.ReportTypeDataTypes.objects.create(
+                report_type=self.rt_job_locations,
+                data_type=unagg,
+                is_active=True,
+                configuration=self.config_job_locations))
+
+        myreports_models.ConfigurationColumn.objects.create(
+            configuration=self.config_job_titles,
+            order=1,
+            column_name="title",
+            filter_interface_type='string',
+            filter_interface_display='Job Title',
+            multi_value_expansion=0,
+            is_active=True)
+        myreports_models.ConfigurationColumn.objects.create(
+            configuration=self.config_job_titles,
+            order=2,
+            column_name="job_guid",
+            filter_interface_type='string',
+            filter_interface_display='Job Id',
+            multi_value_expansion=0,
+            is_active=True)
+        myreports_models.ConfigurationColumn.objects.create(
+            configuration=self.config_job_titles,
+            order=3,
+            column_name="country",
+            filter_interface_type='map:world',
+            filter_interface_display='Country',
+            multi_value_expansion=0,
+            is_active=True)
+        myreports_models.ConfigurationColumn.objects.create(
+            configuration=self.config_job_titles,
+            order=4,
+            column_name="state",
+            filter_interface_type='map:nation',
+            filter_interface_display='State',
+            multi_value_expansion=0,
+            is_active=True)
+        myreports_models.ConfigurationColumn.objects.create(
+            configuration=self.config_job_titles,
+            order=5,
+            column_name="city",
+            filter_interface_type='map:state',
+            filter_interface_display='City',
+            multi_value_expansion=0,
+            is_active=True)
+        myreports_models.ConfigurationColumn.objects.create(
+            configuration=self.config_job_titles,
+            order=6,
+            column_name="found_on",
+            filter_interface_type='string',
+            filter_interface_display='Found on',
+            multi_value_expansion=0,
+            is_active=True)
+
+        myreports_models.ConfigurationColumn.objects.create(
+            configuration=self.config_found_on,
+            order=1,
+            column_name="found_on",
+            filter_interface_type='string',
+            filter_interface_display='Found On',
+            multi_value_expansion=0,
+            is_active=True)
+        myreports_models.ConfigurationColumn.objects.create(
+            configuration=self.config_found_on,
+            order=2,
+            column_name="title",
+            filter_interface_type='string',
+            filter_interface_display='Job Title',
+            multi_value_expansion=0,
+            is_active=True)
+        myreports_models.ConfigurationColumn.objects.create(
+            configuration=self.config_found_on,
+            order=3,
+            column_name="job_guid",
+            filter_interface_type='string',
+            filter_interface_display='Job Id',
+            multi_value_expansion=0,
+            is_active=True)
+        myreports_models.ConfigurationColumn.objects.create(
+            configuration=self.config_found_on,
+            order=4,
+            column_name="country",
+            filter_interface_type='map:world',
+            filter_interface_display='Country',
+            multi_value_expansion=0,
+            is_active=True)
+        myreports_models.ConfigurationColumn.objects.create(
+            configuration=self.config_found_on,
+            order=4,
+            column_name="state",
+            filter_interface_type='map:nation',
+            filter_interface_display='State',
+            multi_value_expansion=0,
+            is_active=True)
+        myreports_models.ConfigurationColumn.objects.create(
+            configuration=self.config_found_on,
+            order=6,
+            column_name="city",
+            filter_interface_type='map:state',
+            filter_interface_display='City',
+            multi_value_expansion=0,
+            is_active=True)
+
+        myreports_models.ConfigurationColumn.objects.create(
+            configuration=self.config_job_locations,
+            order=1,
+            column_name="country",
+            filter_interface_type='map:world',
+            filter_interface_display='Country',
+            multi_value_expansion=0,
+            is_active=True)
+        myreports_models.ConfigurationColumn.objects.create(
+            configuration=self.config_job_locations,
+            order=2,
+            column_name="state",
+            filter_interface_type='map:nation',
+            filter_interface_display='State',
+            multi_value_expansion=0,
+            is_active=True)
+        myreports_models.ConfigurationColumn.objects.create(
+            configuration=self.config_job_locations,
+            order=3,
+            column_name="city",
+            filter_interface_type='map:state',
+            filter_interface_display='City',
+            multi_value_expansion=0,
+            is_active=True)
+        myreports_models.ConfigurationColumn.objects.create(
+            configuration=self.config_job_locations,
+            order=4,
+            column_name="found_on",
+            filter_interface_type='string',
+            filter_interface_display='Found On',
+            multi_value_expansion=0,
+            is_active=True)
+        myreports_models.ConfigurationColumn.objects.create(
+            configuration=self.config_job_locations,
+            order=5,
+            column_name="title",
+            filter_interface_type='string',
+            filter_interface_display='Job Title',
+            multi_value_expansion=0,
+            is_active=True)
+        myreports_models.ConfigurationColumn.objects.create(
+            configuration=self.config_job_locations,
+            order=6,
+            column_name="job_guid",
+            filter_interface_type='string',
+            filter_interface_display='Job Id',
+            multi_value_expansion=0,
+            is_active=True)
+
+    def test_available(self):
+        response = self.client.get(reverse(get_available_analytics))
+        result = json.loads(response.content)
+        expected = {
+            'reports': [
+                {
+                    'value': 'job-locations',
+                    'display': 'Job Locations',
+                },
+                {
+                    'value': 'job-titles',
+                    'display': 'Job Titles',
+                },
+                {
+                    'value': 'job-found-on',
+                    'display': 'Site Found On',
+                },
+            ],
+        }
+        self.assertEqual(expected, result)
+
+    def test_report_info(self):
+        response = self.client.get(
+            reverse(get_report_info),
+            {'analytics_report_id': 'job-locations'})
+        result = json.loads(response.content)
+        expected = {
+            'dimensions': [
+                {
+                    'value': 'country',
+                    'display': 'Country',
+                    'interface_type': 'map:world',
+                },
+                {
+                    'value': 'state',
+                    'display': 'State',
+                    'interface_type': 'map:nation',
+                },
+                {
+                    'value': 'city',
+                    'display': 'City',
+                    'interface_type': 'map:state',
+                },
+                {
+                    'value': 'found_on',
+                    'display': 'Found On',
+                    'interface_type': 'string',
+                },
+                {
+                    'value': 'title',
+                    'display': 'Job Title',
+                    'interface_type': 'string',
+                },
+                {
+                    'value': 'job_guid',
+                    'display': 'Job Id',
+                    'interface_type': 'string',
+                },
+            ]
+        }
+        self.assertEqual(expected, result)
+
+    def test_report_info_no_id(self):
+        response = self.client.get(reverse(get_report_info))
+        self.assertEqual(400, response.status_code)
+        result = json.loads(response.content)
+        fields = [i['field'] for i in result]
+        self.assertIn('analytics_report_id', fields)
+
+    def test_report_info_bad_id(self):
+        response = self.client.get(
+            reverse(get_report_info),
+            {'analytics_report_id': 'zzzzz'})
+        self.assertEqual(400, response.status_code)
+        result = json.loads(response.content)
+        fields = [i['field'] for i in result]
+        self.assertIn('analytics_report_id', fields)

--- a/analytics/urls.py
+++ b/analytics/urls.py
@@ -1,21 +1,30 @@
 from django.conf.urls import url, patterns, include
 
 # API URLs
-api_patterns = patterns('analytics.api',
-   url(r'^views-week', 'views_last_7_days', name='views_last_7_days'),
-   url(r'^activity-week', 'activity_last_7_days', name='activity_last_7_days'),
-   url(r'^campaign-percent', 'campaign_percentages', name='campaign_percentages'),
-   url(r'^dynamic', 'dynamic_chart', name='dynamic_chart'),
+api_patterns = patterns(
+    'analytics.api',
+    url(r'^available-reports', 'get_available_analytics',
+        name='available_reports'),
+    url(r'^report-info', 'get_report_info',
+        name='get_report_info'),
+    url(r'^views-week', 'views_last_7_days', name='views_last_7_days'),
+    url(r'^activity-week', 'activity_last_7_days',
+        name='activity_last_7_days'),
+    url(r'^campaign-percent', 'campaign_percentages',
+        name='campaign_percentages'),
+    url(r'^dynamic', 'dynamic_chart', name='dynamic_chart'),
 )
 
 # View URLs
 
-view_patterns = patterns('analytics.views',
-  url(r'^main', 'analytics_main', name='analytics_main'),
+view_patterns = patterns(
+    'analytics.views',
+    url(r'^main', 'analytics_main', name='analytics_main'),
 )
 
 
-urlpatterns = patterns('',
-   url(r'^api/', include(api_patterns)),
-   url(r'^view/', include(view_patterns)),
+urlpatterns = patterns(
+    '',
+    url(r'^api/', include(api_patterns)),
+    url(r'^view/', include(view_patterns)),
 )

--- a/myjobs/tests/setup.py
+++ b/myjobs/tests/setup.py
@@ -111,7 +111,7 @@ class MyJobsBase(TestCase):
                 "read outreach email address", "create outreach email address",
                 "delete outreach email address",
                 "update outreach email address", "read outreach record",
-                "convert outreach record"]]
+                "convert outreach record", "view analytics"]]
 
         self.company = CompanyFactory(app_access=[self.app_access])
         # this role will be populated by activities on a test-by-test basis

--- a/myreports/migrations/0015_analyticsreports.py
+++ b/myreports/migrations/0015_analyticsreports.py
@@ -1,0 +1,700 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import DataMigration
+
+
+class Migration(DataMigration):
+
+    def forwards(self, orm):
+        "Write your forwards methods here."
+        # Note: Don't use "from appname.models import ModelName".
+        # Use orm.ModelName to refer to models in this application,
+        # and orm['appname.ModelName'] for models in other applications.
+
+        rit_analytics = orm.ReportingType.objects.create(
+            reporting_type="web-analytics",
+            description="Web Analytics",
+            is_active=True)
+
+        rt_job_titles = orm.ReportType.objects.create(
+            report_type="job-titles",
+            description="Job Titles",
+            is_active=True)
+        rt_job_found_on = orm.ReportType.objects.create(
+            report_type="job-found-on",
+            description="Site Found On",
+            is_active=True)
+        rt_job_locations = orm.ReportType.objects.create(
+            report_type="job-locations",
+            description="Job Locations",
+            is_active=True)
+
+        orm.ReportingTypeReportTypes.objects.create(
+            reporting_type=rit_analytics,
+            report_type=rt_job_titles,
+            is_active=True)
+        orm.ReportingTypeReportTypes.objects.create(
+            reporting_type=rit_analytics,
+            report_type=rt_job_found_on,
+            is_active=True)
+        orm.ReportingTypeReportTypes.objects.create(
+            reporting_type=rit_analytics,
+            report_type=rt_job_locations,
+            is_active=True)
+
+        unagg = orm.DataType.objects.get(data_type="Unaggregated")
+
+        config_job_titles = orm.Configuration.objects.create(
+            name="Job Titles",
+            is_active=True)
+        config_found_on = orm.Configuration.objects.create(
+            name="Found On",
+            is_active=True)
+        config_job_locations = orm.Configuration.objects.create(
+            name="Job Locations",
+            is_active=True)
+
+        orm.ReportTypeDataTypes.objects.create(
+            report_type=rt_job_titles,
+            data_type=unagg,
+            is_active=True,
+            configuration=config_job_titles)
+        orm.ReportTypeDataTypes.objects.create(
+            report_type=rt_job_found_on,
+            data_type=unagg,
+            is_active=True,
+            configuration=config_found_on)
+        orm.ReportTypeDataTypes.objects.create(
+            report_type=rt_job_locations,
+            data_type=unagg,
+            is_active=True,
+            configuration=config_job_locations)
+
+        orm.ConfigurationColumn.objects.create(
+            configuration=config_job_titles,
+            order=1,
+            column_name="title",
+            filter_interface_type='string',
+            filter_interface_display='Job Title',
+            multi_value_expansion=0,
+            is_active=True)
+        orm.ConfigurationColumn.objects.create(
+            configuration=config_job_titles,
+            order=2,
+            column_name="job_guid",
+            filter_interface_type='string',
+            filter_interface_display='Job Id',
+            multi_value_expansion=0,
+            is_active=True)
+        orm.ConfigurationColumn.objects.create(
+            configuration=config_job_titles,
+            order=3,
+            column_name="country",
+            filter_interface_type='map:world',
+            filter_interface_display='Country',
+            multi_value_expansion=0,
+            is_active=True)
+        orm.ConfigurationColumn.objects.create(
+            configuration=config_job_titles,
+            order=4,
+            column_name="state",
+            filter_interface_type='map:nation',
+            filter_interface_display='State',
+            multi_value_expansion=0,
+            is_active=True)
+        orm.ConfigurationColumn.objects.create(
+            configuration=config_job_titles,
+            order=5,
+            column_name="city",
+            filter_interface_type='map:state',
+            filter_interface_display='City',
+            multi_value_expansion=0,
+            is_active=True)
+        orm.ConfigurationColumn.objects.create(
+            configuration=config_job_titles,
+            order=6,
+            column_name="found_on",
+            filter_interface_type='string',
+            filter_interface_display='Found on',
+            multi_value_expansion=0,
+            is_active=True)
+
+        orm.ConfigurationColumn.objects.create(
+            configuration=config_found_on,
+            order=1,
+            column_name="found_on",
+            filter_interface_type='string',
+            filter_interface_display='Found On',
+            multi_value_expansion=0,
+            is_active=True)
+        orm.ConfigurationColumn.objects.create(
+            configuration=config_found_on,
+            order=2,
+            column_name="title",
+            filter_interface_type='string',
+            filter_interface_display='Job Title',
+            multi_value_expansion=0,
+            is_active=True)
+        orm.ConfigurationColumn.objects.create(
+            configuration=config_found_on,
+            order=3,
+            column_name="job_guid",
+            filter_interface_type='string',
+            filter_interface_display='Job Id',
+            multi_value_expansion=0,
+            is_active=True)
+        orm.ConfigurationColumn.objects.create(
+            configuration=config_found_on,
+            order=4,
+            column_name="country",
+            filter_interface_type='map:world',
+            filter_interface_display='Country',
+            multi_value_expansion=0,
+            is_active=True)
+        orm.ConfigurationColumn.objects.create(
+            configuration=config_found_on,
+            order=4,
+            column_name="state",
+            filter_interface_type='map:nation',
+            filter_interface_display='State',
+            multi_value_expansion=0,
+            is_active=True)
+        orm.ConfigurationColumn.objects.create(
+            configuration=config_found_on,
+            order=6,
+            column_name="city",
+            filter_interface_type='map:state',
+            filter_interface_display='City',
+            multi_value_expansion=0,
+            is_active=True)
+
+        orm.ConfigurationColumn.objects.create(
+            configuration=config_job_locations,
+            order=1,
+            column_name="country",
+            filter_interface_type='map:world',
+            filter_interface_display='Country',
+            multi_value_expansion=0,
+            is_active=True)
+        orm.ConfigurationColumn.objects.create(
+            configuration=config_job_locations,
+            order=2,
+            column_name="state",
+            filter_interface_type='map:nation',
+            filter_interface_display='State',
+            multi_value_expansion=0,
+            is_active=True)
+        orm.ConfigurationColumn.objects.create(
+            configuration=config_job_locations,
+            order=3,
+            column_name="city",
+            filter_interface_type='map:state',
+            filter_interface_display='City',
+            multi_value_expansion=0,
+            is_active=True)
+        orm.ConfigurationColumn.objects.create(
+            configuration=config_job_locations,
+            order=4,
+            column_name="found_on",
+            filter_interface_type='string',
+            filter_interface_display='Found On',
+            multi_value_expansion=0,
+            is_active=True)
+        orm.ConfigurationColumn.objects.create(
+            configuration=config_job_locations,
+            order=5,
+            column_name="title",
+            filter_interface_type='string',
+            filter_interface_display='Job Title',
+            multi_value_expansion=0,
+            is_active=True)
+        orm.ConfigurationColumn.objects.create(
+            configuration=config_job_locations,
+            order=6,
+            column_name="job_guid",
+            filter_interface_type='string',
+            filter_interface_display='Job Id',
+            multi_value_expansion=0,
+            is_active=True)
+
+    def backwards(self, orm):
+        "Write your backwards methods here."
+
+        rit_analytics = orm.ReportingType.objects.filter(
+            reporting_type="web-analytics")
+
+        orm.ReportingTypeReportTypes.objects.filter(
+            reporting_type=rit_analytics).delete()
+
+        report_types = orm.ReportType.objects.filter(
+            reportingtype=rit_analytics)
+
+        orm.ReportTypeDataTypes.objects.filter(
+            report_type=report_types).delete()
+
+        config_job_titles = orm.Configuration.objects.filter(name="Job Titles")
+        config_found_on = orm.Configuration.objects.filter(name="Found On")
+        config_job_locations = orm.Configuration.objects.filter(
+            name="Job Locations")
+
+        orm.ReportTypeDataTypes.objects.filter(
+                report_type__in=report_types).delete()
+
+        orm.ConfigurationColumn.objects.filter(
+            configuration__in=config_job_titles).delete()
+        orm.ConfigurationColumn.objects.filter(
+            configuration__in=config_found_on).delete()
+        orm.ConfigurationColumn.objects.filter(
+            configuration__in=config_job_locations).delete()
+
+        report_types.delete()
+        rit_analytics.delete()
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'myjobs.activity': {
+            'Meta': {'object_name': 'Activity'},
+            'app_access': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['myjobs.AppAccess']"}),
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '150'}),
+            'display_name': ('django.db.models.fields.CharField', [], {'max_length': '50', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '50'})
+        },
+        u'myjobs.appaccess': {
+            'Meta': {'object_name': 'AppAccess'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '50'})
+        },
+        u'myjobs.role': {
+            'Meta': {'unique_together': "(('company', 'name'),)", 'object_name': 'Role'},
+            'activities': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['myjobs.Activity']", 'symmetrical': 'False'}),
+            'company': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['seo.Company']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'myjobs.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'deactivate_type': ('django.db.models.fields.CharField', [], {'default': "'none'", 'max_length': '11'}),
+            'email': ('django.db.models.fields.EmailField', [], {'unique': 'True', 'max_length': '255', 'db_index': 'True'}),
+            'failed_login_count': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'gravatar': ('django.db.models.fields.EmailField', [], {'db_index': 'True', 'max_length': '255', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'in_reserve': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_disabled': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_verified': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'last_response': ('django.db.models.fields.DateField', [], {'default': 'datetime.datetime.now', 'blank': 'True'}),
+            'opt_in_employers': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'opt_in_myjobs': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'password_change': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'password_last_modified': ('django.db.models.fields.DateTimeField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'profile_completion': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'roles': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['myjobs.Role']", 'symmetrical': 'False'}),
+            'source': ('django.db.models.fields.CharField', [], {'default': "'https://secure.my.jobs'", 'max_length': '255'}),
+            'timezone': ('django.db.models.fields.CharField', [], {'default': "'America/New_York'", 'max_length': '255'}),
+            'user_guid': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '100', 'db_index': 'True'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"})
+        },
+        u'myreports.column': {
+            'Meta': {'object_name': 'Column'},
+            'column_name': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'table_name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'myreports.configuration': {
+            'Meta': {'object_name': 'Configuration'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'myreports.configurationcolumn': {
+            'Meta': {'object_name': 'ConfigurationColumn'},
+            'alias': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'column_name': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '50'}),
+            'configuration': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['myreports.Configuration']"}),
+            'default_value': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '500', 'blank': 'True'}),
+            'filter_interface_display': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True'}),
+            'filter_interface_type': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True'}),
+            'filter_only': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'has_help': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'multi_value_expansion': ('django.db.models.fields.PositiveSmallIntegerField', [], {}),
+            'order': ('django.db.models.fields.IntegerField', [], {'default': '100'}),
+            'output_format': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '50'})
+        },
+        u'myreports.datatype': {
+            'Meta': {'object_name': 'DataType'},
+            'data_type': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '500'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        u'myreports.dynamicreport': {
+            'Meta': {'object_name': 'DynamicReport'},
+            'created_by': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['myjobs.User']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
+            'created_on': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'filters': ('django.db.models.fields.TextField', [], {'default': "'{}'"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['seo.Company']"}),
+            'report_data': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['myreports.ReportTypeDataTypes']", 'null': 'True'}),
+            'results': ('django.db.models.fields.files.FileField', [], {'max_length': '100'})
+        },
+        u'myreports.presentationtype': {
+            'Meta': {'object_name': 'PresentationType'},
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '500'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'presentation_type': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'myreports.report': {
+            'Meta': {'object_name': 'Report'},
+            'app': ('django.db.models.fields.CharField', [], {'default': "'mypartners'", 'max_length': '50'}),
+            'created_by': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['myjobs.User']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
+            'created_on': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'filters': ('django.db.models.fields.TextField', [], {'default': "'{}'"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'default': "'contactrecord'", 'max_length': '50'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'order_by': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '50', 'blank': 'True'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['seo.Company']"}),
+            'results': ('django.db.models.fields.files.FileField', [], {'max_length': '100'}),
+            'values': ('django.db.models.fields.CharField', [], {'default': "'[]'", 'max_length': '500'})
+        },
+        u'myreports.reportingtype': {
+            'Meta': {'object_name': 'ReportingType'},
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '500'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'report_types': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['myreports.ReportType']", 'through': u"orm['myreports.ReportingTypeReportTypes']", 'symmetrical': 'False'}),
+            'reporting_type': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'myreports.reportingtypereporttypes': {
+            'Meta': {'object_name': 'ReportingTypeReportTypes'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'report_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['myreports.ReportType']"}),
+            'reporting_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['myreports.ReportingType']"})
+        },
+        u'myreports.reportpresentation': {
+            'Meta': {'object_name': 'ReportPresentation'},
+            'display_name': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'presentation_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['myreports.PresentationType']"}),
+            'report_data': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['myreports.ReportTypeDataTypes']"})
+        },
+        u'myreports.reporttype': {
+            'Meta': {'object_name': 'ReportType'},
+            'data_types': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['myreports.DataType']", 'through': u"orm['myreports.ReportTypeDataTypes']", 'symmetrical': 'False'}),
+            'datasource': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '50'}),
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '500'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'report_type': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'myreports.reporttypedatatypes': {
+            'Meta': {'object_name': 'ReportTypeDataTypes'},
+            'configuration': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['myreports.Configuration']", 'null': 'True'}),
+            'data_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['myreports.DataType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'report_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['myreports.ReportType']"})
+        },
+        u'myreports.userreportingtypes': {
+            'Meta': {'object_name': 'UserReportingTypes'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'reporting_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['myreports.ReportingType']"}),
+            'user_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['myreports.UserType']"})
+        },
+        u'myreports.usertype': {
+            'Meta': {'object_name': 'UserType'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'reporting_types': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['myreports.ReportingType']", 'through': u"orm['myreports.UserReportingTypes']", 'symmetrical': 'False'}),
+            'user_type': ('django.db.models.fields.CharField', [], {'max_length': '10'})
+        },
+        u'postajob.package': {
+            'Meta': {'object_name': 'Package'},
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        },
+        u'postajob.sitepackage': {
+            'Meta': {'object_name': 'SitePackage', '_ormbases': [u'postajob.Package']},
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['seo.Company']", 'null': 'True', 'blank': 'True'}),
+            u'package_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['postajob.Package']", 'unique': 'True', 'primary_key': 'True'}),
+            'sites': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['seo.SeoSite']", 'null': 'True', 'symmetrical': 'False'})
+        },
+        u'seo.atssourcecode': {
+            'Meta': {'object_name': 'ATSSourceCode'},
+            'ats_name': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '200'}),
+            'group': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.Group']", 'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '200'}),
+            'value': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '200'})
+        },
+        u'seo.billboardimage': {
+            'Meta': {'object_name': 'BillboardImage'},
+            'copyright_info': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'group': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.Group']", 'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'image_url': ('django.db.models.fields.URLField', [], {'max_length': '200'}),
+            'logo_url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'source_url': ('django.db.models.fields.URLField', [], {'max_length': '200'}),
+            'sponsor_url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '200'})
+        },
+        u'seo.businessunit': {
+            'Meta': {'object_name': 'BusinessUnit'},
+            'associated_jobs': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'date_crawled': ('django.db.models.fields.DateTimeField', [], {}),
+            'date_updated': ('django.db.models.fields.DateTimeField', [], {}),
+            'enable_markdown': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'federal_contractor': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'id': ('django.db.models.fields.IntegerField', [], {'max_length': '10', 'primary_key': 'True'}),
+            'ignore_includeinindex': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'site_packages': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['postajob.SitePackage']", 'null': 'True', 'blank': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '500', 'null': 'True', 'blank': 'True'}),
+            'title_slug': ('django.db.models.fields.SlugField', [], {'max_length': '500', 'null': 'True', 'blank': 'True'})
+        },
+        u'seo.company': {
+            'Meta': {'ordering': "['name']", 'unique_together': "(('name', 'user_created'),)", 'object_name': 'Company'},
+            'app_access': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['myjobs.AppAccess']", 'symmetrical': 'False', 'blank': 'True'}),
+            'canonical_microsite': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'company_slug': ('django.db.models.fields.SlugField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'digital_strategies_customer': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'enhanced': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'job_source_ids': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['seo.BusinessUnit']", 'symmetrical': 'False'}),
+            'linkedin_id': ('django.db.models.fields.CharField', [], {'max_length': '20', 'null': 'True', 'blank': 'True'}),
+            'logo_url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'member': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'og_img': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'password_expiration': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'prm_saved_search_sites': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['seo.SeoSite']", 'null': 'True', 'blank': 'True'}),
+            'site_package': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['postajob.SitePackage']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
+            'user_created': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        u'seo.configuration': {
+            'Meta': {'object_name': 'Configuration'},
+            'backgroundColor': ('django.db.models.fields.CharField', [], {'max_length': '6', 'null': 'True', 'blank': 'True'}),
+            'body': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'browse_city_order': ('django.db.models.fields.IntegerField', [], {'default': '5'}),
+            'browse_city_show': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'browse_city_text': ('django.db.models.fields.CharField', [], {'default': "'City'", 'max_length': '50'}),
+            'browse_company_order': ('django.db.models.fields.IntegerField', [], {'default': '7'}),
+            'browse_company_show': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'browse_company_text': ('django.db.models.fields.CharField', [], {'default': "'Company'", 'max_length': '50'}),
+            'browse_country_order': ('django.db.models.fields.IntegerField', [], {'default': '3'}),
+            'browse_country_show': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'browse_country_text': ('django.db.models.fields.CharField', [], {'default': "'Country'", 'max_length': '50'}),
+            'browse_facet_order': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'browse_facet_order_2': ('django.db.models.fields.IntegerField', [], {'default': '2'}),
+            'browse_facet_order_3': ('django.db.models.fields.IntegerField', [], {'default': '3'}),
+            'browse_facet_order_4': ('django.db.models.fields.IntegerField', [], {'default': '4'}),
+            'browse_facet_show': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'browse_facet_show_2': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'browse_facet_show_3': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'browse_facet_show_4': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'browse_facet_text': ('django.db.models.fields.CharField', [], {'default': "'Job Profiles'", 'max_length': '50'}),
+            'browse_facet_text_2': ('django.db.models.fields.CharField', [], {'default': "'Job Profiles'", 'max_length': '50'}),
+            'browse_facet_text_3': ('django.db.models.fields.CharField', [], {'default': "'Job Profiles'", 'max_length': '50'}),
+            'browse_facet_text_4': ('django.db.models.fields.CharField', [], {'default': "'Job Profiles'", 'max_length': '50'}),
+            'browse_moc_order': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'browse_moc_show': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'browse_moc_text': ('django.db.models.fields.CharField', [], {'default': "'Military Titles'", 'max_length': '50'}),
+            'browse_state_order': ('django.db.models.fields.IntegerField', [], {'default': '4'}),
+            'browse_state_show': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'browse_state_text': ('django.db.models.fields.CharField', [], {'default': "'State'", 'max_length': '50'}),
+            'browse_title_order': ('django.db.models.fields.IntegerField', [], {'default': '6'}),
+            'browse_title_show': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'browse_title_text': ('django.db.models.fields.CharField', [], {'default': "'Title'", 'max_length': '50'}),
+            'company_tag': ('django.db.models.fields.CharField', [], {'default': "'careers'", 'max_length': '50'}),
+            'defaultBlurb': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'defaultBlurbTitle': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'directemployers_link': ('django.db.models.fields.URLField', [], {'default': "'http://directemployers.org'", 'max_length': '200'}),
+            'doc_type': ('django.db.models.fields.CharField', [], {'default': '\'<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">\'', 'max_length': '255'}),
+            'facet_tag': ('django.db.models.fields.CharField', [], {'default': "'new-jobs'", 'max_length': '50'}),
+            'fontColor': ('django.db.models.fields.CharField', [], {'default': "'666666'", 'max_length': '6'}),
+            'footer': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'group': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.Group']", 'null': 'True'}),
+            'header': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'home_page_template': ('django.db.models.fields.CharField', [], {'default': "'home_page/home_page_listing.html'", 'max_length': '200'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'language_code': ('django.db.models.fields.CharField', [], {'default': "'en'", 'max_length': '16'}),
+            'location_tag': ('django.db.models.fields.CharField', [], {'default': "'jobs'", 'max_length': '50'}),
+            'meta': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'moc_helptext': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'moc_label': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'moc_placeholder': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'moc_tag': ('django.db.models.fields.CharField', [], {'default': "'vet-jobs'", 'max_length': '50'}),
+            'num_filter_items_to_show': ('django.db.models.fields.IntegerField', [], {'default': '10'}),
+            'num_job_items_to_show': ('django.db.models.fields.IntegerField', [], {'default': '15'}),
+            'num_subnav_items_to_show': ('django.db.models.fields.IntegerField', [], {'default': '9'}),
+            'percent_featured': ('django.db.models.fields.DecimalField', [], {'default': "'0.5'", 'max_digits': '3', 'decimal_places': '2'}),
+            'primaryColor': ('django.db.models.fields.CharField', [], {'default': "'990000'", 'max_length': '6'}),
+            'publisher': ('django.db.models.fields.CharField', [], {'max_length': '50', 'blank': 'True'}),
+            'revision': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'show_home_microsite_carousel': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'show_home_social_footer': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'show_saved_search_widget': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'show_social_footer': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'status': ('django.db.models.fields.IntegerField', [], {'default': '1', 'null': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'template_version': ('django.db.models.fields.CharField', [], {'default': "'v1'", 'max_length': '5'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True'}),
+            'title_tag': ('django.db.models.fields.CharField', [], {'default': "'jobs-in'", 'max_length': '50'}),
+            'use_secure_blocks': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'view_all_jobs_detail': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'what_helptext': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'what_label': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'what_placeholder': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'where_helptext': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'where_label': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'where_placeholder': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'wide_footer': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'wide_header': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'})
+        },
+        u'seo.customfacet': {
+            'Meta': {'object_name': 'CustomFacet'},
+            'always_show': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'blurb': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'business_units': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['seo.BusinessUnit']", 'null': 'True', 'blank': 'True'}),
+            'city': ('django.db.models.fields.CharField', [], {'max_length': '800', 'null': 'True', 'blank': 'True'}),
+            'company': ('django.db.models.fields.CharField', [], {'max_length': '800', 'null': 'True', 'blank': 'True'}),
+            'country': ('django.db.models.fields.CharField', [], {'max_length': '800', 'null': 'True', 'blank': 'True'}),
+            'date_created': ('django.db.models.fields.DateField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'group': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.Group']", 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name_slug': ('django.db.models.fields.SlugField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'onet': ('django.db.models.fields.CharField', [], {'max_length': '10', 'null': 'True', 'blank': 'True'}),
+            'querystring': ('django.db.models.fields.CharField', [], {'max_length': '2000', 'null': 'True', 'blank': 'True'}),
+            'saved_querystring': ('django.db.models.fields.CharField', [], {'max_length': '10000', 'blank': 'True'}),
+            'show_blurb': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'show_production': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'state': ('django.db.models.fields.CharField', [], {'max_length': '800', 'null': 'True', 'blank': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '800', 'null': 'True', 'blank': 'True'}),
+            'url_slab': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'})
+        },
+        u'seo.googleanalytics': {
+            'Meta': {'object_name': 'GoogleAnalytics'},
+            'group': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.Group']", 'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'web_property_id': ('django.db.models.fields.CharField', [], {'max_length': '20'})
+        },
+        u'seo.googleanalyticscampaign': {
+            'Meta': {'object_name': 'GoogleAnalyticsCampaign'},
+            'campaign_content': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '200'}),
+            'campaign_medium': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '200'}),
+            'campaign_name': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '200'}),
+            'campaign_source': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '200'}),
+            'campaign_term': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '200'}),
+            'group': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.Group']", 'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '200'})
+        },
+        u'seo.seosite': {
+            'Meta': {'ordering': "(u'domain',)", 'object_name': 'SeoSite', '_ormbases': [u'sites.Site']},
+            'ats_source_codes': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['seo.ATSSourceCode']", 'null': 'True', 'blank': 'True'}),
+            'billboard_images': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['seo.BillboardImage']", 'null': 'True', 'blank': 'True'}),
+            'business_units': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['seo.BusinessUnit']", 'null': 'True', 'blank': 'True'}),
+            'canonical_company': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'canonical_company_for'", 'null': 'True', 'on_delete': 'models.SET_NULL', 'to': u"orm['seo.Company']"}),
+            'configurations': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['seo.Configuration']", 'symmetrical': 'False', 'blank': 'True'}),
+            'email_domain': ('django.db.models.fields.CharField', [], {'default': "'my.jobs'", 'max_length': '255'}),
+            'facets': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['seo.CustomFacet']", 'null': 'True', 'through': u"orm['seo.SeoSiteFacet']", 'blank': 'True'}),
+            'featured_companies': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['seo.Company']", 'null': 'True', 'blank': 'True'}),
+            'google_analytics': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['seo.GoogleAnalytics']", 'null': 'True', 'blank': 'True'}),
+            'google_analytics_campaigns': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['seo.GoogleAnalyticsCampaign']", 'null': 'True', 'blank': 'True'}),
+            'group': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.Group']", 'null': 'True'}),
+            'microsite_carousel': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['social_links.MicrositeCarousel']", 'null': 'True', 'on_delete': 'models.SET_NULL', 'blank': 'True'}),
+            'parent_site': ('seo.models.NonChainedForeignKey', [], {'blank': 'True', 'related_name': "'child_sites'", 'null': 'True', 'on_delete': 'models.SET_NULL', 'to': u"orm['seo.SeoSite']"}),
+            'postajob_filter_type': ('django.db.models.fields.CharField', [], {'default': "'this site only'", 'max_length': '255'}),
+            'site_description': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '200', 'blank': 'True'}),
+            'site_heading': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '200', 'blank': 'True'}),
+            'site_package': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['postajob.SitePackage']", 'null': 'True', 'on_delete': 'models.SET_NULL', 'blank': 'True'}),
+            u'site_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['sites.Site']", 'unique': 'True', 'primary_key': 'True'}),
+            'site_tags': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['seo.SiteTag']", 'null': 'True', 'blank': 'True'}),
+            'site_title': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '200', 'blank': 'True'}),
+            'special_commitments': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['seo.SpecialCommitment']", 'null': 'True', 'blank': 'True'}),
+            'view_sources': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['seo.ViewSource']", 'null': 'True', 'blank': 'True'})
+        },
+        u'seo.seositefacet': {
+            'Meta': {'object_name': 'SeoSiteFacet'},
+            'boolean_operation': ('django.db.models.fields.CharField', [], {'default': "'or'", 'max_length': '3', 'db_index': 'True'}),
+            'customfacet': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['seo.CustomFacet']"}),
+            'facet_group': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'facet_type': ('django.db.models.fields.CharField', [], {'default': "'STD'", 'max_length': '4', 'db_index': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'seosite': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['seo.SeoSite']"})
+        },
+        u'seo.sitetag': {
+            'Meta': {'object_name': 'SiteTag'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'site_tag': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '100'}),
+            'tag_navigation': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        u'seo.specialcommitment': {
+            'Meta': {'object_name': 'SpecialCommitment'},
+            'commit': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200'})
+        },
+        u'seo.viewsource': {
+            'Meta': {'object_name': 'ViewSource'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '200'}),
+            'view_source': ('django.db.models.fields.IntegerField', [], {'default': "''", 'max_length': '20'})
+        },
+        u'sites.site': {
+            'Meta': {'ordering': "(u'domain',)", 'object_name': 'Site', 'db_table': "u'django_site'"},
+            'domain': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'social_links.micrositecarousel': {
+            'Meta': {'object_name': 'MicrositeCarousel'},
+            'carousel_title': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'display_rows': ('django.db.models.fields.IntegerField', [], {}),
+            'group': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.Group']", 'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'include_all_sites': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'link_sites': ('django.db.models.fields.related.ManyToManyField', [], {'blank': 'True', 'related_name': "'linked_carousel'", 'null': 'True', 'symmetrical': 'False', 'to': u"orm['seo.SeoSite']"})
+        }
+    }
+
+    complete_apps = ['myreports']
+    symmetrical = True


### PR DESCRIPTION
This creates a starting point api for analytics.

## Review

* There are unit tests for the happy path
* I use `ApiValidator` for handling errors in a consistent way. It's also consistent with reporting.
* There are unit tests for the error cases.
* I use `value` to represent keys and ids that we want returned to us. I use `display` to represent things shown to the user. (We should convert the other analytics api call to follow that.)
* I'm still _not_ dealing with the fact that this api assumes that we are interested in analytics. We can add a parameter to `api/available-reports` when we are ready.

## Test

* If you have a working postman interface you can hit the api:
  * `https://secure.my.jobs/analytics/api/available-reports`
  * `https://secure.my.jobs/analytics/api/report-info?analytics_report_id=job-locations`
