### PR TITLE
[PD- 2797] remove pager.164-21.js call from seo_base_bootstrap3 template

### DIFF
--- a/gulp/src/v2/seo-base-scripts.js
+++ b/gulp/src/v2/seo-base-scripts.js
@@ -2,7 +2,11 @@
 /* eslint-disable */
 /**
  * Legacy es5.1 functions used in seo_base_bootstrap3.html template,
- * relocated to the gulp directory to utilize es6, webpack, et al, during Sprint 24.
+ * relocated to the gulp directory to utilize es6, webpack, et al, during Sprint 24-2016.
+ * ESLint stills complains about coding styles, however, for certain
+ * variable/property names, we still need the underscore casing to work with python codes.
+ * TODO: Refactor 'pager' codes to be less verbose.
+ * TODO: Convert function expressions to arrow functions where appropriate.
  **/
 
 $(document).ready(function() {
@@ -10,14 +14,13 @@ $(document).ready(function() {
   if (typeof site_name !== 'undefined' && !$('*[data-widget_type=tools]').length) {
     getToolbar(site_name);
   }
-
   // Autocomplete functionality for the job,title,keyword input box.
   $('.micrositeTitleField').autocomplete({
-    source: function(request, response) {
+    source: function (request, response) {
       $.ajax({
         url: '/ajax/ac/?lookup=title&term=' + request.term,
         dataType: 'jsonp',
-        success: function(data) {
+        success: function (data) {
           response($.map(data, function(item) {
             return {
               label: item.title,
@@ -31,20 +34,19 @@ $(document).ready(function() {
       $('.ui-autocomplete li.ui-menu-item:odd').addClass('ui-menu-item-alternate');
       $('.ui-autocomplete li.ui-menu-item a').removeClass('ui-corner-all');
     },
-    select: function(event, ui) {
+    select: function (event, ui) {
       $('.micrositeTitleField').val('"' + ui.item.value + '"');
       return false;
     },
     minLength: 2,
   });
-
-    // Autocomplete functionality for the city,state,country input box.
+  // Autocomplete functionality for the city,state,country input box.
   $('.micrositeLocationField').autocomplete({
     source: function(request, response) {
       $.ajax({
         url: '/ajax/ac/?lookup=location&term=' + request.term,
         dataType: 'jsonp',
-        success: function(data) {
+        success: function (data) {
           response($.map(data, function(item) {
             return {
               label: item.location + ' - (' + item.jobcount + ')',
@@ -59,14 +61,12 @@ $(document).ready(function() {
     },
     minLength: 2,
   });
-
   // Add syntax highlighting to autocomplete results.
   $.ui.autocomplete.prototype._renderItem = function(ul, item) {
     /**
      Inputs:
      :ul:    the autocomplete object to modify
      :item:  the individual item to modify
-
      Returns:
      Modified item
      **/
@@ -76,7 +76,6 @@ $(document).ready(function() {
     } else {
       term = this.term.split(' ').join('|');
     }
-
     const re = new RegExp('(' + term + ')', 'gi');
     const t = item.label.replace(re, '<strong class="ac-highlight">$1</strong>');
     return $('<li></li>')
@@ -84,13 +83,11 @@ $(document).ready(function() {
       .append('<a>' + t + '</a>')
       .appendTo(ul);
   };
-
   // Size the width of the drop down list to match width of input, always, in any size, without CSS
   $.ui.autocomplete.prototype._resizeMenu = function() {
     const ul = this.menu.element;
     ul.outerWidth(this.element.outerWidth());
   };
-
   // Submit the search form if location AND title fields have a value in them (and MOC if applicable).
   $('#standardSearch input[type=text]').bind('autocompleteselect', function(event, ul) {
     /**
@@ -109,15 +106,14 @@ $(document).ready(function() {
       }
     }
   });
-
   // Add autocomplete functionality to the MOC/MOS search field.
   $('.micrositeMOCField').autocomplete({
-    source: function(request, response) {
+    source: function (request, response) {
       $.ajax({
         url: '/ajax/mac/?lookup=moc&term=' + request.term,
         dataType: 'jsonp',
-        success: function(data) {
-          response($.map(data, function(item) {
+        success: function (data) {
+          response($.map(data, function (item) {
             return {
               label: item.label,
               value: item.value,
@@ -135,14 +131,93 @@ $(document).ready(function() {
     },
     minLength: 2,
   });
-
   // Clear moc_id value if moc is changed
   $('#moc').change(function() {
     $('#moc_id').val('');
   });
-
   // Save Search Functionality
   get_default_widget_html(false);
+  // 'Pager' logic for the 'Show More' && 'Show Less' logic begins here
+  const pager = new Pager();
+  const total_clicks = parseInt(window.location.hash.slice(1, 10));
+  if (!isNaN(total_clicks)) {
+    // Only set hash if one already existed.
+    window.location.hash = '';
+  }
+  $(document).on('click', 'a.direct_optionsMore', function(e) {
+    const parent = $(this).parent();
+    const num_items = parent.attr('data-num-items');
+    return pager.showMoreHandler(e, num_items, parent);
+  });
+  $('#button_moreJobs').click(function(e) {
+    e.preventDefault();
+    const parent = $(this).parent();
+    const num_items = parseInt(parent.attr('data-num-items'));
+    const offset = parseInt(parent.attr('offset'));
+    const path = window.location.pathname;
+    const query = window.location.search;
+    const ajax_url = path + 'ajax/joblisting/' + query;
+    const hiddenFeaturedList = $('#direct_listingDiv .featured_jobListing.direct_hiddenOption .direct_joblisting');
+    const hiddenDefaultList = $('#direct_listingDiv .default_jobListing.direct_hiddenOption .direct_joblisting');
+    let focus_item;
+    let firstItem;
+    if (hiddenFeaturedList.length > 0) {
+      firstItem = $(hiddenFeaturedList)[0];
+    } else {
+      firstItem = $(hiddenDefaultList)[0];
+    }
+    focus_item = $(firstItem).find('a');
+    focus_item.focus();
+    $('#direct_listingDiv .direct_hiddenOption').removeClass('direct_hiddenOption');
+    $.ajax({
+      url: ajax_url,
+      data: {'num_items': num_items, 'offset': offset},
+      success: function(data) {
+        $('#direct_listingDiv ul:last').after(data);
+        parent.attr('offset', (offset + num_items).toString());
+        let num_clicks = parseInt(window.location.hash.slice(1, 10));
+        if (isNaN(num_clicks) && isNaN(total_clicks)) {
+          window.location.hash = '1';
+        } else {
+          if (isNaN(num_clicks)) {
+            num_clicks = 0;
+          }
+          window.location.hash = (++num_clicks).toString();
+          if (!isNaN(total_clicks) && num_clicks < total_clicks) {
+            $('#button_moreJobs').click();
+          }
+        }
+      },
+    });
+  });
+  if (!isNaN(total_clicks)) {
+    $('#button_moreJobs').trigger('click');
+  }
+  $('a.direct_optionsLess').click(function(e) {
+    const parent = $(this).parent();
+    const num_items = parent.attr('data-num-items');
+    return pager.showLessHandler(e, num_items, parent);
+  });
+  $('.direct_offsiteContainer').hover(function() {
+    $(this).children('.direct_offsiteHoverDiv').show();
+  }, function() {
+    $(this).children('.direct_offsiteHoverDiv').hide();
+  });
+  $('div.direct_offsiteHoverDiv').each(function() {
+    $(this).attr('style', 'margin-top: -' + ($(this).height() + 2) + 'px;');
+  });
+  $('.direct_deBadgeLink').click(function() {
+    goalClick('/G/de-click', this.href);
+    return false;
+  });
+  $('.direct_companyLink').click(function() {
+    goalClick('/G/career-site-click', this.href);
+    return false;
+  });
+  $('.direct_socialLink').click(function() {
+    goalClick('/G/social-media-click', this.href);
+    return false;
+  });
 });
 
 function getToolbar(site_name) {
@@ -175,13 +250,11 @@ const SS_URL = encodeURIComponent(window.location.href);
 
 let most_recent_html = '';
 
-
 function handle_error() {
   // Fills with the most recent text and then overwrites applicable parts
   // with the error message. Uses the most recent text to ensure formatting
   // and variables supplied by myjobs are persistent, so the experience
   // for logged in users continues to be the same.
-
   fill(most_recent_html);
   $('.saved-search-form').prepend('<em class="warning">Something went wrong!</em>');
   $('.saved-search-form > form > b').html('<p>Your search could not successfully be created.</p>');
@@ -209,7 +282,6 @@ function reload_default_widget(data) {
 
 function get_default_widget_html(success) {
   let ajax_url;
-
   if (success) {
     ajax_url = BASE_URL + '/saved-search/widget/?v2=1&callback=fill&success=' + user_email + '&url=' + SS_URL;
   } else {
@@ -234,7 +306,6 @@ function save_search() {
   // If there is any hint that there isn't a well-defined user email
   // provided, attempts to get a user from the input and create a new user.
   // Otherwise, uses the currently provided user to create a saved search.
-
   if (user_email !== 'None' && user_email !== 'undefined' && user_email) {
     $('.saved-search-form').html('<em class="saved-search-widget-loading">Saving this search</em>');
     create_saved_search();
@@ -338,11 +409,9 @@ function showHideHeaderScroll() {
   const delta = 5;
   const navbarHeight = $('nav.main-nav-topbar').outerHeight();
   const viewPort = $(window).width();
-
   // Checking to make sure a scroll has occured
   function hasScrolled() {
     const scrollTop = $(window).scrollTop();
-
     // Make sure they scroll more than delta
     if (Math.abs(lastScrollTop - scrollTop) <= delta) {
       return;
@@ -357,16 +426,13 @@ function showHideHeaderScroll() {
         $('nav.main-nav-topbar').removeClass('nav-up').addClass('nav-down');
       }
     }
-
     lastScrollTop = scrollTop;
   }
-
-    // Checking to see if it's a mobile device or if the screensize is in mobile view
-  if ( /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent) || viewPort < 992 ) {
+  // Checking to see if it's a mobile device or if the screensize is in mobile view
+  if (/Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent) || viewPort < 992) {
     $(window).scroll(() => {
       didScroll = true;
     });
-
     setInterval(() => {
       if (didScroll) {
         hasScrolled();
@@ -378,24 +444,20 @@ function showHideHeaderScroll() {
 
 showHideHeaderScroll();
 
-// Secure Block Begins
+// Secure Block Begins.  Secure Block is on hold when this comment was written,
 let saved_dashboard_url = '';
 
 function secure_block(secure_block_url, request) {
   // need to explicitly marshal the result data into this deferred
   // because we are on old jQuery.
-  let result = $.Deferred();
+  const result = $.Deferred();
   $.ajax({
-    type: "OPTIONS",
+    type: 'OPTIONS',
     crossDomain: true,
   }).done(function(data, textStatus, xhr) {
-    xhr_secure_block(secure_block_url, request).
-        done(result.resolve).
-        fail(result.reject);
+    xhr_secure_block(secure_block_url, request).done(result.resolve).fail(result.reject);
   }).fail(function(xhr, textStatus, error) {
-    jsonp_secure_block(secure_block_url, request).
-        done(result.resolve).
-        fail(result.reject);
+    jsonp_secure_block(secure_block_url, request).done(result.resolve).fail(result.reject);
   });
   return result.promise();
 }
@@ -403,12 +465,12 @@ function secure_block(secure_block_url, request) {
 function xhr_secure_block(secure_block_url, data) {
   return $.ajax({
     url: secure_block_url,
-    type: "POST",
+    type: 'POST',
     headers: {'X-Requested-With': 'XMLHttpRequest'},
     data: JSON.stringify({'blocks': data}),
-    contentType: "application/json",
+    contentType: 'application/json',
     xhrFields: {
-      withCredentials: true
+      withCredentials: true,
     },
   });
 }
@@ -418,11 +480,11 @@ if (window) {
 }
 
 function jsonp_secure_block(secure_block_url, data) {
-  let json = JSON.stringify(data);
+  const json = JSON.stringify(data);
   return $.ajax({
     url: secure_block_url,
-    type: "GET",
-    dataType: "jsonp",
+    type: 'GET',
+    dataType: 'jsonp',
     data: {'blocks': json},
   });
 }
@@ -434,14 +496,14 @@ if (window) {
 function populate_secure_blocks(request, callback) {
   if (!$.isEmptyObject(request)) {
     secure_block(saved_dashboard_url, request).fail(function(xhr, text, error) {
-        console.error("dashboard fail: ", xhr, text, error);
-    }).done(function(data, text, xhr) {
-        $.each(data, function(key, value) {
-        $("[data-secure_block_id=" + key + "]").html(value);
-        });
-        if (typeof callback === "function") {
-          callback();
-        }
+      console.error('dashboard fail: ', xhr, text, error);
+    }).done(function (data, text, xhr) {
+      $.each(data, function (key, value) {
+        $('[data-secure_block_id=' + key + ']').html(value);
+      });
+      if (typeof callback === 'function') {
+        callback();
+      }
     });
   }
 }
@@ -449,9 +511,9 @@ function populate_secure_blocks(request, callback) {
 function load_secure_blocks(dashboard_url) {
   // load secure blocks for all divs containing the proper data tag
   saved_dashboard_url = dashboard_url;
-  let request = {};
-  $("*[data-secure_block_id]").each(function(i, block) {
-    let element_id = $(block).data('secure_block_id');
+  const request = {};
+  $('*[data-secure_block_id]').each(function(i, block) {
+    const element_id = $(block).data('secure_block_id');
     request[element_id] = $(block).data();
   });
   populate_secure_blocks(request);
@@ -465,10 +527,186 @@ function reload_secure_block(block_id, callback) {
   // reload an individual secure block that may have changed state
   // callback is an optional argument of a function that should be called
   // upon completion of the reload
-  let request = {};
-  let block = $("[data-secure_block_id=" + block_id + "]");
+  const request = {};
+  const block = $('[data-secure_block_id=' + block_id + ']');
   if (block) {
     request[block_id] = block.data();
     populate_secure_blocks(request, callback);
   }
 }
+
+// Show More && Show Less logic inside of the facets
+function Pager() {
+  this._PAGE_SIZE = 20;
+  this._HIDDEN_CLASS_NAME = 'direct_hiddenOption';
+}
+
+Pager.prototype = {
+  showLessHandler: function(e, num_items, parent) {
+    // hide the items
+    this._showLessItems(parent, num_items, num_items);
+    // toggle more/less link, if needed
+    this._toggleLessLink(parent, num_items);
+    this._toggleMoreLink(parent);
+    // stop default behavior of the link, since we're
+    // not really using it as a link.  yeah, its not ideal.
+    return false;
+  },
+  showMoreHandler: function(e, num_items, parent) {
+    const type = parent.attr('data-type');
+    this._showMoreItems(num_items, type, parent);
+    // toggle more/less links, if needed
+    this._toggleLessLink(parent, num_items);
+    // stop default behavior of the link, since we're
+    // not really using it as a link.  yeah, its not ideal.
+    return false;
+  },
+  _toggleLessLink: function(moreLessSpan, minVisible) {
+    /* Turn the 'Less' link off when we're at the minVisible limit. */
+    const relatedList = this._getListFromMoreLessLinksSpan(moreLessSpan);
+    const lessLink = moreLessSpan.children('.direct_optionsLess')[0];
+    const moreLink = moreLessSpan.children('.direct_optionsMore')[0];
+    const currNumVisible = relatedList.children(':visible').length;
+    if (currNumVisible > minVisible) {
+      $(lessLink).show();
+    } else {
+      $(lessLink).hide();
+      $(moreLink).focus();
+    }
+  },
+  _toggleMoreLink: function(moreLessSpan) {
+    const relatedList = this._getListFromMoreLessLinksSpan(moreLessSpan);
+    const numHiddenItems = relatedList.children('.' + this._HIDDEN_CLASS_NAME).length;
+    const moreLink = moreLessSpan.children('.direct_optionsMore')[0];
+    (numHiddenItems > 0) ? $(moreLink).show() : $(moreLink).hide();
+  },
+  _getListFromMoreLessLinksSpan: function(moreLessSpan) {
+    // The container for all the facet blocks.
+    const parentDiv = $(moreLessSpan).parent();
+    // From the container for all the facet blocks we can get the
+    // exact list we want to work with.
+    const itemListId = this._getListElementFromContainerId(moreLessSpan.attr('id'));
+    return $(parentDiv).children('#' + itemListId);
+  },
+  _getListElementFromContainerId: function(linkContainerId) {
+    // Current List IDs that we'll be looking for:
+    // - direct_titleDisambig
+    // - direct_countryDisambig
+    // - direct_stateDisambig
+    // - direct_cityDisambig
+    // - direct_jobListing
+    // - direct_facetDisambig
+    // - direct_mocDisambig
+    // We've attached the second part onto the ID of
+    // the <span> tag that wraps the more/less links,
+    // so we can pull it off of there to know which
+    // list we should take action on.
+    // i.e. <span id="direct_moreLessLinks_countryDisambig">
+    const baseElementId = 'direct_%s';
+    const idPieces = linkContainerId.split('_');
+    const listId = idPieces[2];
+    return baseElementId.replace('%s', listId);
+  },
+  _showMoreItems: function(numToShow, type, parent) {
+    const relatedList = this._getListFromMoreLessLinksSpan(parent);
+    const hiddenItems = relatedList.children('.' + this._HIDDEN_CLASS_NAME);
+    let currNumHidden = hiddenItems.length;
+    const focus_item = relatedList.children(this._HIDDEN_CLASS_NAME + ':first li');
+    // if we have current hidden ones, lets show those
+    if (currNumHidden > 0) {
+      // if there's less hidden items than what we want to show
+      // then we'll only show those and if there's zero hidden,
+      // then we'll go get some more and still show the number
+      // we want to
+      numToShow = (numToShow > currNumHidden) ? currNumHidden : numToShow;
+      hiddenItems.slice(0, numToShow).removeClass(this._HIDDEN_CLASS_NAME);
+      currNumHidden -= numToShow;
+    }
+    if (currNumHidden === 0) {
+      // lets see if we have any to get from the server
+      const data = {
+        'offset': parent.attr('data-offset'),
+        'num_items': this._PAGE_SIZE,
+      };
+      const qsParams = this._getQueryParams();
+      data.q = qsParams.q;
+      data.location = qsParams.location;
+      data.moc = qsParams.moc;
+      data.company = qsParams.company;
+      data.filter_path = window.location.pathname;
+      this._ajax_getItems(type, data, parent);
+    }
+    focus_item.focus();
+  },
+  _showLessItems: function(parent, numToHide, minVisible) {
+    const relatedList = this._getListFromMoreLessLinksSpan(parent);
+    const visibleItems = relatedList.children(':visible');
+    const numVisible = visibleItems.length;
+    const numAvailableToHide = numVisible - minVisible;
+    if (numAvailableToHide < numToHide) {
+      numToHide = numAvailableToHide;
+    }
+    if (numToHide > 0) {
+      visibleItems.slice(-numToHide).addClass(this._HIDDEN_CLASS_NAME);
+    }
+  },
+  _ajax_getItems: function(type, data, parent) {
+    // Preserve the reference to "this" so it can be used inside the
+    // ajax call.
+    const alsoThis = this;
+    const url = this._build_url(type);
+    if (url) {
+      $.get(
+        url,
+        data,
+        function(html) {
+          alsoThis._getItemsSuccessHandler(html, parent);
+        }
+      );
+    } else {
+      alsoThis._getItemsSuccessHandler('', parent);
+    }
+  },
+  _build_url: function(type) {
+    // Build the URL with the current path as our
+    // 'filter' that is sent into to filter objects
+    const urls = {
+      'title': '/ajax/titles/',
+      'city': '/ajax/cities/',
+      'state': '/ajax/states/',
+      'country': '/ajax/countries/',
+      'facet': '/ajax/facets/',
+      'facet-2': '/ajax/facets/',
+      'facet-3': '/ajax/facets/',
+      'moc': '/ajax/mocs/',
+      'mappedmoc': '/ajax/mapped/',
+      'company': '/ajax/company-ajax/',
+      'listing': '/ajax/joblisting/',
+      'search': '/ajax/joblisting/',
+    };
+    return urls[type];
+  },
+  _getItemsSuccessHandler: function(html, parent) {
+    // Since the update was successful, the offset can be updated to
+    // reflect the requested amount.
+    parent.attr('data-offset', parseInt(parent.attr('data-offset')) + this._PAGE_SIZE);
+    // From the Django templates we get a lot of line breaks,
+    // so we'll remove them right here, just to be safe.
+    html = html.replace(/\n/g, '');
+    const parentDiv = $(parent).parent();
+    const itemListId = this._getListElementFromContainerId(parent.attr('id'));
+    const relatedList = $(parentDiv).children('#' + itemListId);
+    $(relatedList).children(':last').after(html);
+    this._toggleMoreLink(parent);
+  },
+  _getQueryParams: function() {
+    const result = {};
+    const queryString = location.search.substring(1);
+    const re = /([^&=]+)=([^&+]*)/g;
+    let m;
+    while (m = re.exec(queryString)) {
+      result[decodeURIComponent(m[1])] = decodeURIComponent(m[2]);
+    }
+    return result;
+  },
+};

--- a/templates/seo_base_bootstrap3.html
+++ b/templates/seo_base_bootstrap3.html
@@ -168,8 +168,6 @@
   {% endcompress %}
 {% endif %}
 
-<script src="{% static "pager.164-21.js" %}"></script>
-
 {% if site_config.use_secure_blocks %}
     <script>
       var pager_num_items = {{ site_config.num_subnav_items_to_show }};


### PR DESCRIPTION
Purpose:  Remove the pager.164.21.js file call from the v2 seo_base_bootstrap3.html template that is being shared with the v1 template in order to avoid complications.  I added codes to the seo-base-scripts.js file to make the "Show More" / "Show Less" buttons work in the Facets, which was missing from my previously closed PR.  I also took this opportunity to fix some low hanging fruit eslint error, I didn't fix all of them, that will be for another task.

To test: 

1.  In Django Admin, please switch to v2 template and select home_page_listing_bootstrap3.html in the "home page template" dropdown.

2.  Please open browser's dev tool > Network tab and **ensure** (there goes that word again), that the pager.164-21.js file is not in the call stack.  

3. Please test the "Show More +" and "Show Less -" buttons in the facets (Title, City, State, Country, etc).  There should be no UI changes, I just want to ensure that the functionality still works.