### PR TITLE
[PD-2812] Fix Company Facet width discrepancy

### DIFF
--- a/gulp/src/sass/seo_base_styles.scss
+++ b/gulp/src/sass/seo_base_styles.scss
@@ -184,7 +184,6 @@ legend{
     }
   }
   .company-box {
-    margin: 0px 15px;
     border: 1px solid $extra-light-gray;
     background-color: $medium-gray;
     border-top: none;


### PR DESCRIPTION
**Purpose**:  Fix width mis-match with the "Company" facet in desktop view.  Please see after pic below.

Before: 
![company_facet_bug](https://cloud.githubusercontent.com/assets/5124153/21314605/fa4d6426-c5c5-11e6-9fd5-7c4b6d249130.png)

After:
![compan_facet_after](https://cloud.githubusercontent.com/assets/5124153/21314626/0e39f5bc-c5c6-11e6-8fb1-88182e2e53cb.png)

**To Test:**

1.  In Django Admin, please switch to v2 template and select home_page_listing_bootstrap3.html in the "home page template" dropdown list.

2.  In desktop mode, please click on a company name in the "Company" facet, which will render a facet matching the width of the other facets like in the "after" pic above.