### PR TITLE
[PD-2801], added second 'Apply Now' button

### DIFF
--- a/gulp/src/sass/seo_base_styles.scss
+++ b/gulp/src/sass/seo_base_styles.scss
@@ -976,22 +976,13 @@ margin-bottom: 50px;
     }
   }
   .apply {
-    background-color: $primary-navy-blue;
-    color: #ffffff;
-    font-size: 12px;
     border: none;
     border-radius: 3px;
     display: inline-block;
     margin: 0 15px 10px 0;
     padding: 10px 75px;
-    font-size: 18px;
+    font-size: 1.9rem;
     border-radius: 3px;
-    font-weight: 100;
-    font-weight: 100;
-
-		&:hover {
-			background-color: $red-maroon;
-		}
   }
 }
 
@@ -1269,7 +1260,6 @@ margin-bottom: 50px;
 		padding: 0 20px;
 
 		.apply {
-			margin: 0 auto;
 			width: 100%;
 			text-align: center;
 		}

--- a/templates/v2/job_detail.html
+++ b/templates/v2/job_detail.html
@@ -1,7 +1,10 @@
 {% extends "seo_base_bootstrap3.html" %}
-{% load i18n %}
 {% load seo_extras %}
 {% load redirect_urls %}
+{% comment %}
+    TODO: Research consequences of removing def.ui.dotjobs.results.css and then remove it.
+    TODO: Make this view more html5 semantic instead of nested div
+{% endcomment %}
 {% block direct_extraHeaderContent %}
 <link rel="stylesheet" href="/style/def.ui.dotjobs.results.css" type="text/css">
 
@@ -61,9 +64,15 @@
           </span>
         </h3>
     </div>
-    <div class="direct-detail-horzRule"></div>
     <div id="direct_listingDiv">
         <meta itemprop="datePosted" content="{{the_job.date_updated|date:'c'}}"/>
+        <div class='direct-action-btn' id="direct_applyButtonBottom">
+            {% if the_job.link %}
+            <a class="apply btn btn-success" href="{{the_job.link|swap_http_with_https:"my.jobs"}}" onclick="goalClick('/G/apply-click', this.href); return false;">Apply Now</a>
+            {% elif the_job.apply_info %}
+            <div id="apply-block">{{ the_job.apply_info }}</div>
+            {% endif %}
+        </div>
         <div id="direct_jobDescriptionText" itemprop="description">
             {% if the_job.html_description %}
                 {{ the_job.html_description|safe|cut:"??"|cut:"~" }}
@@ -80,12 +89,11 @@
         </div>
         <div class='direct-action-btn' id="direct_applyButtonBottom">
             {% if the_job.link %}
-            <a class="apply" href="{{the_job.link|swap_http_with_https:"my.jobs"}}" onclick="goalClick('/G/apply-click', this.href); return false;">{% blocktrans %}Apply Now{% endblocktrans %}</a>
+            <a class="apply btn btn-success" href="{{the_job.link|swap_http_with_https:"my.jobs"}}" onclick="goalClick('/G/apply-click', this.href); return false;">Apply Now</a>
             {% elif the_job.apply_info %}
             <div id="apply-block">{{ the_job.apply_info }}</div>
             {% endif %}
         </div>
-
     </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
**Purpose**:   Add a second "Apply Now" button to the top of the Job Details view, I placed the second button at the top based on the projected use case scenarios.  I also changed the color of these call-to-action buttons to the industry standard green, and made the font easier to read.  Also removed Django internationalization tags and added future todo items.

**To test**:

 1.  In Django Admin, please switch to v2 template and select home_page_listing_bootstrap3.html in the "home page template" dropdown menu.

2.  Please click on a job, ensure that there is an "Apply Now" button below the job title and location verbiage, as well as another "Apply Now" button at the bottom of the job info text.  Please click on the these buttons, if the job is not expired, then it should take you away from our app. Please also try out the new "Apply Now" buttons in mobile view.