### PR TITLE
[PD-2782] Prevent WildcardMiddleware from redirecting when using domain switching

### DIFF
--- a/middleware.py
+++ b/middleware.py
@@ -137,8 +137,16 @@ class MultiHostMiddleware:
 
         """
         host = None
+
+        # Allow for specifying a domain to use as the current site rather
+        # than using the site that matches the current domain.
+        # Intended use is for testing specific Sites/Configurations
+        # in QC/Staging.
         if request.user.is_authenticated() and request.user.is_staff:
             host = request.REQUEST.get('domain')
+            # If a user is domain switching, assume they really do know
+            # where they want to go.
+            setattr(settings, 'WILDCARD_REDIRECT', False)
 
         if host is None:
             host = request.get_host()


### PR DESCRIPTION
This is one of those "that never should have worked" situations. Best guess is it never did work, and it's just that no one noticed until now. 

In QC we explicitly bypass the WildcardMiddleware, which is why it works there: https://github.com/DirectEmployers/MyJobs/blob/ba78d748fce0f82974cbf6979aad9d1e6c8eb6d0/deploy/settings_dseo_qc.py#L68

It doesn't work locally using the suggested setup, but I believe no one ran into it when it was written because we were likely using it via http://127.0.0.1:8000?domain=micrositeyouwanttoaccess.jobs, and WildcardMiddleware ignores requests going to an IP address directly: https://github.com/DirectEmployers/MyJobs/blob/ba78d748fce0f82974cbf6979aad9d1e6c8eb6d0/wildcard/middleware.py#L46-L48 