### PR TITLE
[PD-2763] Allow redirects to send logfiles to kinesis/mongo.

### DIFF
--- a/analytics_logpipe.py
+++ b/analytics_logpipe.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python2
+import sys
+import json
+import boto3
+import time
+from botocore.exceptions import ClientError
+
+import secrets
+
+
+def process_lines(kinesis, lines):
+    """Read log lines and send them to AWS Kinesis.
+
+    kinesis: AWS kinesis API client
+    lines: iterable over log lines.
+
+    Runs string unescaping and parses line to get an ip for the partition key.
+
+    Also converts some string values to ints.
+    """
+    for line in lines:
+        # Strip of the string escaping.
+        data = line.decode('string_escape')
+
+        # Parse the json or give up.
+        parsed = None
+        try:
+            parsed = json.loads(data)
+        except ValueError:
+            continue
+
+        # Give up if we are looking at something wierd. i.e. "-"
+        if not isinstance(parsed, dict):
+            continue
+
+        partition_key = parsed.get('ip')
+
+        # Convert some strings to ints, etc.
+        massaged = massage_log_line(parsed)
+
+        data = json.dumps(massaged)
+
+        needs_resend = u'ProvisionedThroughputExceededException'
+        for attempts in xrange(1, 8):
+            try:
+                result = kinesis.put_record(
+                    StreamName=secrets.LOG_TO_STREAM,
+                    Data=data,
+                    PartitionKey=partition_key)
+                error_code = result.get('ErrorCode')
+                if error_code is None:
+                    break
+                elif error_code == needs_resend:
+                    print >>sys.stderr, "Attempt: %d" % attempts, repr(result)
+                    time.sleep(2 ** attempts)
+                    continue
+                else:
+                    print >>sys.stderr, repr(result)
+            except ClientError as e:
+                print >>sys.stderr, e.message
+
+
+def massage_log_line(json_line):
+    """Convert some values from strings to more meaningful types."""
+    result = dict(json_line)
+    for key, value in json_line.items():
+        if isinstance(value, basestring) and value.isdigit():
+            int_val = int(value)
+            if isinstance(int_val, long):
+                # We have an undefined number of fields that can
+                # potentially contain guids. It is possible for
+                # a guid to be comprised entirely of digits. Don't
+                # insert a guid as a number - Mongo can only take
+                # 8-byte ints.
+                continue
+
+            result[key] = int_val
+    return result
+
+
+if __name__ == '__main__':
+    kinesis = boto3.client(
+        'kinesis',
+        region_name=secrets.AWS_DEFAULT_REGION,
+        aws_access_key_id=secrets.AWS_ACCESS_KEY_ID,
+        aws_secret_access_key=secrets.AWS_SECRET_KEY)
+
+    process_lines(kinesis, sys.stdin)

--- a/requirements.txt
+++ b/requirements.txt
@@ -63,3 +63,4 @@ html5lib==0.999 #Put in place because as of 2016-07-18 bleach depends on html5li
 python-dateutil==2.4.2
 freezegun==0.3.7
 git+git://github.com/DirectEmployers/pymongo-env.git@1f6a6f218ca16a516cceed4f213ab605aaa1d245
+boto3==1.4.0


### PR DESCRIPTION
Adds the file from MyJobs-Analytics that allows shipping Apache log files to kinesis/mongo. 

There were 4 real options for how I could have accomplished this:
1. Add the file to pymongo-env. It doesn't make sense there, but it would've been a convenient place for it. This would've caused issues with the analytics server, given the fact that the Apache config is pointing to a very specific location for this file that would change if installed via a package. Since that project auto-deploys I would've been jumping through hoops to get that deployment done without taking anything down, and I don't really didn't want to find out the penalties of taking down that server. 
2. Create a new repository. See 1.
3. Add this to the deployment repository. I actually kind of liked that idea, because then we could just arbitrarily deploy it to any server we wanted to do log file capture from. However, doing it this way would've taken some magic with editing/updating Apache configs and set a weird precedent for what goes in the deployment repository.
4. Copy the file.

I obviously went with 4. Future me will regret this decision, but current me is completely fine with the fact that this doesn't appear to be a file that will change frequently. I'm assuming that since it's been running fine on the analytics servers to this point, it's also battle-tested. 