### PR TITLE
[PD-2781], copied the functions in utils.181-20.js and pasted it in topbar_v2-183-9.js 

### DIFF
--- a/gulp/src/v2/seo-base-scripts.js
+++ b/gulp/src/v2/seo-base-scripts.js
@@ -3,7 +3,6 @@
 /**
  * Legacy es5.1 functions used in seo_base_bootstrap3.html template,
  * relocated to the gulp directory to utilize es6, webpack, et al, during Sprint 24.
- * TODO: Put utils.js in here as well, and make it es6-ish.
  **/
 
 $(document).ready(function() {

--- a/static/topbar_v2-183-9.js
+++ b/static/topbar_v2-183-9.js
@@ -1,3 +1,59 @@
+var utils = {};
+var timer;
+
+/**
+ * Returns the value of the cookie. Returns null if that cookie is not found.
+ * cookie: The name of the cookie to retrieve.
+ **/
+utils.readCookie = function readCookie(cookie) {
+  var nameEQ = cookie + '=';
+  var ca = document.cookie.split(';');
+  var i;
+  var c;
+  for (i = 0; i < ca.length; i++) {
+    c = ca[i];
+    while (c.charAt(0) === ' ') {
+      c = c.substring(1, c.length);
+    }
+    if (c.indexOf(nameEQ) === 0) {
+      return c.substring(nameEQ.length, c.length);
+    }
+  }
+  return null;
+};
+
+/**
+ * Creates a new timer which redirects the user if the `loggedout` cookie is
+ * set.
+ *
+ * url: The url to redirect to.
+ **/
+utils.logoutTimer = function readCookie(url) {
+  if (!timer) {
+    timer = window.setInterval(function redirect() {
+      // if we are logged out and not already on the home page
+      if (utils.readCookie('loggedout') && window.location.pathname !== url) {
+        window.location.assign(url);
+      }
+    }, 500);
+  } else {
+    window.clearInterval(timer);
+  }
+};
+
+utils.setCookie = function(name, value, days) {
+  var expires;
+  if (days) {
+    var date = new Date();
+    date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000));
+    expires = '; expires=' + date.toGMTString();
+  } else {
+    expires = '';
+  }
+
+  document.cookie = name + '=' + value + expires + '; path=/';
+};
+
 var readCookie = utils.readCookie;
 
 $(window).ready(function () {

--- a/templates/includes/topbar_v2.html
+++ b/templates/includes/topbar_v2.html
@@ -116,4 +116,4 @@
     </script>
 {% endif %}
 
-<script defer src="{% static "topbar_v2-181-27.js" %}"></script>
+<script defer src="{% static "topbar_v2-183-9.js" %}"></script>

--- a/templates/seo_base_bootstrap3.html
+++ b/templates/seo_base_bootstrap3.html
@@ -168,7 +168,6 @@
   {% endcompress %}
 {% endif %}
 
-<script src="{% static "utils.181-20.js" %}"></script>
 <script src="{% static "secure-blocks/secure-block.181-20.js" %}"></script>
 <script src="{% static "pager.164-21.js" %}"></script>
 


### PR DESCRIPTION
Purpose:  I would like to prevent the possibility of adversely affecting the v1 templates with any changes to the v2 templates that might share static files with the former.  To that end, I copied the functions in the utils.181-20.js file and pasted them in the topbar_v2-183-9.js file because the topbar_v2 js file is the only file that needs utils.181-20.js, as far as the v2 base template is concerned.  I also removed the call to utils.181.20.js in the v2 seo_base_bootstrap3.html template, because it's no longer necessary. 

To test:  

1.  In Django Admin, please switch to v2 template and select home_page_listing_bootstrap3.html in the "home page template" dropdown.

2. Please test the functionality of topbar in desktop and mobile views, for example: log in/out, hyperlinks, companies, etc.