### PR TITLE
[PD-2798] added 2 additional steps to the Deployment Checklist

### DIFF
--- a/doc/source/developers/deployment/checklist.rst
+++ b/doc/source/developers/deployment/checklist.rst
@@ -48,6 +48,7 @@ Redirects Integrity
 Search
 ------
 
+- The second keystroke should show the autocomplete drop down list
 - Searching for a keyword returns correct results
 - Searching for a location returns correct results
 - Searching for both keyword and location returns correct results
@@ -63,6 +64,7 @@ Navigation
 - Adding a filter in the side bar works
 - Removing a filter in the side bar works
 - Active filters and search terms both show in the sidebar correctly
+- "Show More" and "Show Less" buttons should work like they're supposed to
 
 
 Secure.my.jobs


### PR DESCRIPTION
**Purpose**:  Until I can add a testing framework that can inject a DOM to work with our Jasmine, I'm adding 2 more steps to our Deployment checklist.

To "**Test**":

1.  In MyJobs > doc > source > developers > deployment > checklist.rst, 

My Modifications are as follows, hopefully it will appear in the Deployment Checklist:

A.  Under the "Search" section, " - The second keystroke should show the autocomplete drop down list"

B.  Under the "Navigation" section, "- "Show More" and "Show Less" buttons should work like they're supposed to"

