### PR TITLE
[PD-2797] removed pager.164-21.js from seo_base_bootstrap3.html template

### DIFF
--- a/templates/seo_base_bootstrap3.html
+++ b/templates/seo_base_bootstrap3.html
@@ -168,8 +168,6 @@
   {% endcompress %}
 {% endif %}
 
-<script src="{% static "pager.164-21.js" %}"></script>
-
 {% if site_config.use_secure_blocks %}
     <script>
       var pager_num_items = {{ site_config.num_subnav_items_to_show }};


### PR DESCRIPTION
Purpose:  Remove unused pager.164-21.js file call from seo_base_bootstrap3.html template to decrease template load time.  If we need a carousel in the future for v2, we can refactor the current pager file into a separate file for v2.

To test: 

1.  In Django Admin, please switch to v2 template and select home_page_listing_bootstrap3.html in the "home page template" dropdown.

2.  Please open browser's dev tool > Network tab and **ensure** (there goes that word again), that the pager.164-21.js file is not in the call stack.  There should be no UI changes.