### PR TITLE
[PD 2809] replacing calendar

### DIFF
--- a/gulp/src/analytics/actions/calendar-actions.js
+++ b/gulp/src/analytics/actions/calendar-actions.js
@@ -1,11 +1,11 @@
 import {createAction} from 'redux-actions';
 
-// import {markNavLoadingAction} from '../../common/actions/loading-actions';
+import {markNavLoadingAction} from '../../common/actions/loading-actions';
 
 export const setSelectedMonth = createAction('SET_SELECTED_MONTH');
 export const setSelectedYear = createAction('SET_SELECTED_YEAR');
 export const setSelectedDay = createAction('SET_SELECTED_DAY');
-export const setSelectedRange = createAction('SET_SELECTED_DAY');
+export const setSelectedRange = createAction('SET_SELECTED_RANGE');
 
 // Sets the current month selected for the calendar
 export function doSetSelectedMonth(month) {
@@ -29,13 +29,15 @@ export function doSetSelectedDay(day) {
   };
 }
 // Sets the selected range for the calendar
-// export function doSetSelectedRange(start, end) {
-//   return async(dispatch, _, {api}) => {
-//   dispatch(markNavLoadingAction(true));
-//   const currentStartRange = start;
-//   const currentEndRange = end;
-//   const rangeData = await api.getDateRangeData(currentStartRange, currentEndRange);
-//   dispatch(setSelectedRange(rangeData));
-//   dispatch(markNavLoadingAction(true));
-//   };
-// }
+export function doSetSelectedRange(start, end, mainDimension, activeFilters) {
+  return async(dispatch, _, {api}) => {
+    dispatch(markNavLoadingAction(true));
+    const currentStartRange = start;
+    const currentEndRange = end;
+    const currentDimension = mainDimension;
+    const currentFilters = activeFilters;
+    const rangeData = await api.getDateRangeData(currentStartRange, currentEndRange, currentDimension, currentFilters);
+    dispatch(setSelectedRange(rangeData));
+    dispatch(markNavLoadingAction(false));
+  };
+}

--- a/gulp/src/analytics/actions/calendar-actions.js
+++ b/gulp/src/analytics/actions/calendar-actions.js
@@ -1,8 +1,11 @@
 import {createAction} from 'redux-actions';
 
+// import {markNavLoadingAction} from '../../common/actions/loading-actions';
+
 export const setSelectedMonth = createAction('SET_SELECTED_MONTH');
 export const setSelectedYear = createAction('SET_SELECTED_YEAR');
 export const setSelectedDay = createAction('SET_SELECTED_DAY');
+export const setSelectedRange = createAction('SET_SELECTED_DAY');
 
 // Sets the current month selected for the calendar
 export function doSetSelectedMonth(month) {
@@ -25,3 +28,14 @@ export function doSetSelectedDay(day) {
     dispatch(setSelectedDay(currentDay));
   };
 }
+// Sets the selected range for the calendar
+// export function doSetSelectedRange(start, end) {
+//   return async(dispatch, _, {api}) => {
+//   dispatch(markNavLoadingAction(true));
+//   const currentStartRange = start;
+//   const currentEndRange = end;
+//   const rangeData = await api.getDateRangeData(currentStartRange, currentEndRange);
+//   dispatch(setSelectedRange(rangeData));
+//   dispatch(markNavLoadingAction(true));
+//   };
+// }

--- a/gulp/src/analytics/actions/calendar-actions.js
+++ b/gulp/src/analytics/actions/calendar-actions.js
@@ -1,0 +1,19 @@
+import {createAction} from 'redux-actions';
+
+export const setSelectedMonth = createAction('SET_SELECTED_MONTH');
+export const setSelectedYear = createAction('SET_SELECTED_YEAR');
+
+// Sets the current month selected for the calendar
+export function doSetSelectedMonth(month) {
+  return async(dispatch) => {
+    const currentMonth = month;
+    dispatch(setSelectedMonth(currentMonth));
+  };
+}
+// Sets the selected year for the calendar
+export function doSetSelectedYear(year) {
+  return async(dispatch) => {
+    const currentYear = year;
+    dispatch(setSelectedYear(currentYear));
+  };
+}

--- a/gulp/src/analytics/actions/calendar-actions.js
+++ b/gulp/src/analytics/actions/calendar-actions.js
@@ -2,6 +2,7 @@ import {createAction} from 'redux-actions';
 
 export const setSelectedMonth = createAction('SET_SELECTED_MONTH');
 export const setSelectedYear = createAction('SET_SELECTED_YEAR');
