### PR TITLE
Since we're pulling stuff from secrets in pymongo-env, update secrets rather than settings.

### DIFF
--- a/deploy/settings.myjobs_qc.py
+++ b/deploy/settings.myjobs_qc.py
@@ -3,8 +3,8 @@ from default_settings import *
 import datetime
 import os
 
-from secrets import (REDIRECT_QC, ARCHIVE_STAGING, REDIRECT_STAGING,
-                     QC_MONGO_HOST, QC_MONGO_DBNAME, QC_MONGO_SSL)
+from secrets import REDIRECT_QC, ARCHIVE_STAGING, REDIRECT_STAGING
+import secrets
 
 DEBUG = True
 
@@ -108,6 +108,6 @@ LOGGING['loggers']['mypartners.views']['level'] = 'INFO'
 # The email host used to parse communication records
 PRM_EMAIL_HOST = 'qc.my.jobs'
 
-MONGO_HOST = QC_MONGO_HOST
-MONGO_DBNAME = QC_MONGO_DBNAME
-MONGO_SSL = QC_MONGO_SSL
+setattr(secrets, 'MONGO_HOST', secrets.QC_MONGO_HOST)
+setattr(secrets, 'MONGO_DBNAME', secrets.QC_MONGO_DBNAME)
+setattr(secrets, 'MONGO_SSL', secrets.QC_MONGO_SSL)

--- a/deploy/settings.myjobs_staging.py
+++ b/deploy/settings.myjobs_staging.py
@@ -3,9 +3,9 @@ from default_settings import *
 import datetime
 import os
 
-from secrets import (REDIRECT_STAGING, REDIRECT_QC, ARCHIVE_STAGING,
-                     STAGING_MONGO_HOST, STAGING_MONGO_SSL,
-                     STAGING_MONGO_DBNAME)
+from secrets import REDIRECT_STAGING, REDIRECT_QC, ARCHIVE_STAGING
+import secrets
+
 DEBUG = True
 
 COMPRESS_ENABLED = True
@@ -105,6 +105,6 @@ EMAIL_HOST_PASSWORD = STAGING_EMAIL_HOST_PASSWORD
 
 CELERY_ALWAYS_EAGER = True
 
-MONGO_HOST = STAGING_MONGO_HOST
-MONGO_DBNAME = STAGING_MONGO_DBNAME
-MONGO_SSL = STAGING_MONGO_SSL
+setattr(secrets, 'MONGO_HOST', secrets.STAGING_MONGO_HOST)
+setattr(secrets, 'MONGO_DBNAME', secrets.STAGING_MONGO_DBNAME)
+setattr(secrets, 'MONGO_SSL', secrets.STAGING_MONGO_SSL)

--- a/deploy/settings.redirect_staging.py
+++ b/deploy/settings.redirect_staging.py
@@ -1,9 +1,8 @@
 from default_settings import *
 from redirect_settings import *
 
-from secrets import (REDIRECT_STAGING, REDIRECT_QC, ARCHIVE_STAGING,
-                     STAGING_MONGO_HOST, STAGING_MONGO_SSL,
-                     STAGING_MONGO_DBNAME)
+from secrets import REDIRECT_STAGING, REDIRECT_QC, ARCHIVE_STAGING
+import secrets
 
 DEBUG = False
 TEMPLATE_DEBUG = DEBUG
@@ -49,6 +48,6 @@ SOLR = {
 EMAIL_HOST_USER = STAGING_EMAIL_HOST_USER
 EMAIL_HOST_PASSWORD = STAGING_EMAIL_HOST_PASSWORD
 
-MONGO_HOST = STAGING_MONGO_HOST
-MONGO_DBNAME = STAGING_MONGO_DBNAME
-MONGO_SSL = STAGING_MONGO_SSL
+setattr(secrets, 'MONGO_HOST', secrets.STAGING_MONGO_HOST)
+setattr(secrets, 'MONGO_DBNAME', secrets.STAGING_MONGO_DBNAME)
+setattr(secrets, 'MONGO_SSL', secrets.STAGING_MONGO_SSL)

--- a/deploy/settings_dseo_qc.py
+++ b/deploy/settings_dseo_qc.py
@@ -1,8 +1,8 @@
 import datetime
 
 from default_settings import *
-from secrets import (REDIRECT_QC, ARCHIVE_STAGING, REDIRECT_STAGING,
-                     QC_MONGO_HOST, QC_MONGO_DBNAME, QC_MONGO_SSL)
+from secrets import REDIRECT_QC, ARCHIVE_STAGING, REDIRECT_STAGING
+import secrets
 
 COMPRESS_ENABLED = True
 COMPRESS_OFFLINE_MANIFEST = 'manifest.json'
@@ -108,6 +108,6 @@ CELERY_ROUTES = {
     },
 }
 
-MONGO_HOST = QC_MONGO_HOST
-MONGO_DBNAME = QC_MONGO_DBNAME
-MONGO_SSL = QC_MONGO_SSL
+setattr(secrets, 'MONGO_HOST', secrets.QC_MONGO_HOST)
+setattr(secrets, 'MONGO_DBNAME', secrets.QC_MONGO_DBNAME)
+setattr(secrets, 'MONGO_SSL', secrets.QC_MONGO_SSL)

--- a/deploy/settings_dseo_staging.py
+++ b/deploy/settings_dseo_staging.py
@@ -1,9 +1,8 @@
 import datetime
 
 from default_settings import *
-from secrets import (REDIRECT_STAGING, REDIRECT_QC, ARCHIVE_STAGING,
-                     STAGING_MONGO_HOST, STAGING_MONGO_SSL,
-                     STAGING_MONGO_DBNAME)
+from secrets import REDIRECT_STAGING, REDIRECT_QC, ARCHIVE_STAGING
+import secrets
 
 
 ALLOWED_HOSTS = ['*', ]
@@ -108,6 +107,6 @@ CELERY_ROUTES = {
     },
 }
 
-MONGO_HOST = STAGING_MONGO_HOST
-MONGO_DBNAME = STAGING_MONGO_DBNAME
-MONGO_SSL = STAGING_MONGO_SSL
+setattr(secrets, 'MONGO_HOST', secrets.STAGING_MONGO_HOST)
+setattr(secrets, 'MONGO_DBNAME', secrets.STAGING_MONGO_DBNAME)
+setattr(secrets, 'MONGO_SSL', secrets.STAGING_MONGO_SSL)


### PR DESCRIPTION
For safety purposes the goal should be to stop setting MONGO_HOST, MONGO_DBNAME and MONGO_SSL in the secrets file all together and always require the settings file to either set it or choose which one it should be set to.