### PR TITLE
[PD-2789] Copied secure blocks JS and pasted them in seo-base-scripts

### DIFF
--- a/gulp/src/v2/seo-base-scripts.js
+++ b/gulp/src/v2/seo-base-scripts.js
@@ -377,3 +377,98 @@ function showHideHeaderScroll() {
 }
 
 showHideHeaderScroll();
+
+// Secure Block Begins
+let saved_dashboard_url = '';
+
+function secure_block(secure_block_url, request) {
+  // need to explicitly marshal the result data into this deferred
+  // because we are on old jQuery.
+  let result = $.Deferred();
+  $.ajax({
+    type: "OPTIONS",
+    crossDomain: true,
+  }).done(function(data, textStatus, xhr) {
+    xhr_secure_block(secure_block_url, request).
+        done(result.resolve).
+        fail(result.reject);
+  }).fail(function(xhr, textStatus, error) {
+    jsonp_secure_block(secure_block_url, request).
+        done(result.resolve).
+        fail(result.reject);
+  });
+  return result.promise();
+}
+
+function xhr_secure_block(secure_block_url, data) {
+  return $.ajax({
+    url: secure_block_url,
+    type: "POST",
+    headers: {'X-Requested-With': 'XMLHttpRequest'},
+    data: JSON.stringify({'blocks': data}),
+    contentType: "application/json",
+    xhrFields: {
+      withCredentials: true
+    },
+  });
+}
+
+if (window) {
+  window.xhr_secure_block = xhr_secure_block;
+}
+
+function jsonp_secure_block(secure_block_url, data) {
+  let json = JSON.stringify(data);
+  return $.ajax({
+    url: secure_block_url,
+    type: "GET",
+    dataType: "jsonp",
+    data: {'blocks': json},
+  });
+}
+
+if (window) {
+  window.jsonp_secure_block = jsonp_secure_block;
+}
+
+function populate_secure_blocks(request, callback) {
+  if (!$.isEmptyObject(request)) {
+    secure_block(saved_dashboard_url, request).fail(function(xhr, text, error) {
+        console.error("dashboard fail: ", xhr, text, error);
+    }).done(function(data, text, xhr) {
+        $.each(data, function(key, value) {
+        $("[data-secure_block_id=" + key + "]").html(value);
+        });
+        if (typeof callback === "function") {
+          callback();
+        }
+    });
+  }
+}
+
+function load_secure_blocks(dashboard_url) {
+  // load secure blocks for all divs containing the proper data tag
+  saved_dashboard_url = dashboard_url;
+  let request = {};
+  $("*[data-secure_block_id]").each(function(i, block) {
+    let element_id = $(block).data('secure_block_id');
+    request[element_id] = $(block).data();
+  });
+  populate_secure_blocks(request);
+}
+
+if (window) {
+  window.load_secure_blocks = load_secure_blocks;
+}
+
+function reload_secure_block(block_id, callback) {
+  // reload an individual secure block that may have changed state
+  // callback is an optional argument of a function that should be called
+  // upon completion of the reload
+  let request = {};
+  let block = $("[data-secure_block_id=" + block_id + "]");
+  if (block) {
+    request[block_id] = block.data();
+    populate_secure_blocks(request, callback);
+  }
+}

--- a/templates/seo_base_bootstrap3.html
+++ b/templates/seo_base_bootstrap3.html
@@ -168,7 +168,6 @@
   {% endcompress %}
 {% endif %}
 
-<script src="{% static "secure-blocks/secure-block.181-20.js" %}"></script>
 <script src="{% static "pager.164-21.js" %}"></script>
 
 {% if site_config.use_secure_blocks %}


### PR DESCRIPTION
Purpose:  In my continuing effort to isolate the v1 and v2 templates, I copied the JavaScript functions in secure-block.181-20.js and pasted them in seo-base-scripts.js, and removed the called to secure-block.181-20.js in the seo_base_bootstrap3.html template.  

To Test:

1.  In Django Admin, please switch to v2 template and select home_page_listing_bootstrap3.html in the "home page template" dropdown, please click on the "Use secure blocks" checkbox and save.

2. Please go to www.my.jobs, use the browser's web dev tool to ensure there are no errors in the console because the base template checks for secure block immediately upon page load.  If things goes wrong, you will see an error like "load_secure_blocks is undefined".

3. With the "Use secure blocks" checkbox still checked in Django Admin, please save a job search, if things goes correctly, you will see this:
![secure_block_no_styles](https://cloud.githubusercontent.com/assets/5124153/21114638/b807360e-c07b-11e6-91ec-6699d6a680b2.png)


It's un-styled for now, the styling will be in a different PR.

4.  Please also check for other aspects of secure blocks that I'm not aware of.