+export const setSelectedDay = createAction('SET_SELECTED_DAY');
 
 // Sets the current month selected for the calendar
 export function doSetSelectedMonth(month) {
@@ -15,5 +16,12 @@ export function doSetSelectedYear(year) {
   return async(dispatch) => {
     const currentYear = year;
     dispatch(setSelectedYear(currentYear));
+  };
+}
+// Sets the selected day for the calendar
+export function doSetSelectedDay(day) {
+  return async(dispatch) => {
+    const currentDay = day.day;
+    dispatch(setSelectedDay(currentDay));
   };
 }

--- a/gulp/src/analytics/actions/page-loading-actions.js
+++ b/gulp/src/analytics/actions/page-loading-actions.js
@@ -1,0 +1,33 @@
+import {createAction} from 'redux-actions';
+
+import {markPageLoadingAction} from '../../common/actions/loading-actions';
+
+export const setPageData = createAction('SET_PAGE_DATA');
+export const setPrimaryDimensions = createAction('SET_PRIMARY_DIMENSIONS');
+export const setSelectedFilterData = createAction('SET_SELECTED_FILTER_DATA');
+export const storeInitialReport = createAction('STORE_INITIAL_REPORT');
+
+export const setCurrentMonth = createAction('SET_CURRENT_MONTH');
+export const setCurrentYear = createAction('SET_CURRENT_YEAR');
+export const setCurrentDay = createAction('SET_CURRENT_DAY');
+
+// Function to set the default loading data for the analytics page
+export function doGetPageData(start, end) {
+  return async (dispatch, _, {api}) => {
+    dispatch(markPageLoadingAction(true));
+    const dateObject = new Date();
+    const startingMonth = dateObject.getMonth();
+    const startingDay = dateObject.getDate();
+    const startingYear = dateObject.getFullYear();
+    const rawPageData = await api.getInitialPageData(start, end);
+    const dimensionData = await api.getPrimaryDimensions();
+    const reportType = await api.getStartingPointReport();
+    dispatch(setPageData(rawPageData));
+    dispatch(setCurrentMonth(startingMonth));
+    dispatch(setCurrentYear(startingYear));
+    dispatch(setCurrentDay(startingDay));
+    dispatch(setPrimaryDimensions(dimensionData));
+    dispatch(storeInitialReport(reportType));
+    dispatch(markPageLoadingAction(false));
+  };
+}

--- a/gulp/src/analytics/actions/page-loading-actions.js
+++ b/gulp/src/analytics/actions/page-loading-actions.js
@@ -12,20 +12,16 @@ export const setCurrentYear = createAction('SET_CURRENT_YEAR');
 export const setCurrentDay = createAction('SET_CURRENT_DAY');
 
 // Function to set the default loading data for the analytics page
-export function doGetPageData(start, end) {
+export function doGetPageData(start, end, currentMonth, currentDay, currentYear) {
   return async (dispatch, _, {api}) => {
     dispatch(markPageLoadingAction(true));
-    const dateObject = new Date();
-    const startingMonth = dateObject.getMonth();
-    const startingDay = dateObject.getDate();
-    const startingYear = dateObject.getFullYear();
     const rawPageData = await api.getInitialPageData(start, end);
     const dimensionData = await api.getPrimaryDimensions();
     const reportType = await api.getStartingPointReport();
     dispatch(setPageData(rawPageData));
-    dispatch(setCurrentMonth(startingMonth));
-    dispatch(setCurrentYear(startingYear));
-    dispatch(setCurrentDay(startingDay));
+    dispatch(setCurrentMonth(currentMonth));
+    dispatch(setCurrentYear(currentYear));
+    dispatch(setCurrentDay(currentDay));
     dispatch(setPrimaryDimensions(dimensionData));
     dispatch(storeInitialReport(reportType));
     dispatch(markPageLoadingAction(false));

--- a/gulp/src/analytics/actions/sidebar-actions.js
+++ b/gulp/src/analytics/actions/sidebar-actions.js
@@ -5,6 +5,7 @@ import {markNavLoadingAction} from '../../common/actions/loading-actions';
 
 export const setPrimaryDimensions = createAction('SET_PRIMARY_DIMENSIONS');
 export const switchMainDimension = createAction('SWITCH_MAIN_DIMENSION');
+export const setMainDimension = createAction('SET_MAIN_DIMENSION');
 export const storeActiveReport = createAction('STORE_ACTIVE_REPORT');
 
 // Action for loading the initial primary dimensions
@@ -25,5 +26,6 @@ export function doSwitchMainDimension(mainDimension) {
     const currentDimensionData = await api.getMainDimensionData(mainDimension);
     dispatch(switchMainDimension(currentDimensionData));
     dispatch(markNavLoadingAction(false));
+    dispatch(setMainDimension(mainDimension));
   };
 }

--- a/gulp/src/analytics/actions/sidebar-actions.js
+++ b/gulp/src/analytics/actions/sidebar-actions.js
@@ -19,11 +19,11 @@ export function doGetPrimaryDimensions() {
 }
 
 // Action for switching the main dimensions from the sidebar
-export function doSwitchMainDimension(mainDimension) {
+export function doSwitchMainDimension(mainDimension, start, end) {
   return async (dispatch, getState, {api}) => {
     dispatch(markNavLoadingAction(true));
     dispatch(storeActiveReport(mainDimension));
-    const currentDimensionData = await api.getMainDimensionData(mainDimension);
+    const currentDimensionData = await api.getMainDimensionData(mainDimension, start, end);
     dispatch(switchMainDimension(currentDimensionData));
     dispatch(markNavLoadingAction(false));
     dispatch(setMainDimension(mainDimension));

--- a/gulp/src/analytics/actions/table-filter-actions.js
+++ b/gulp/src/analytics/actions/table-filter-actions.js
@@ -9,14 +9,25 @@ export const setSelectedFilterData = createAction('SET_SELECTED_FILTER_DATA');
 export const storeActiveFilter = createAction('STORE_ACTIVE_FILTER');
 export const storeInitialReport = createAction('STORE_INITIAL_REPORT');
 
+export const setCurrentMonth = createAction('SET_CURRENT_MONTH');
+export const setCurrentYear = createAction('SET_CURRENT_YEAR');
+export const setCurrentDay = createAction('SET_CURRENT_DAY');
+
 // Function to set the default loading data for the analytics page
 export function doGetPageData(start, end) {
   return async (dispatch, _, {api}) => {
     dispatch(markPageLoadingAction(true));
+    const dateObject = new Date();
+    const startingMonth = dateObject.getMonth();
+    const startingDay = dateObject.getDay();
+    const startingYear = dateObject.getFullYear();
     const rawPageData = await api.getInitialPageData(start, end);
     const dimensionData = await api.getPrimaryDimensions();
     const reportType = await api.getStartingPointReport();
     dispatch(setPageData(rawPageData));
+    dispatch(setCurrentMonth(startingMonth));
+    dispatch(setCurrentYear(startingYear));
+    dispatch(setCurrentDay(startingDay));
     dispatch(setPrimaryDimensions(dimensionData));
     dispatch(storeInitialReport(reportType));
     dispatch(markPageLoadingAction(false));

--- a/gulp/src/analytics/actions/table-filter-actions.js
+++ b/gulp/src/analytics/actions/table-filter-actions.js
@@ -1,38 +1,9 @@
 import {createAction} from 'redux-actions';
 
-import {markPageLoadingAction} from '../../common/actions/loading-actions';
 import {markNavLoadingAction} from '../../common/actions/loading-actions';
 
-export const setPageData = createAction('SET_PAGE_DATA');
-export const setPrimaryDimensions = createAction('SET_PRIMARY_DIMENSIONS');
 export const setSelectedFilterData = createAction('SET_SELECTED_FILTER_DATA');
 export const storeActiveFilter = createAction('STORE_ACTIVE_FILTER');
-export const storeInitialReport = createAction('STORE_INITIAL_REPORT');
-
-export const setCurrentMonth = createAction('SET_CURRENT_MONTH');
-export const setCurrentYear = createAction('SET_CURRENT_YEAR');
-export const setCurrentDay = createAction('SET_CURRENT_DAY');
-
-// Function to set the default loading data for the analytics page
-export function doGetPageData(start, end) {
-  return async (dispatch, _, {api}) => {
-    dispatch(markPageLoadingAction(true));
-    const dateObject = new Date();
-    const startingMonth = dateObject.getMonth();
-    const startingDay = dateObject.getDay();
-    const startingYear = dateObject.getFullYear();
-    const rawPageData = await api.getInitialPageData(start, end);
-    const dimensionData = await api.getPrimaryDimensions();
-    const reportType = await api.getStartingPointReport();
-    dispatch(setPageData(rawPageData));
-    dispatch(setCurrentMonth(startingMonth));
-    dispatch(setCurrentYear(startingYear));
-    dispatch(setCurrentDay(startingDay));
-    dispatch(setPrimaryDimensions(dimensionData));
-    dispatch(storeInitialReport(reportType));
-    dispatch(markPageLoadingAction(false));
-  };
-}
 
 // Function for storing the active filters for the API
 export function doStoreActiveFilter(type, value) {

--- a/gulp/src/analytics/api.js
+++ b/gulp/src/analytics/api.js
@@ -33,23 +33,25 @@ export default class Api {
     return await this.api.post('/analytics/api/dynamic', {'request': JSON.stringify(selectedFilterRequest)});
   }
   // Get the data from the main dimensions selected from sidebar
-  async getMainDimensionData(mainDimension) {
+  async getMainDimensionData(mainDimension, start, end) {
     const mainDimensionDataRequest = {
-      'date_start': '12/01/2016 00:00:00',
-      'date_end': '12/12/2016 23:59:59',
+      'date_start': start,
+      'date_end': end,
       'active_filters': [],
       'report': mainDimension,
     };
     return await this.api.post('/analytics/api/dynamic', {'request': JSON.stringify(mainDimensionDataRequest)});
   }
   // Get the date range data selected from the Calendar
-  // async getDateRangeData(start, end) {
-  //   const mainDimensionDataRequest = {
-  //     'date_start': start,
-  //     'date_end': end,
-  //     'active_filters': [],
-  //     'report': mainDimension,
-  //   };
-  //   return await this.api.post('/analytics/api/dynamic', {'request': JSON.stringify(mainDimensionDataRequest)});
-  // }
+  async getDateRangeData(start, end, mainDimension, activeFilters) {
+    const setDateRangeDataRequest = {
+      'date_start': start,
+      'date_end': end,
+      'active_filters': activeFilters,
+      'report': mainDimension,
+    };
+    // console.log(setDateRangeDataRequest);
+    // console.log(await this.api.post('/analytics/api/dynamic', {'request': JSON.stringify(setDateRangeDataRequest)}));
+    return await this.api.post('/analytics/api/dynamic', {'request': JSON.stringify(setDateRangeDataRequest)});
+  }
 }

--- a/gulp/src/analytics/api.js
+++ b/gulp/src/analytics/api.js
@@ -7,7 +7,7 @@ export default class Api {
     const loadStartingPointReport = await this.api.get('/analytics/api/available-reports');
     const initialPageRequest = {
       'date_start': start + ' 00:00:00',
-      'date_end': end + ' 23:59:00',
+      'date_end': end,
       'active_filters': [],
       'report': loadStartingPointReport.reports[0].value,
     };
@@ -26,7 +26,7 @@ export default class Api {
   async getSelectedFilterData(tableValue, typeValue, storedFilters, currentReport) {
     const selectedFilterRequest = {
       'date_start': '12/01/2016 00:00:00',
-      'date_end': '12/12/2016 00:00:00',
+      'date_end': '12/12/2016 23:59:59',
       'active_filters': storedFilters,
       'report': currentReport,
     };
@@ -36,10 +36,20 @@ export default class Api {
   async getMainDimensionData(mainDimension) {
     const mainDimensionDataRequest = {
       'date_start': '12/01/2016 00:00:00',
-      'date_end': '12/12/2016 00:00:00',
+      'date_end': '12/12/2016 23:59:59',
       'active_filters': [],
       'report': mainDimension,
     };
     return await this.api.post('/analytics/api/dynamic', {'request': JSON.stringify(mainDimensionDataRequest)});
   }
+  // Get the date range data selected from the Calendar
+  // async getDateRangeData(start, end) {
+  //   const mainDimensionDataRequest = {
+  //     'date_start': start,
+  //     'date_end': end,
+  //     'active_filters': [],
+  //     'report': mainDimension,
+  //   };
+  //   return await this.api.post('/analytics/api/dynamic', {'request': JSON.stringify(mainDimensionDataRequest)});
+  // }
 }

--- a/gulp/src/analytics/api.js
+++ b/gulp/src/analytics/api.js
@@ -7,7 +7,7 @@ export default class Api {
     const loadStartingPointReport = await this.api.get('/analytics/api/available-reports');
     const initialPageRequest = {
       'date_start': start + ' 00:00:00',
-      'date_end': end + ' 00:00:00',
+      'date_end': end + ' 23:59:00',
       'active_filters': [],
       'report': loadStartingPointReport.reports[0].value,
     };

--- a/gulp/src/analytics/components/AnalyticsApp.jsx
+++ b/gulp/src/analytics/components/AnalyticsApp.jsx
@@ -13,8 +13,11 @@ class AnalyticsApp extends React.Component {
     const endDate = moment().format('MM/DD/YYYY H:mm:ss');
     startDate = startDate.subtract(30, 'days');
     startDate = startDate.format('MM/DD/YYYY');
+    const currentMonth = moment().month();
+    const currentDay = moment().date();
+    const currentYear = moment().year();
     const {dispatch} = this.props;
-    dispatch(doGetPageData(startDate, endDate));
+    dispatch(doGetPageData(startDate, endDate, currentMonth, currentDay, currentYear));
   }
   render() {
     const {analytics} = this.props;

--- a/gulp/src/analytics/components/AnalyticsApp.jsx
+++ b/gulp/src/analytics/components/AnalyticsApp.jsx
@@ -10,7 +10,7 @@ import moment from 'moment';
 class AnalyticsApp extends React.Component {
   componentDidMount() {
     let startDate = moment();
-    const endDate = moment().format('MM/DD/YYYY');
+    const endDate = moment().format('MM/DD/YYYY H:mm:ss');
     startDate = startDate.subtract(30, 'days');
     startDate = startDate.format('MM/DD/YYYY');
     const {dispatch} = this.props;

--- a/gulp/src/analytics/components/AnalyticsApp.jsx
+++ b/gulp/src/analytics/components/AnalyticsApp.jsx
@@ -18,7 +18,6 @@ class AnalyticsApp extends React.Component {
   }
   render() {
     const {analytics} = this.props;
-    console.log('Analytics Data: ', analytics);
     if (analytics.pageFetching) {
       return (
         <LoadingSpinner/>

--- a/gulp/src/analytics/components/AnalyticsApp.jsx
+++ b/gulp/src/analytics/components/AnalyticsApp.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {connect} from 'react-redux';
-import {doGetPageData} from '../actions/table-filter-actions';
+import {doGetPageData} from '../actions/page-loading-actions';
 import SideBar from './SideBar/SideBar';
 import Header from './Header/Header';
 import TabsContainer from './Tabs/TabsContainer';

--- a/gulp/src/analytics/components/AnalyticsApp.jsx
+++ b/gulp/src/analytics/components/AnalyticsApp.jsx
@@ -18,6 +18,7 @@ class AnalyticsApp extends React.Component {
   }
   render() {
     const {analytics} = this.props;
+    console.log('Analytics Data: ', analytics);
     if (analytics.pageFetching) {
       return (
         <LoadingSpinner/>

--- a/gulp/src/analytics/components/Calendar/BootstrapCalendar.js
+++ b/gulp/src/analytics/components/Calendar/BootstrapCalendar.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import {Component} from 'react';
+import moment from 'moment';
+import DateRangePicker from 'react-bootstrap-daterangepicker';
+import {Button} from 'react-bootstrap';
+
+class Calendar extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      ranges: {
+        'Today': [moment(), moment()],
+        'Yesterday': [moment().subtract(1, 'days'), moment().subtract(1, 'days')],
+        'Last 7 Days': [moment().subtract(6, 'days'), moment()],
+        'Last 30 Days': [moment().subtract(29, 'days'), moment()],
+        'This Month': [moment().startOf('month'), moment().endOf('month')],
+        'Last Month': [moment().subtract(1, 'month').startOf('month'), moment().subtract(1, 'month').endOf('month')],
+      },
+      startDate: moment().subtract(29, 'days'),
+      endDate: moment(),
+    };
+  }
+  handleEvent(event, picker) {
+    this.setState({
+      startDate: picker.startDate,
+      endDate: picker.endDate,
+    });
+  }
+  applyDateRange() {
+
+  }
+  cancelDateRange() {
+
+  }
+  render() {
+    const localizeTime = moment().format('LT');
+    const localizeDate = moment().format('MMMM Do, YYYY');
+    return (
+      <div>
+        <DateRangePicker opens="left" onApply={this.applyDateRange.bind(this)} onCancel={this.cancelDateRange.bind(this)} startDate={this.state.startDate} endDate={this.state.endDate} ranges={this.state.ranges} onEvent={this.handleEvent.bind(this)}>
+          <Button className="selected-date-range-btn">
+              <i className="head-icon fa fa-calendar" aria-hidden="true"></i>
+              <span className="dashboard-date">{localizeDate} {localizeTime}</span>
+          </Button>
+        </DateRangePicker>
+      </div>
+    );
+  }
+}
+
+export default Calendar;

--- a/gulp/src/analytics/components/Calendar/Calendar.js
+++ b/gulp/src/analytics/components/Calendar/Calendar.js
@@ -11,8 +11,9 @@ import RangeSelection from './RangeSelection';
 class Calendar extends Component {
   constructor(props) {
     super(props);
+
     this.state = {
-      displayCalendar: false,
+      showCalendar: false,
     };
   }
   setRangeSelection(range) {
@@ -25,7 +26,7 @@ class Calendar extends Component {
   }
   showCalendar() {
     this.setState({
-      displayCalendar: true,
+      showCalendar: true,
     });
   }
   updateMonth(month) {
@@ -59,10 +60,9 @@ class Calendar extends Component {
     dispatch(doSetSelectedDay(day));
   }
   showRange() {
-
   }
   render() {
-    const {analytics} = this.props;
+    const {analytics, showCalendarRangePicker} = this.props;
     const day = analytics.day;
     const month = analytics.month;
     const year = analytics.year;
@@ -77,13 +77,13 @@ class Calendar extends Component {
                       yearChoices={this.generateYearChoices()}
                     />);
     return (
-      <div className="calendar-container">
+      <div className={showCalendarRangePicker ? 'calendar-container active-picker' : 'calendar-container non-active-picker'}>
         <ul>
           <li className="calendar-pick full-calendar">
-            {calendar}
-          </li>
-          <li className="calendar-pick quick-calendar">
-            <RangeSelection showCustomRange={() => this.showRange()} setRange={y => this.setRangeSelection(y)}/>
+            <div className={this.state.showCalendar ? 'show-calendar' : 'hide-calendar'}>
+              {calendar}
+            </div>
+            <RangeSelection showCalendar={this.showCalendar.bind(this)} showCustomRange={() => this.showCalendar()} setRange={y => this.setRangeSelection(y)}/>
           </li>
         </ul>
       </div>
@@ -94,6 +94,7 @@ class Calendar extends Component {
 Calendar.propTypes = {
   dispatch: React.PropTypes.func.isRequired,
   analytics: React.PropTypes.object.isRequired,
+  showCalendarRangePicker: React.PropTypes.bool,
 };
 
 export default connect(state => ({

--- a/gulp/src/analytics/components/Calendar/Calendar.js
+++ b/gulp/src/analytics/components/Calendar/Calendar.js
@@ -1,48 +1,20 @@
 import React from 'react';
 import {Component} from 'react';
 import moment from 'moment';
-import DateRangePicker from 'react-bootstrap-daterangepicker';
-import {Button} from 'react-bootstrap';
+import RangeSelection from './RangeSelection';
 
 class Calendar extends Component {
   constructor(props) {
     super(props);
-    this.state = {
-      ranges: {
-        'Today': [moment(), moment()],
-        'Yesterday': [moment().subtract(1, 'days'), moment().subtract(1, 'days')],
-        'Last 7 Days': [moment().subtract(6, 'days'), moment()],
-        'Last 30 Days': [moment().subtract(29, 'days'), moment()],
-        'This Month': [moment().startOf('month'), moment().endOf('month')],
-        'Last Month': [moment().subtract(1, 'month').startOf('month'), moment().subtract(1, 'month').endOf('month')],
-      },
-      startDate: moment().subtract(29, 'days'),
-      endDate: moment(),
-    };
-  }
-  handleEvent(event, picker) {
-    this.setState({
-      startDate: picker.startDate,
-      endDate: picker.endDate,
-    });
-  }
-  applyDateRange() {
 
   }
-  cancelDateRange() {
-
+  setRangeSelection(y) {
+    console.log(y);
   }
   render() {
-    const localizeTime = moment().format('LT');
-    const localizeDate = moment().format('MMMM Do, YYYY');
     return (
-      <div>
-        <DateRangePicker opens="left" onApply={this.applyDateRange.bind(this)} onCancel={this.cancelDateRange.bind(this)} startDate={this.state.startDate} endDate={this.state.endDate} ranges={this.state.ranges} onEvent={this.handleEvent.bind(this)}>
-          <Button className="selected-date-range-btn">
-              <i className="head-icon fa fa-calendar" aria-hidden="true"></i>
-              <span className="dashboard-date">{localizeDate} {localizeTime}</span>
-          </Button>
-        </DateRangePicker>
+      <div className="calendar-container">
+        <RangeSelection setRange={y => this.setRangeSelection(y)}/>
       </div>
     );
   }

--- a/gulp/src/analytics/components/Calendar/Calendar.js
+++ b/gulp/src/analytics/components/Calendar/Calendar.js
@@ -1,23 +1,99 @@
 import React from 'react';
 import {Component} from 'react';
-import moment from 'moment';
+import {connect} from 'react-redux';
+import {doSetSelectedMonth} from '../../actions/calendar-actions';
+import {doSetSelectedYear} from '../../actions/calendar-actions';
+import {doSetSelectedDay} from '../../actions/calendar-actions';
+import CalendarPanel from 'common/ui/CalendarPanel';
 import RangeSelection from './RangeSelection';
 
 class Calendar extends Component {
   constructor(props) {
     super(props);
-
+    this.state = {
+      displayCalendar: false,
+    };
   }
-  setRangeSelection(y) {
-    console.log(y);
+  setRangeSelection(range) {
+    console.log(range);
+    // const startRange = range[0];
+    // const endRange = range[1];
+    // dispatch(doSetSelectedRange(startRange, endRange));
+  }
+  showCalendar() {
+    this.setState({
+      displayCalendar: true,
+    });
+  }
+  updateMonth(month) {
+    const {dispatch} = this.props;
+    dispatch(doSetSelectedMonth(month));
+    console.log(month);
+  }
+  updateYear(year) {
+    const {dispatch} = this.props;
+    dispatch(doSetSelectedYear(year));
+  }
+  generateYearChoices() {
+    const now = new Date();
+    const numberOfYears = 50;
+    let offset = 0;
+    // how many years should come before and after the current year
+    const pivot = numberOfYears % 2 === 0 ? numberOfYears - 1 : numberOfYears;
+    offset = Math.floor(pivot / 2);
+    const startYear = now.getFullYear() + offset;
+
+    const yearChoices = [];
+    for (let i = 0; i < numberOfYears; i++) {
+      yearChoices.push({
+        value: (startYear - i),
+        display: (startYear - i).toString(),
+      });
+    }
+    return yearChoices;
+  }
+  daySelected(day) {
+    const {dispatch} = this.props;
+    dispatch(doSetSelectedDay(day));
+  }
+  showRange() {
+    console.log('SHOWING');
   }
   render() {
+    const {analytics} = this.props;
+    const day = analytics.day;
+    const month = analytics.month;
+    const year = analytics.year;
+
+    const calendar = ( <CalendarPanel
+                      year={year}
+                      month={month}
+                      day={day}
+                      onYearChange={y => this.updateYear(y)}
+                      onMonthChange={m => this.updateMonth(m)}
+                      onSelect={d => this.daySelected(d)}
+                      yearChoices={this.generateYearChoices()}
+                    />);
     return (
       <div className="calendar-container">
-        <RangeSelection setRange={y => this.setRangeSelection(y)}/>
+        <ul>
+          <li className="calendar-pick full-calendar">
+            {calendar}
+          </li>
+          <li className="calendar-pick quick-calendar">
+            <RangeSelection showCustomRange={() => this.showRange()} setRange={y => this.setRangeSelection(y)}/>
+          </li>
+        </ul>
       </div>
     );
   }
 }
 
-export default Calendar;
+Calendar.propTypes = {
+  dispatch: React.PropTypes.func.isRequired,
+  analytics: React.PropTypes.object.isRequired,
+};
+
+export default connect(state => ({
+  analytics: state.pageLoadData,
+}))(Calendar);

--- a/gulp/src/analytics/components/Calendar/Calendar.js
+++ b/gulp/src/analytics/components/Calendar/Calendar.js
@@ -30,9 +30,9 @@ class Calendar extends Component {
     });
   }
   updateMonth(month) {
-    console.log(month);
+    const updatedMonth = (month - 1);
     const {dispatch} = this.props;
-    dispatch(doSetSelectedMonth(month));
+    dispatch(doSetSelectedMonth(updatedMonth));
   }
   updateYear(year) {
     const {dispatch} = this.props;

--- a/gulp/src/analytics/components/Calendar/Calendar.js
+++ b/gulp/src/analytics/components/Calendar/Calendar.js
@@ -4,6 +4,7 @@ import {connect} from 'react-redux';
 import {doSetSelectedMonth} from '../../actions/calendar-actions';
 import {doSetSelectedYear} from '../../actions/calendar-actions';
 import {doSetSelectedDay} from '../../actions/calendar-actions';
+import {doSetSelectedRange} from '../../actions/calendar-actions';
 import CalendarPanel from 'common/ui/CalendarPanel';
 import RangeSelection from './RangeSelection';
 
@@ -15,10 +16,12 @@ class Calendar extends Component {
     };
   }
   setRangeSelection(range) {
-    console.log(range);
-    // const startRange = range[0];
-    // const endRange = range[1];
-    // dispatch(doSetSelectedRange(startRange, endRange));
+    const {dispatch, analytics} = this.props;
+    const startRange = range[0];
+    const endRange = range[1];
+    const activeMainDimension = analytics.activePrimaryDimension;
+    const activeFilters = analytics.activeFilters;
+    dispatch(doSetSelectedRange(startRange, endRange, activeMainDimension, activeFilters));
   }
   showCalendar() {
     this.setState({
@@ -28,7 +31,6 @@ class Calendar extends Component {
   updateMonth(month) {
     const {dispatch} = this.props;
     dispatch(doSetSelectedMonth(month));
-    console.log(month);
   }
   updateYear(year) {
     const {dispatch} = this.props;
@@ -57,7 +59,7 @@ class Calendar extends Component {
     dispatch(doSetSelectedDay(day));
   }
   showRange() {
-    console.log('SHOWING');
+
   }
   render() {
     const {analytics} = this.props;

--- a/gulp/src/analytics/components/Calendar/Calendar.js
+++ b/gulp/src/analytics/components/Calendar/Calendar.js
@@ -30,6 +30,7 @@ class Calendar extends Component {
     });
   }
   updateMonth(month) {
+    console.log(month);
     const {dispatch} = this.props;
     dispatch(doSetSelectedMonth(month));
   }
@@ -59,10 +60,8 @@ class Calendar extends Component {
     const {dispatch} = this.props;
     dispatch(doSetSelectedDay(day));
   }
-  showRange() {
-  }
   render() {
-    const {analytics, showCalendarRangePicker} = this.props;
+    const {analytics, showCalendarRangePicker, hideCalendarRangePicker, onMouseDown, onMouseUp} = this.props;
     const day = analytics.day;
     const month = analytics.month;
     const year = analytics.year;
@@ -77,13 +76,13 @@ class Calendar extends Component {
                       yearChoices={this.generateYearChoices()}
                     />);
     return (
-      <div className={showCalendarRangePicker ? 'calendar-container active-picker' : 'calendar-container non-active-picker'}>
+      <div onMouseDown={onMouseDown} onMouseUp={onMouseUp} className={showCalendarRangePicker ? 'calendar-container active-picker' : 'calendar-container non-active-picker'}>
         <ul>
           <li className="calendar-pick full-calendar">
             <div className={this.state.showCalendar ? 'show-calendar' : 'hide-calendar'}>
               {calendar}
             </div>
-            <RangeSelection showCalendar={this.showCalendar.bind(this)} showCustomRange={() => this.showCalendar()} setRange={y => this.setRangeSelection(y)}/>
+            <RangeSelection cancelSelection={hideCalendarRangePicker} showCalendar={this.showCalendar.bind(this)} showCustomRange={() => this.showCalendar()} setRange={y => this.setRangeSelection(y)}/>
           </li>
         </ul>
       </div>
@@ -91,10 +90,14 @@ class Calendar extends Component {
   }
 }
 
+
 Calendar.propTypes = {
   dispatch: React.PropTypes.func.isRequired,
   analytics: React.PropTypes.object.isRequired,
   showCalendarRangePicker: React.PropTypes.bool,
+  hideCalendarRangePicker: React.PropTypes.func,
+  onMouseDown: React.PropTypes.func,
+  onMouseUp: React.PropTypes.func,
 };
 
 export default connect(state => ({

--- a/gulp/src/analytics/components/Calendar/RangeSelection.js
+++ b/gulp/src/analytics/components/Calendar/RangeSelection.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import {Component} from 'react';
+import moment from 'moment';
+
+class RangeSelection extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      ranges: [
+        {name: 'Today', date: [moment(), moment()]},
+        {name: 'Yesterday', date: [moment().subtract(1, 'days'), moment().subtract(1, 'days')]},
+        {name: 'Last 7 Days', date: [moment().subtract(6, 'days'), moment()]},
+        {name: 'Last 30 Days', date: [moment().subtract(29, 'days'), moment()]},
+        {name: 'This Month', date: [moment().startOf('month'), moment().endOf('month')]},
+        {name: 'Last Month', date: [moment().subtract(1, 'month').startOf('month'), moment().subtract(1, 'month').endOf('month')]},
+      ],
+    };
+  }
+  render() {
+    const {setRange} = this.props;
+    const generateRanges = this.state.ranges.map((range, i) => {
+      return (
+        <li key={i} className="range" onClick={() => setRange(range.date)}>{range.name}</li>
+      );
+    });
+    return (
+      <div className="range-container">
+        <ul className="range-selections">
+          {generateRanges}
+          <li className="range">Custom Range</li>
+          <li className="apply-cancel"><button className="range-btn apply-range">APPLY</button><button className="range-btn cancel-range">CANCEL</button></li>
+        </ul>
+      </div>
+    );
+  }
+}
+
+export default RangeSelection;

--- a/gulp/src/analytics/components/Calendar/RangeSelection.js
+++ b/gulp/src/analytics/components/Calendar/RangeSelection.js
@@ -18,7 +18,7 @@ class RangeSelection extends Component {
     };
   }
   render() {
-    const {setRange, showCustomRange} = this.props;
+    const {setRange, showCustomRange, cancelSelection} = this.props;
     const generateRanges = this.state.ranges.map((range, i) => {
       return (
         <li key={i} className="range" onClick={() => setRange(range.date)}>{range.name}</li>
@@ -29,7 +29,7 @@ class RangeSelection extends Component {
         <ul className="range-selections">
           {generateRanges}
           <li onClick={() => showCustomRange()} className="range">Custom Range</li>
-          <li className="apply-cancel"><button className="range-btn apply-range">APPLY</button><button className="range-btn cancel-range">CANCEL</button></li>
+          <li className="apply-cancel"><button className="range-btn apply-range">APPLY</button><button onClick={cancelSelection} className="range-btn cancel-range">CANCEL</button></li>
         </ul>
       </div>
     );
@@ -39,6 +39,7 @@ class RangeSelection extends Component {
 RangeSelection.propTypes = {
   setRange: React.PropTypes.func.isRequired,
   showCustomRange: React.PropTypes.func,
+  cancelSelection: React.PropTypes.func,
 };
 
 export default RangeSelection;

--- a/gulp/src/analytics/components/Calendar/RangeSelection.js
+++ b/gulp/src/analytics/components/Calendar/RangeSelection.js
@@ -8,17 +8,17 @@ class RangeSelection extends Component {
 
     this.state = {
       ranges: [
-        {name: 'Today', date: [moment(), moment()]},
-        {name: 'Yesterday', date: [moment().subtract(1, 'days'), moment().subtract(1, 'days')]},
-        {name: 'Last 7 Days', date: [moment().subtract(6, 'days'), moment()]},
-        {name: 'Last 30 Days', date: [moment().subtract(29, 'days'), moment()]},
-        {name: 'This Month', date: [moment().startOf('month'), moment().endOf('month')]},
-        {name: 'Last Month', date: [moment().subtract(1, 'month').startOf('month'), moment().subtract(1, 'month').endOf('month')]},
+        {name: 'Today', date: [moment().format('MM/DD/YYYY 00:00:00'), moment().format('MM/DD/YYYY H:mm:ss')]},
+        {name: 'Yesterday', date: [moment().subtract(1, 'days').format('MM/DD/YYYY 00:00:00'), moment().subtract(1, 'days').format('MM/DD/YYYY 23:59:59')]},
+        {name: 'Last 7 Days', date: [moment().subtract(6, 'days').format('MM/DD/YYYY 00:00:00'), moment().format('MM/DD/YYYY H:mm:ss')]},
+        {name: 'Last 30 Days', date: [moment().subtract(29, 'days').format('MM/DD/YYYY 00:00:00'), moment().format('MM/DD/YYYY H:mm:ss')]},
+        {name: 'This Month', date: [moment().startOf('month').format('MM/DD/YYYY 00:00:00'), moment().endOf('month').format('MM/DD/YYYY H:mm:ss')]},
+        {name: 'Last Month', date: [moment().subtract(1, 'month').startOf('month').format('MM/DD/YYYY 00:00:00'), moment().subtract(1, 'month').endOf('month').format('MM/DD/YYYY 23:59:59')]},
       ],
     };
   }
   render() {
-    const {setRange} = this.props;
+    const {setRange, showCustomRange} = this.props;
     const generateRanges = this.state.ranges.map((range, i) => {
       return (
         <li key={i} className="range" onClick={() => setRange(range.date)}>{range.name}</li>
@@ -28,12 +28,17 @@ class RangeSelection extends Component {
       <div className="range-container">
         <ul className="range-selections">
           {generateRanges}
-          <li className="range">Custom Range</li>
+          <li onClick={() => showCustomRange()} className="range">Custom Range</li>
           <li className="apply-cancel"><button className="range-btn apply-range">APPLY</button><button className="range-btn cancel-range">CANCEL</button></li>
         </ul>
       </div>
     );
   }
 }
+
+RangeSelection.propTypes = {
+  setRange: React.PropTypes.func.isRequired,
+  showCustomRange: React.PropTypes.func,
+};
 
 export default RangeSelection;

--- a/gulp/src/analytics/components/Header/Header.js
+++ b/gulp/src/analytics/components/Header/Header.js
@@ -1,23 +1,202 @@
 import React from 'react';
 import {Component} from 'react';
 import {connect} from 'react-redux';
+import moment from 'moment';
+import {Button} from 'react-bootstrap';
+import CalendarPanel from 'common/ui/CalendarPanel';
 
 class Header extends Component {
+  constructor(props) {
+    super(props);
+    let year;
+    let month;
+    let day;
+
+    const momentObject = moment('YYYY-MM-DD');
+    day = momentObject.date();
+    month = momentObject.month();
+    year = momentObject.year();
+
+    this.state = {
+      year: year,
+      month: month,
+      day: day,
+      displayCalendar: true,
+      dateInvalid: false,
+    };
+  }
+  onMouseInCalendar(value) {
+    this.setState({mouseInCalendar: value});
+  }
+  // onDaySelect(day) {
+  //   this.updateDay(day);
+  //   this.closeCalendar();
+  // }
+  generateYearChoices() {
+    const {pastOnly, numberOfYears} = this.props;
+    const now = new Date();
+    let offset = 0;
+    if (!pastOnly) {
+      // how many years should come before and after the current year
+      const pivot = numberOfYears % 2 === 0 ? numberOfYears - 1 : numberOfYears;
+      offset = Math.floor(pivot / 2);
+    }
+    const startYear = now.getFullYear() + offset;
+
+    const yearChoices = [];
+    for (let i = 0; i < numberOfYears; i++) {
+      yearChoices.push({
+        value: (startYear - i),
+        display: (startYear - i).toString(),
+      });
+    }
+    return yearChoices;
+  }
+  // updateDay(day) {
+  //   const {onChange, value} = this.props;
+  //
+  //   if (!moment(value, 'MM/DD/YYYY', true).isValid()) {
+  //     this.resetDateToNow();
+  //   }
+  //
+  //   const fakeEvent = {};
+  //   fakeEvent.target = {};
+  //   fakeEvent.target.name = this.props.name;
+  //   fakeEvent.target.type = 'calendar-day';
+  //   fakeEvent.target.value = day.day;
+  //   onChange(fakeEvent);
+  // }
+  // updateMonth(month) {
+  //   const {onChange, value} = this.props;
+  //
+  //   if (!moment(value, 'MM/DD/YYYY', true).isValid()) {
+  //     this.resetDateToNow();
+  //   }
+  //
+  //   const fakeEvent = {};
+  //   fakeEvent.target = {};
+  //   fakeEvent.target.name = this.props.name;
+  //   fakeEvent.target.type = 'calendar-month';
+  //   fakeEvent.target.value = month;
+  //   onChange(fakeEvent);
+  // }
+
+  // updateYear(year) {
+  //   const {onChange, value} = this.props;
+  //
+  //   if (!moment(value, 'MM/DD/YYYY', true).isValid()) {
+  //     this.resetDateToNow();
+  //   }
+  //
+  //   const fakeEvent = {};
+  //   fakeEvent.target = {};
+  //   fakeEvent.target.name = this.props.name;
+  //   fakeEvent.target.type = 'calendar-year';
+  //   fakeEvent.target.value = year;
+  //   onChange(fakeEvent);
+  // }
+  openCalendar() {
+    const {value} = this.props;
+    // Check if date is valid
+    // If not, replace with what it was on page load (what was passed in or today's date
+    if (!moment(value, 'MM/DD/YYYY', true).isValid()) {
+      this.resetDateToNow();
+    }
+    this.setState({displayCalendar: true});
+  }
+  closeCalendar() {
+    this.setState({displayCalendar: false});
+  }
   render() {
+    const localizeTime = moment().format('LT');
+    const localizeDate = moment().format('MMMM Do, YYYY');
+    let momentObject = moment('MM/DD/YYYY');
+    let day;
+    let month;
+    let year;
+
+    // Handle error message
+    // let errorMessage;
+    // if (error) {
+    //   errorMessage = error;
+    // }
+
+      momentObject = moment('MM/DD/YYYY');
+      day = momentObject.date();
+      month = momentObject.month();
+      year = momentObject.year();
+
+    // let errorComponent;
+    // if (errorMessage) {
+    //   errorComponent = (
+    //     <div className="error-text">{errorMessage}</div>
+    //   );
+    // }
+    let calendar;
+    if (this.state.displayCalendar) {
+      calendar = ( <CalendarPanel
+                      year={year}
+                      yearChoices={this.generateYearChoices()}
+                      month={month}
+                      day={day}
+                      onSelect={d => console.log('Select Change', d)}
+                      onYearChange={y => console.log('Year Change', y)}
+                      onMonthChange={m => console.log('Month Change', m)}
+                      closeCalendar={() => this.closeCalendar()}
+                      pastOnly
+                    />);
+    }
     return (
       <div className="tabs-header">
         <nav>
           <i className="open-mobile fa fa-arrow-circle-right" aria-hidden="true"></i>
           <ul className="nav navbar-nav navbar-right right-options">
+            <li>
+              <Button onClick={() => this.onMouseInCalendar(true)} className="selected-date-range-btn">
+                  <i className="head-icon fa fa-calendar" aria-hidden="true"></i>
+                  <span className="dashboard-date">{localizeDate} {localizeTime}</span>
+              </Button>
+            </li>
             <li><a href="#"><span className="head-icon fa fa-envelope-o"></span></a></li>
             <li><a href="#"><span className="head-icon fa fa-print"></span></a></li>
             <li><a href="#"><span className="head-icon fa fa-file-excel-o"></span></a></li>
           </ul>
         </nav>
+        {calendar}
       </div>
     );
   }
 }
+
+Header.propTypes = {
+  // onChange: React.PropTypes.func.isRequired,
+  /**
+   * Value at first page load
+   */
+  value: React.PropTypes.string,
+  /**
+   * Should this component be shown or not?
+   */
+  isHidden: React.PropTypes.bool,
+  /**
+   * Should this bad boy focus, all auto like?
+   */
+  autoFocus: React.PropTypes.string,
+  /**
+   * Validation error
+   */
+  error: React.PropTypes.string,
+
+  /**
+  * How many years to include in the year selection
+  */
+  numberOfYears: React.PropTypes.number,
+  /** Whether or not to only include past years. When false, the current year
+  * is used as a pivot and half of the selectable years will fall before, and
+  * half of them will fall after it.
+  */
+  pastOnly: React.PropTypes.bool,
+};
 
 export default connect(state => ({
   analytics: state.pageLoadData,

--- a/gulp/src/analytics/components/Header/Header.js
+++ b/gulp/src/analytics/components/Header/Header.js
@@ -7,13 +7,14 @@ import {doSetSelectedMonth} from '../../actions/calendar-actions';
 import {doSetSelectedYear} from '../../actions/calendar-actions';
 import {doSetSelectedDay} from '../../actions/calendar-actions';
 import CalendarPanel from 'common/ui/CalendarPanel';
+import RangeSelection from '../Calendar/RangeSelection';
+import Calendar from '../Calendar/Calendar';
 
 class Header extends Component {
   constructor(props) {
     super(props);
-
     this.state = {
-      displayCalendar: true,
+      displayCalendar: false,
     };
   }
   daySelected(day) {
@@ -46,6 +47,11 @@ class Header extends Component {
     }
     return yearChoices;
   }
+  showCalendar() {
+    this.setState({
+      displayCalendar: true,
+    });
+  }
   render() {
     const {analytics} = this.props;
     console.log(analytics);
@@ -55,9 +61,7 @@ class Header extends Component {
     const month = analytics.month;
     const year = analytics.year;
 
-    let calendar;
-    if (this.state.displayCalendar) {
-      calendar = ( <CalendarPanel
+    const calendar = ( <CalendarPanel
                       year={year}
                       month={month}
                       day={day}
@@ -66,14 +70,14 @@ class Header extends Component {
                       onSelect={d => this.daySelected(d)}
                       yearChoices={this.generateYearChoices()}
                     />);
-    }
+
     return (
       <div className="tabs-header">
         <nav>
           <i className="open-mobile fa fa-arrow-circle-right" aria-hidden="true"></i>
           <ul className="nav navbar-nav navbar-right right-options">
             <li>
-              <Button className="selected-date-range-btn">
+              <Button onClick={this.showCalendar.bind(this)} className="selected-date-range-btn">
                   <i className="head-icon fa fa-calendar" aria-hidden="true"></i>
                   <span className="dashboard-date">{localizeDate} {localizeTime}</span>
               </Button>
@@ -83,7 +87,7 @@ class Header extends Component {
             <li><a href="#"><span className="head-icon fa fa-file-excel-o"></span></a></li>
           </ul>
         </nav>
-          {calendar}          
+        <Calendar/>
       </div>
     );
   }

--- a/gulp/src/analytics/components/Header/Header.js
+++ b/gulp/src/analytics/components/Header/Header.js
@@ -3,73 +3,73 @@ import {Component} from 'react';
 import {connect} from 'react-redux';
 import moment from 'moment';
 import {Button} from 'react-bootstrap';
-import {doSetSelectedMonth} from '../../actions/calendar-actions';
-import {doSetSelectedYear} from '../../actions/calendar-actions';
-import {doSetSelectedDay} from '../../actions/calendar-actions';
-import CalendarPanel from 'common/ui/CalendarPanel';
-import RangeSelection from '../Calendar/RangeSelection';
+// import {doSetSelectedMonth} from '../../actions/calendar-actions';
+// import {doSetSelectedYear} from '../../actions/calendar-actions';
+// import {doSetSelectedDay} from '../../actions/calendar-actions';
+// import CalendarPanel from 'common/ui/CalendarPanel';
+// import RangeSelection from '../Calendar/RangeSelection';
 import Calendar from '../Calendar/Calendar';
 
 class Header extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      displayCalendar: false,
-    };
-  }
-  daySelected(day) {
-    const {dispatch} = this.props;
-    dispatch(doSetSelectedDay(day));
-  }
-  updateMonth(month) {
-    const {dispatch} = this.props;
-    dispatch(doSetSelectedMonth(month));
-  }
-  updateYear(year) {
-    const {dispatch} = this.props;
-    dispatch(doSetSelectedYear(year));
-  }
-  generateYearChoices() {
-    const now = new Date();
-    const numberOfYears = 50;
-    let offset = 0;
-    // how many years should come before and after the current year
-    const pivot = numberOfYears % 2 === 0 ? numberOfYears - 1 : numberOfYears;
-    offset = Math.floor(pivot / 2);
-    const startYear = now.getFullYear() + offset;
-
-    const yearChoices = [];
-    for (let i = 0; i < numberOfYears; i++) {
-      yearChoices.push({
-        value: (startYear - i),
-        display: (startYear - i).toString(),
-      });
-    }
-    return yearChoices;
-  }
-  showCalendar() {
-    this.setState({
-      displayCalendar: true,
-    });
-  }
+  // constructor(props) {
+  //   super(props);
+  //   this.state = {
+  //     displayCalendar: false,
+  //   };
+  // }
+  // daySelected(day) {
+  //   const {dispatch} = this.props;
+  //   dispatch(doSetSelectedDay(day));
+  // }
+  // updateMonth(month) {
+  //   const {dispatch} = this.props;
+  //   dispatch(doSetSelectedMonth(month));
+  // }
+  // updateYear(year) {
+  //   const {dispatch} = this.props;
+  //   dispatch(doSetSelectedYear(year));
+  // }
+  // generateYearChoices() {
+  //   const now = new Date();
+  //   const numberOfYears = 50;
+  //   let offset = 0;
+  //   // how many years should come before and after the current year
+  //   const pivot = numberOfYears % 2 === 0 ? numberOfYears - 1 : numberOfYears;
+  //   offset = Math.floor(pivot / 2);
+  //   const startYear = now.getFullYear() + offset;
+  //
+  //   const yearChoices = [];
+  //   for (let i = 0; i < numberOfYears; i++) {
+  //     yearChoices.push({
+  //       value: (startYear - i),
+  //       display: (startYear - i).toString(),
+  //     });
+  //   }
+  //   return yearChoices;
+  // }
+  // showCalendar() {
+  //   this.setState({
+  //     displayCalendar: true,
+  //   });
+  // }
   render() {
-    const {analytics} = this.props;
-    console.log(analytics);
+    // const {analytics} = this.props;
+    // console.log(analytics);
     const localizeTime = moment().format('LT');
     const localizeDate = moment().format('MMMM Do, YYYY');
-    const day = analytics.day;
-    const month = analytics.month;
-    const year = analytics.year;
-
-    const calendar = ( <CalendarPanel
-                      year={year}
-                      month={month}
-                      day={day}
-                      onYearChange={y => this.updateYear(y)}
-                      onMonthChange={m => this.updateMonth(m)}
-                      onSelect={d => this.daySelected(d)}
-                      yearChoices={this.generateYearChoices()}
-                    />);
+    // const day = analytics.day;
+    // const month = analytics.month;
+    // const year = analytics.year;
+    //
+    // const calendar = ( <CalendarPanel
+    //                   year={year}
+    //                   month={month}
+    //                   day={day}
+    //                   onYearChange={y => this.updateYear(y)}
+    //                   onMonthChange={m => this.updateMonth(m)}
+    //                   onSelect={d => this.daySelected(d)}
+    //                   yearChoices={this.generateYearChoices()}
+    //                 />);
 
     return (
       <div className="tabs-header">
@@ -77,7 +77,7 @@ class Header extends Component {
           <i className="open-mobile fa fa-arrow-circle-right" aria-hidden="true"></i>
           <ul className="nav navbar-nav navbar-right right-options">
             <li>
-              <Button onClick={this.showCalendar.bind(this)} className="selected-date-range-btn">
+              <Button className="selected-date-range-btn">
                   <i className="head-icon fa fa-calendar" aria-hidden="true"></i>
                   <span className="dashboard-date">{localizeDate} {localizeTime}</span>
               </Button>

--- a/gulp/src/analytics/components/Header/Header.js
+++ b/gulp/src/analytics/components/Header/Header.js
@@ -3,49 +3,30 @@ import {Component} from 'react';
 import {connect} from 'react-redux';
 import moment from 'moment';
 import {Button} from 'react-bootstrap';
+import {doSetSelectedMonth} from '../../actions/calendar-actions';
+import {doSetSelectedYear} from '../../actions/calendar-actions';
 import CalendarPanel from 'common/ui/CalendarPanel';
 
 class Header extends Component {
   constructor(props) {
     super(props);
-    let year;
-    let month;
-    let day;
-
-    const momentObject = moment('YYYY-MM-DD');
-    day = momentObject.date();
-    month = momentObject.month();
-    year = momentObject.year();
 
     this.state = {
-      year: year,
-      month: month,
-      day: day,
       displayCalendar: true,
-      dateInvalid: false,
     };
   }
-  onMouseInCalendar(value) {
-    this.setState({mouseInCalendar: value});
+  // onSelect(d) {
+  //
+  // }
+  updateMonth(month) {
+    const {dispatch} = this.props;
+    dispatch(doSetSelectedMonth(month));
   }
-  // updateYear(year) {
-  //   const {onChange, value} = this.props;
-  //
-  //   if (!moment(value, 'MM/DD/YYYY', true).isValid()) {
-  //     this.resetDateToNow();
-  //   }
-  //
-  //   const fakeEvent = {};
-  //   fakeEvent.target = {};
-  //   fakeEvent.target.name = this.props.name;
-  //   fakeEvent.target.type = 'calendar-year';
-  //   fakeEvent.target.value = year;
-  //   onChange(fakeEvent);
-  // }
-  // onDaySelect(day) {
-  //   this.updateDay(day);
-  //   this.closeCalendar();
-  // }
+  updateYear(year) {
+    const {dispatch} = this.props;
+    dispatch(doSetSelectedYear(year));
+    // console.log('Analytics', analytics);
+  }
   generateYearChoices() {
     const now = new Date();
     const numberOfYears = 50;
@@ -64,91 +45,24 @@ class Header extends Component {
     }
     return yearChoices;
   }
-  // updateDay(day) {
-  //   const {onChange, value} = this.props;
-  //
-  //   if (!moment(value, 'MM/DD/YYYY', true).isValid()) {
-  //     this.resetDateToNow();
-  //   }
-  //
-  //   const fakeEvent = {};
-  //   fakeEvent.target = {};
-  //   fakeEvent.target.name = this.props.name;
-  //   fakeEvent.target.type = 'calendar-day';
-  //   fakeEvent.target.value = day.day;
-  //   onChange(fakeEvent);
-  // }
-  // updateMonth(month) {
-  //   const {onChange, value} = this.props;
-  //
-  //   if (!moment(value, 'MM/DD/YYYY', true).isValid()) {
-  //     this.resetDateToNow();
-  //   }
-  //
-  //   const fakeEvent = {};
-  //   fakeEvent.target = {};
-  //   fakeEvent.target.name = this.props.name;
-  //   fakeEvent.target.type = 'calendar-month';
-  //   fakeEvent.target.value = month;
-  //   onChange(fakeEvent);
-  // }
-
-  // updateYear(year) {
-  //   const {onChange, value} = this.props;
-  //
-  //   if (!moment(value, 'MM/DD/YYYY', true).isValid()) {
-  //     this.resetDateToNow();
-  //   }
-  //
-  //   const fakeEvent = {};
-  //   fakeEvent.target = {};
-  //   fakeEvent.target.name = this.props.name;
-  //   fakeEvent.target.type = 'calendar-year';
-  //   fakeEvent.target.value = year;
-  //   onChange(fakeEvent);
-  // }
-  openCalendar() {
-    const {value} = this.props;
-    // Check if date is valid
-    // If not, replace with what it was on page load (what was passed in or today's date
-    if (!moment(value, 'MM/DD/YYYY', true).isValid()) {
-      this.resetDateToNow();
-    }
-    this.setState({displayCalendar: true});
-  }
-  closeCalendar() {
-    this.setState({displayCalendar: false});
-  }
   render() {
+    const {analytics} = this.props;
     const localizeTime = moment().format('LT');
     const localizeDate = moment().format('MMMM Do, YYYY');
-    const dateObject = new Date();
-    const day = dateObject.getDay();
-    const month = dateObject.getMonth();
-    const year = dateObject.getFullYear();
+    const day = analytics.day;
+    const month = analytics.month;
+    const year = analytics.year;
 
-    // Handle error message
-    // let errorMessage;
-    // if (error) {
-    //   errorMessage = error;
-    // }
-
-    // let errorComponent;
-    // if (errorMessage) {
-    //   errorComponent = (
-    //     <div className="error-text">{errorMessage}</div>
-    //   );
-    // }
     let calendar;
     if (this.state.displayCalendar) {
       calendar = ( <CalendarPanel
                       year={year}
-                      yearChoices={this.generateYearChoices()}
                       month={month}
                       day={day}
-                      onSelect={d => console.log('Select Change', d)}
-                      onYearChange={y => console.log('Year Change', y)}
-                      onMonthChange={m => console.log('Month Change', m)}
+                      onYearChange={y => this.updateYear(y)}
+                      onMonthChange={m => this.updateMonth(m)}
+                      onSelect={d => this.onSelect(d)}
+                      yearChoices={this.generateYearChoices()}
                     />);
     }
     return (
@@ -157,7 +71,7 @@ class Header extends Component {
           <i className="open-mobile fa fa-arrow-circle-right" aria-hidden="true"></i>
           <ul className="nav navbar-nav navbar-right right-options">
             <li>
-              <Button onClick={() => this.onMouseInCalendar(true)} className="selected-date-range-btn">
+              <Button className="selected-date-range-btn">
                   <i className="head-icon fa fa-calendar" aria-hidden="true"></i>
                   <span className="dashboard-date">{localizeDate} {localizeTime}</span>
               </Button>
@@ -174,33 +88,8 @@ class Header extends Component {
 }
 
 Header.propTypes = {
-  // onChange: React.PropTypes.func.isRequired,
-  /**
-   * Value at first page load
-   */
-  value: React.PropTypes.string,
-  /**
-   * Should this component be shown or not?
-   */
-  isHidden: React.PropTypes.bool,
-  /**
-   * Should this bad boy focus, all auto like?
-   */
-  autoFocus: React.PropTypes.string,
-  /**
-   * Validation error
-   */
-  error: React.PropTypes.string,
-
-  /**
-  * How many years to include in the year selection
-  */
-  numberOfYears: React.PropTypes.number,
-  /** Whether or not to only include past years. When false, the current year
-  * is used as a pivot and half of the selectable years will fall before, and
-  * half of them will fall after it.
-  */
-  pastOnly: React.PropTypes.bool,
+  dispatch: React.PropTypes.func.isRequired,
+  analytics: React.PropTypes.object.isRequired,
 };
 
 export default connect(state => ({

--- a/gulp/src/analytics/components/Header/Header.js
+++ b/gulp/src/analytics/components/Header/Header.js
@@ -28,19 +28,31 @@ class Header extends Component {
   onMouseInCalendar(value) {
     this.setState({mouseInCalendar: value});
   }
+  // updateYear(year) {
+  //   const {onChange, value} = this.props;
+  //
+  //   if (!moment(value, 'MM/DD/YYYY', true).isValid()) {
+  //     this.resetDateToNow();
+  //   }
+  //
+  //   const fakeEvent = {};
+  //   fakeEvent.target = {};
+  //   fakeEvent.target.name = this.props.name;
+  //   fakeEvent.target.type = 'calendar-year';
+  //   fakeEvent.target.value = year;
+  //   onChange(fakeEvent);
+  // }
   // onDaySelect(day) {
   //   this.updateDay(day);
   //   this.closeCalendar();
   // }
   generateYearChoices() {
-    const {pastOnly, numberOfYears} = this.props;
     const now = new Date();
+    const numberOfYears = 50;
     let offset = 0;
-    if (!pastOnly) {
-      // how many years should come before and after the current year
-      const pivot = numberOfYears % 2 === 0 ? numberOfYears - 1 : numberOfYears;
-      offset = Math.floor(pivot / 2);
-    }
+    // how many years should come before and after the current year
+    const pivot = numberOfYears % 2 === 0 ? numberOfYears - 1 : numberOfYears;
+    offset = Math.floor(pivot / 2);
     const startYear = now.getFullYear() + offset;
 
     const yearChoices = [];
@@ -110,21 +122,16 @@ class Header extends Component {
   render() {
     const localizeTime = moment().format('LT');
     const localizeDate = moment().format('MMMM Do, YYYY');
-    let momentObject = moment('MM/DD/YYYY');
-    let day;
-    let month;
-    let year;
+    const dateObject = new Date();
+    const day = dateObject.getDay();
+    const month = dateObject.getMonth();
+    const year = dateObject.getFullYear();
 
     // Handle error message
     // let errorMessage;
     // if (error) {
     //   errorMessage = error;
     // }
-
-      momentObject = moment('MM/DD/YYYY');
-      day = momentObject.date();
-      month = momentObject.month();
-      year = momentObject.year();
 
     // let errorComponent;
     // if (errorMessage) {
@@ -142,8 +149,6 @@ class Header extends Component {
                       onSelect={d => console.log('Select Change', d)}
                       onYearChange={y => console.log('Year Change', y)}
                       onMonthChange={m => console.log('Month Change', m)}
-                      closeCalendar={() => this.closeCalendar()}
-                      pastOnly
                     />);
     }
     return (

--- a/gulp/src/analytics/components/Header/Header.js
+++ b/gulp/src/analytics/components/Header/Header.js
@@ -13,9 +13,31 @@ class Header extends Component {
       showPicker: false,
     };
   }
+  componentDidMount() {
+    window.addEventListener('mousedown', this.pageClick.bind(this), false);
+  }
+  pageClick() {
+    if (this.mouseIsDownOnCalendar) {
+      return;
+    }
+    this.setState({
+      showPicker: false,
+    });
+  }
+  mouseDownHandler() {
+    this.mouseIsDownOnCalendar = true;
+  }
+  mouseUpHandler() {
+    this.mouseIsDownOnCalendar = false;
+  }
   showCalendarRangePicker() {
     this.setState({
       showPicker: true,
+    });
+  }
+  hideCalendarRangePicker() {
+    this.setState({
+      showPicker: false,
     });
   }
   render() {
@@ -37,7 +59,7 @@ class Header extends Component {
             <li><a href="#"><span className="head-icon fa fa-file-excel-o"></span></a></li>
           </ul>
         </nav>
-        <Calendar showCalendarRangePicker={this.state.showPicker}/>
+        <Calendar onMouseDown={this.mouseDownHandler.bind(this)} onMouseUp={this.mouseUpHandler.bind(this)} showCalendarRangePicker={this.state.showPicker} hideCalendarRangePicker={this.hideCalendarRangePicker.bind(this)}/>
       </div>
     );
   }

--- a/gulp/src/analytics/components/Header/Header.js
+++ b/gulp/src/analytics/components/Header/Header.js
@@ -3,81 +3,31 @@ import {Component} from 'react';
 import {connect} from 'react-redux';
 import moment from 'moment';
 import {Button} from 'react-bootstrap';
-// import {doSetSelectedMonth} from '../../actions/calendar-actions';
-// import {doSetSelectedYear} from '../../actions/calendar-actions';
-// import {doSetSelectedDay} from '../../actions/calendar-actions';
-// import CalendarPanel from 'common/ui/CalendarPanel';
-// import RangeSelection from '../Calendar/RangeSelection';
 import Calendar from '../Calendar/Calendar';
 
 class Header extends Component {
-  // constructor(props) {
-  //   super(props);
-  //   this.state = {
-  //     displayCalendar: false,
-  //   };
-  // }
-  // daySelected(day) {
-  //   const {dispatch} = this.props;
-  //   dispatch(doSetSelectedDay(day));
-  // }
-  // updateMonth(month) {
-  //   const {dispatch} = this.props;
-  //   dispatch(doSetSelectedMonth(month));
-  // }
-  // updateYear(year) {
-  //   const {dispatch} = this.props;
-  //   dispatch(doSetSelectedYear(year));
-  // }
-  // generateYearChoices() {
-  //   const now = new Date();
-  //   const numberOfYears = 50;
-  //   let offset = 0;
-  //   // how many years should come before and after the current year
-  //   const pivot = numberOfYears % 2 === 0 ? numberOfYears - 1 : numberOfYears;
-  //   offset = Math.floor(pivot / 2);
-  //   const startYear = now.getFullYear() + offset;
-  //
-  //   const yearChoices = [];
-  //   for (let i = 0; i < numberOfYears; i++) {
-  //     yearChoices.push({
-  //       value: (startYear - i),
-  //       display: (startYear - i).toString(),
-  //     });
-  //   }
-  //   return yearChoices;
-  // }
-  // showCalendar() {
-  //   this.setState({
-  //     displayCalendar: true,
-  //   });
-  // }
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      showPicker: false,
+    };
+  }
+  showCalendarRangePicker() {
+    this.setState({
+      showPicker: true,
+    });
+  }
   render() {
-    // const {analytics} = this.props;
-    // console.log(analytics);
     const localizeTime = moment().format('LT');
     const localizeDate = moment().format('MMMM Do, YYYY');
-    // const day = analytics.day;
-    // const month = analytics.month;
-    // const year = analytics.year;
-    //
-    // const calendar = ( <CalendarPanel
-    //                   year={year}
-    //                   month={month}
-    //                   day={day}
-    //                   onYearChange={y => this.updateYear(y)}
-    //                   onMonthChange={m => this.updateMonth(m)}
-    //                   onSelect={d => this.daySelected(d)}
-    //                   yearChoices={this.generateYearChoices()}
-    //                 />);
-
     return (
       <div className="tabs-header">
         <nav>
           <i className="open-mobile fa fa-arrow-circle-right" aria-hidden="true"></i>
           <ul className="nav navbar-nav navbar-right right-options">
             <li>
-              <Button className="selected-date-range-btn">
+              <Button onClick={this.showCalendarRangePicker.bind(this)} className="selected-date-range-btn">
                   <i className="head-icon fa fa-calendar" aria-hidden="true"></i>
                   <span className="dashboard-date">{localizeDate} {localizeTime}</span>
               </Button>
@@ -87,7 +37,7 @@ class Header extends Component {
             <li><a href="#"><span className="head-icon fa fa-file-excel-o"></span></a></li>
           </ul>
         </nav>
-        <Calendar/>
+        <Calendar showCalendarRangePicker={this.state.showPicker}/>
       </div>
     );
   }

--- a/gulp/src/analytics/components/Header/Header.js
+++ b/gulp/src/analytics/components/Header/Header.js
@@ -5,6 +5,7 @@ import moment from 'moment';
 import {Button} from 'react-bootstrap';
 import {doSetSelectedMonth} from '../../actions/calendar-actions';
 import {doSetSelectedYear} from '../../actions/calendar-actions';
+import {doSetSelectedDay} from '../../actions/calendar-actions';
 import CalendarPanel from 'common/ui/CalendarPanel';
 
 class Header extends Component {
@@ -15,9 +16,10 @@ class Header extends Component {
       displayCalendar: true,
     };
   }
-  // onSelect(d) {
-  //
-  // }
+  daySelected(day) {
+    const {dispatch} = this.props;
+    dispatch(doSetSelectedDay(day));
+  }
   updateMonth(month) {
     const {dispatch} = this.props;
     dispatch(doSetSelectedMonth(month));
@@ -25,7 +27,6 @@ class Header extends Component {
   updateYear(year) {
     const {dispatch} = this.props;
     dispatch(doSetSelectedYear(year));
-    // console.log('Analytics', analytics);
   }
   generateYearChoices() {
     const now = new Date();
@@ -47,6 +48,7 @@ class Header extends Component {
   }
   render() {
     const {analytics} = this.props;
+    console.log(analytics);
     const localizeTime = moment().format('LT');
     const localizeDate = moment().format('MMMM Do, YYYY');
     const day = analytics.day;
@@ -61,7 +63,7 @@ class Header extends Component {
                       day={day}
                       onYearChange={y => this.updateYear(y)}
                       onMonthChange={m => this.updateMonth(m)}
-                      onSelect={d => this.onSelect(d)}
+                      onSelect={d => this.daySelected(d)}
                       yearChoices={this.generateYearChoices()}
                     />);
     }
@@ -81,7 +83,7 @@ class Header extends Component {
             <li><a href="#"><span className="head-icon fa fa-file-excel-o"></span></a></li>
           </ul>
         </nav>
-        {calendar}
+          {calendar}          
       </div>
     );
   }

--- a/gulp/src/analytics/components/SideBar/SideBar.js
+++ b/gulp/src/analytics/components/SideBar/SideBar.js
@@ -2,6 +2,7 @@ import React from 'react';
 import {Component} from 'react';
 import {connect} from 'react-redux';
 import {doSwitchMainDimension} from '../../actions/sidebar-actions';
+import moment from 'moment';
 import SideBarDimension from './SideBarDimensionList';
 
 class SideBar extends Component {
@@ -9,8 +10,12 @@ class SideBar extends Component {
     super(props);
   }
   activeDimension(mainDimension) {
+    let startDate = moment();
+    const endDate = moment().format('MM/DD/YYYY H:mm:ss');
+    startDate = startDate.subtract(30, 'days');
+    startDate = startDate.format('MM/DD/YYYY');
     const {dispatch} = this.props;
-    dispatch(doSwitchMainDimension(mainDimension));
+    dispatch(doSwitchMainDimension(mainDimension, startDate, endDate));
   }
   render() {
     const {analytics} = this.props;

--- a/gulp/src/analytics/components/SideBar/SideBar.js
+++ b/gulp/src/analytics/components/SideBar/SideBar.js
@@ -14,9 +14,10 @@ class SideBar extends Component {
   }
   render() {
     const {analytics} = this.props;
+    const activeDimension = analytics.activePrimaryDimension;
     const primaryDimensions = analytics.primaryDimensions.dimensionList.reports.map((report, i) => {
       return (
-        <SideBarDimension active={this.activeDimension.bind(this, report.value)} key={i} dimension={report} />
+        <SideBarDimension selected={activeDimension} active={this.activeDimension.bind(this, report.value)} key={i} dimension={report} />
       );
     });
     return (

--- a/gulp/src/analytics/components/SideBar/SideBarDimensionList.js
+++ b/gulp/src/analytics/components/SideBar/SideBarDimensionList.js
@@ -3,9 +3,9 @@ import {Component} from 'react';
 
 class SideBarDimension extends Component {
   render() {
-    const {dimension, active} = this.props;
+    const {dimension, active, selected} = this.props;
     return (
-      <li onClick={active} className="side-dimension">
+      <li onClick={active} className={selected === dimension.value ? 'side-dimension active-main' : 'side-dimension'}>
          <span className="side-circle-btn"></span><span className="side-dimension-title">{dimension.display}</span>
       </li>
     );
@@ -15,6 +15,7 @@ class SideBarDimension extends Component {
 SideBarDimension.propTypes = {
   dimension: React.PropTypes.object.isRequired,
   active: React.PropTypes.func.isRequired,
+  selected: React.PropTypes.string.isRequired,
 };
 
 export default SideBarDimension;

--- a/gulp/src/analytics/reducers/analytics-reducer.js
+++ b/gulp/src/analytics/reducers/analytics-reducer.js
@@ -7,6 +7,11 @@ export const initialPageData = {
   navFetching: false,
   navigation: [],
   activeFilters: [],
+  month: '',
+  day: '',
+  year: '',
+  startDate: {},
+  endDate: {},
   activeReport: '',
   primaryDimensions: {},
 };
@@ -34,8 +39,8 @@ export default handleActions({
         {
           navId: navCount++,
           active: true,
-          startDate: null,
-          endDate: null,
+          startDate: {},
+          endDate: {},
           PageLoadData: action.payload,
         },
       ],
@@ -135,6 +140,41 @@ export default handleActions({
         }
         return nav;
       }),
+    };
+  },
+  'SET_CURRENT_MONTH': (state, action) => {
+    const currentMonth = action.payload;
+    return {
+      ...state,
+      month: currentMonth,
+    }
+  },
+  'SET_CURRENT_YEAR': (state, action) => {
+    const currentYear = action.payload;
+    return {
+      ...state,
+      year: currentYear,
+    }
+  },
+  'SET_CURRENT_DAY': (state, action) => {
+    const currentDay = action.payload;
+    return {
+      ...state,
+      day: currentDay,
+    }
+  },
+  'SET_SELECTED_MONTH': (state, action) => {
+    const selectedMonth = action.payload;
+    return {
+      ...state,
+      month: selectedMonth,
+    };
+  },
+  'SET_SELECTED_YEAR': (state, action) => {
+    const selectedYear = action.payload;
+    return {
+      ...state,
+      year: selectedYear,
     };
   },
 }, initialPageData);

--- a/gulp/src/analytics/reducers/analytics-reducer.js
+++ b/gulp/src/analytics/reducers/analytics-reducer.js
@@ -193,4 +193,20 @@ export default handleActions({
       day: selectedDay,
     };
   },
+  'SET_SELECTED_RANGE': (state, action) => {
+    const selectedRangeData = action.payload;
+    console.log('Selected Range: ', selectedRangeData);
+    return {
+      ...state,
+      navigation: state.navigation.map((nav) => {
+        if (nav.active === true) {
+          return {
+            ...nav,
+            PageLoadData: selectedRangeData,
+          };
+        }
+        return nav;
+      }),
+    };
+  },
 }, initialPageData);

--- a/gulp/src/analytics/reducers/analytics-reducer.js
+++ b/gulp/src/analytics/reducers/analytics-reducer.js
@@ -147,21 +147,21 @@ export default handleActions({
     return {
       ...state,
       month: currentMonth,
-    }
+    };
   },
   'SET_CURRENT_YEAR': (state, action) => {
     const currentYear = action.payload;
     return {
       ...state,
       year: currentYear,
-    }
+    };
   },
   'SET_CURRENT_DAY': (state, action) => {
     const currentDay = action.payload;
     return {
       ...state,
       day: currentDay,
-    }
+    };
   },
   'SET_SELECTED_MONTH': (state, action) => {
     const selectedMonth = action.payload;
@@ -175,6 +175,13 @@ export default handleActions({
     return {
       ...state,
       year: selectedYear,
+    };
+  },
+  'SET_SELECTED_DAY': (state, action) => {
+    const selectedDay = action.payload;
+    return {
+      ...state,
+      day: selectedDay,
     };
   },
 }, initialPageData);

--- a/gulp/src/analytics/reducers/analytics-reducer.js
+++ b/gulp/src/analytics/reducers/analytics-reducer.js
@@ -14,6 +14,7 @@ export const initialPageData = {
   endDate: {},
   activeReport: '',
   primaryDimensions: {},
+  activePrimaryDimension: '',
 };
 
 export default handleActions({
@@ -49,6 +50,7 @@ export default handleActions({
   'SET_PRIMARY_DIMENSIONS': (state, action) => {
     return {
       ...state,
+      activePrimaryDimension: action.payload.reports[0].value,
       primaryDimensions: {
         dimensionList: action.payload,
       },
@@ -128,6 +130,13 @@ export default handleActions({
         },
       ],
       activeFilters: [],
+    };
+  },
+  'SET_MAIN_DIMENSION': (state, action) => {
+    const activeMainDimension = action.payload;
+    return {
+      ...state,
+      activePrimaryDimension: activeMainDimension,
     };
   },
   'REMOVE_SELECTED_TAB': (state, action) => {

--- a/gulp/src/analytics/reducers/analytics-reducer.js
+++ b/gulp/src/analytics/reducers/analytics-reducer.js
@@ -195,7 +195,6 @@ export default handleActions({
   },
   'SET_SELECTED_RANGE': (state, action) => {
     const selectedRangeData = action.payload;
-    console.log('Selected Range: ', selectedRangeData);
     return {
       ...state,
       navigation: state.navigation.map((nav) => {

--- a/gulp/src/sass/analytics.scss
+++ b/gulp/src/sass/analytics.scss
@@ -115,6 +115,10 @@ a {
           color: $primary-blue;
         }
       }
+      .side-dimension.active-main {
+        background: $light-gray;
+        color: $primary-blue;
+      }
       .side-dimension.active{
         border-left: 5px solid $white;
         padding: 25px 50px;
@@ -151,10 +155,10 @@ a {
   opacity: 1;
   transition: all 300ms;
 }
-.side-dimension:hover .side-circle-btn {
+.side-dimension:hover .side-circle-btn, .side-dimension.active-main .side-circle-btn {
   background: $primary-blue;
 }
-.side-dimension:hover .side-circle-btn:before {
+.side-dimension:hover .side-circle-btn:before, .side-dimension.active-main .side-circle-btn:before {
   border: 5px solid $primary-blue;
   -webkit-box-shadow: inset 0px 0px 0px 4px rgba(90, 109, 129, 1);
   -moz-box-shadow: inset 0px 0px 0px 4px rgba(90, 109, 129, 1);

--- a/gulp/src/sass/analytics.scss
+++ b/gulp/src/sass/analytics.scss
@@ -316,6 +316,18 @@ a {
 
 /*CSS FOR THE CALENDAR*/
 
+.calendar-container.active-picker {
+  display: block;
+}
+.calendar-container.non-active-picker {
+  display: none;
+}
+.hide-calendar {
+  display: none;
+}
+.show-calendar {
+  float: left;
+}
 .calendar-container {
   display: block;
   position: absolute;
@@ -324,6 +336,10 @@ a {
   z-index: 99;
 }
 
+.calendar-pick {
+  border: 1px solid $primary-blue;
+  background: $white;
+}
 // .calendar-container.active {
 //   display: block;
 //   position: absolute;
@@ -333,7 +349,6 @@ a {
 // }
 
 .calendar-panel {
-  border: 1px solid $primary-blue;
   background: $white;
   padding: 17px;
 }
@@ -342,6 +357,7 @@ a {
   background: $white;
   border: 1px solid $black;
   z-index: 99;
+  float: left;
 }
 .range-selections {
   margin: 0;

--- a/gulp/src/sass/analytics.scss
+++ b/gulp/src/sass/analytics.scss
@@ -331,7 +331,7 @@ a {
 .calendar-panel {
   border: 1px solid $primary-blue;
   background: $white;
-  padding: 15px;
+  padding: 17px;
 }
 
 .range-container {
@@ -378,6 +378,9 @@ a {
   color: $primary-blue
 }
 
+.calendar-pick {
+  display: inline-block;
+}
 
 /*CSS FOR THE CHARTS SECTION*/
 

--- a/gulp/src/sass/analytics.scss
+++ b/gulp/src/sass/analytics.scss
@@ -310,6 +310,8 @@ a {
   display: none;
 }
 
+/*CSS FOR THE CALENDAR*/
+
 .calendar-panel {
   position: absolute;
   right: 200px;
@@ -319,6 +321,7 @@ a {
   background: $white;
   padding: 15px;
 }
+
 
 /*CSS FOR THE CHARTS SECTION*/
 

--- a/gulp/src/sass/analytics.scss
+++ b/gulp/src/sass/analytics.scss
@@ -310,6 +310,16 @@ a {
   display: none;
 }
 
+.calendar-panel {
+  position: absolute;
+  right: 200px;
+  top: 60px;
+  z-index: 99;
+  border: 1px solid $primary-blue;
+  background: $white;
+  padding: 15px;
+}
+
 /*CSS FOR THE CHARTS SECTION*/
 
 .charts {

--- a/gulp/src/sass/analytics.scss
+++ b/gulp/src/sass/analytics.scss
@@ -312,14 +312,70 @@ a {
 
 /*CSS FOR THE CALENDAR*/
 
-.calendar-panel {
+.calendar-container {
+  display: block;
   position: absolute;
-  right: 200px;
+  right: 175px;
   top: 60px;
   z-index: 99;
+}
+
+// .calendar-container.active {
+//   display: block;
+//   position: absolute;
+//   right: 200px;
+//   top: 60px;
+//   z-index: 99;
+// }
+
+.calendar-panel {
   border: 1px solid $primary-blue;
   background: $white;
   padding: 15px;
+}
+
+.range-container {
+  background: $white;
+  border: 1px solid $black;
+  z-index: 99;
+}
+.range-selections {
+  margin: 0;
+  padding: 0;
+}
+.range {
+  background: $primary-blue;
+  text-align: center;
+  border-bottom: 1px solid $white;
+  padding: 10px 20px;
+  color: $white;
+  font-size: 14px;
+}
+.range:hover {
+  cursor: pointer;
+  background: $white;
+  color: $primary-blue;
+}
+.apply-cancel {
+  text-align: center;
+  padding: 10px 20px;
+}
+.range-btn {
+  padding: 5px 5px;
+  border: none;
+  color: white;
+  border-radius: 5px;
+}
+.apply-range {
+  background: #63AB62;
+  color: $white;
+  border: 1px solid #63AB62;
+  margin-right: 10px;
+}
+.cancel-range {
+  background: $white;
+  border: 1px solid $primary-blue;
+  color: $primary-blue
 }
 
 


### PR DESCRIPTION
This task was to replace the bootstrap daterangpicker with one that we currently have.

To Test:
Pull down the repository. You can click on the button with the Date in the header and see the calendar come down. The first part is the quick range selections which will trigger an API call and you can see the correct data going into the table in terms of filtering. You can also see the response coming back in the network Tab. If you click custom range inside of the dropdown it will pop out the calendar which has NOT been linked as of yet. This is be a different PR to set it with two calendars as a date range selection.