### PR TITLE
Upgrade to version of pymongo-env that has testing mixin.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -62,5 +62,5 @@ pymongo==3.2.2
 html5lib==0.999 #Put in place because as of 2016-07-18 bleach depends on html5lib>=0.999 and the latest version of html5lib is screwed up.
 python-dateutil==2.4.2
 freezegun==0.3.7
-git+git://github.com/DirectEmployers/pymongo-env.git@1f6a6f218ca16a516cceed4f213ab605aaa1d245
+git+git://github.com/DirectEmployers/pymongo-env.git@7d5d4d4f104b800ed3ce864d3cc01bfa39932248
 boto3==1.4.0


### PR DESCRIPTION
This specific version of pymongo-env has a testing mixin that forces switching to the mongo testing servers: https://github.com/DirectEmployers/pymongo-env/pull/2 