### PR TITLE
[PD 2814] date changing on table filter request

### DIFF
--- a/gulp/src/analytics/actions/calendar-actions.js
+++ b/gulp/src/analytics/actions/calendar-actions.js
@@ -7,7 +7,7 @@ export const setSelectedDay = createAction('SET_SELECTED_DAY');
 export const setSelectedRange = createAction('SET_SELECTED_RANGE');
 
 /**
- * This action sets the current month selected from the Calendar
+ * This action sets the current month selected from the Calendar ONLY
  */
 export function doSetSelectedMonth(month) {
   return async(dispatch) => {
@@ -16,7 +16,7 @@ export function doSetSelectedMonth(month) {
   };
 }
 /**
- * This action sets the current year selected from the Calendar
+ * This action sets the current year selected from the Calendar ONLY
  */
 export function doSetSelectedYear(year) {
   return async(dispatch) => {
@@ -25,7 +25,7 @@ export function doSetSelectedYear(year) {
   };
 }
 /**
- * This action sets the current day selected from the Calendar
+ * This action sets the current day selected from the Calendar ONLY
  */
 export function doSetSelectedDay(day) {
   return async(dispatch) => {
@@ -37,14 +37,20 @@ export function doSetSelectedDay(day) {
  * This action sets the selected range from the quick range selections, not the Calendar
  */
 export function doSetSelectedRange(start, end, mainDimension, activeFilters) {
-  return async(dispatch, _, {api}) => {
+  return async(dispatch, getState, {api}) => {
     dispatch(markNavLoadingAction(true));
     const currentStartRange = start;
     const currentEndRange = end;
     const currentDimension = mainDimension;
     const currentFilters = activeFilters;
     const rangeData = await api.getDateRangeData(currentStartRange, currentEndRange, currentDimension, currentFilters);
-    dispatch(setSelectedRange(rangeData));
+    // Creating object to send to reducer with date range data and start and end dates
+    const updatedRangeData = {
+      data: rangeData,
+      startDate: start,
+      endDate: end,
+    };
+    dispatch(setSelectedRange(updatedRangeData));
     dispatch(markNavLoadingAction(false));
   };
 }

--- a/gulp/src/analytics/actions/calendar-actions.js
+++ b/gulp/src/analytics/actions/calendar-actions.js
@@ -37,7 +37,7 @@ export function doSetSelectedDay(day) {
  * This action sets the selected range from the quick range selections, not the Calendar
  */
 export function doSetSelectedRange(start, end, mainDimension, activeFilters) {
-  return async(dispatch, getState, {api}) => {
+  return async(dispatch, _, {api}) => {
     dispatch(markNavLoadingAction(true));
     const currentStartRange = start;
     const currentEndRange = end;

--- a/gulp/src/analytics/actions/page-loading-actions.js
+++ b/gulp/src/analytics/actions/page-loading-actions.js
@@ -16,9 +16,15 @@ export function doGetPageData(start, end, currentMonth, currentDay, currentYear)
   return async (dispatch, _, {api}) => {
     dispatch(markPageLoadingAction(true));
     const rawPageData = await api.getInitialPageData(start, end);
+    // Creating object of data coming back from the API along with the starting and ending date to send to reducer
+    const allLoadData = {
+      startDate: start,
+      endDate: end,
+      pageData: rawPageData,
+    };
     const dimensionData = await api.getPrimaryDimensions();
     const reportType = await api.getStartingPointReport();
-    dispatch(setPageData(rawPageData));
+    dispatch(setPageData(allLoadData));
     dispatch(setCurrentMonth(currentMonth));
     dispatch(setCurrentYear(currentYear));
     dispatch(setCurrentDay(currentDay));

--- a/gulp/src/analytics/actions/sidebar-actions.js
+++ b/gulp/src/analytics/actions/sidebar-actions.js
@@ -28,7 +28,13 @@ export function doSwitchMainDimension(mainDimension, start, end) {
     dispatch(markNavLoadingAction(true));
     dispatch(storeActiveReport(mainDimension));
     const currentDimensionData = await api.getMainDimensionData(mainDimension, start, end);
-    dispatch(switchMainDimension(currentDimensionData));
+    // Creating object of data coming back from the API along with the starting and ending date to send to reducer when the main dimension is changed
+    const allLoadData = {
+      startDate: start,
+      endDate: end,
+      pageData: currentDimensionData,
+    };
+    dispatch(switchMainDimension(allLoadData));
     dispatch(markNavLoadingAction(false));
     dispatch(setMainDimension(mainDimension));
   };

--- a/gulp/src/analytics/actions/table-filter-actions.js
+++ b/gulp/src/analytics/actions/table-filter-actions.js
@@ -22,12 +22,27 @@ export function doGetSelectedFilterData(tableValue, typeValue) {
     dispatch(doStoreActiveFilter(typeValue, tableValue));
     // Storing the current filters inside of the state to send off in the request to the API
     const storedFilters = [];
+    let storedDates;
     getState().pageLoadData.activeFilters.map((filter) => {
       storedFilters.push(filter);
     });
+    getState().pageLoadData.navigation.map((nav) => {
+      if (nav.active) {
+        storedDates = {
+          startDate: nav.startDate,
+          endDate: nav.endDate,
+        };
+      }
+    });
+    console.log('Current State: ', getState());
+    console.log('Stored Dates: ', storedDates);
     const currentReport = getState().pageLoadData.activeReport;
-    const selectedFilterData = await api.getSelectedFilterData(tableValue, typeValue, storedFilters, currentReport);
-    dispatch(setSelectedFilterData(selectedFilterData));
+    const selectedFilterData = await api.getSelectedFilterData(tableValue, typeValue, storedFilters, currentReport, storedDates);
+    const navFilterData = {
+      data: selectedFilterData,
+      date: storedDates,
+    };
+    dispatch(setSelectedFilterData(navFilterData));
     dispatch(markNavLoadingAction(false));
   };
 }

--- a/gulp/src/analytics/actions/table-filter-actions.js
+++ b/gulp/src/analytics/actions/table-filter-actions.js
@@ -22,6 +22,7 @@ export function doGetSelectedFilterData(tableValue, typeValue) {
     dispatch(doStoreActiveFilter(typeValue, tableValue));
     // Storing the current filters inside of the state to send off in the request to the API
     const storedFilters = [];
+    // Storing the dates in order to update the reducer with them
     let storedDates;
     getState().pageLoadData.activeFilters.map((filter) => {
       storedFilters.push(filter);
@@ -34,10 +35,10 @@ export function doGetSelectedFilterData(tableValue, typeValue) {
         };
       }
     });
-    console.log('Current State: ', getState());
-    console.log('Stored Dates: ', storedDates);
+    // Grabbing the current report selected from the state to send to the API
     const currentReport = getState().pageLoadData.activeReport;
     const selectedFilterData = await api.getSelectedFilterData(tableValue, typeValue, storedFilters, currentReport, storedDates);
+    // Creating object from the filter selection data to send off to the reducer to update
     const navFilterData = {
       data: selectedFilterData,
       date: storedDates,

--- a/gulp/src/analytics/api.js
+++ b/gulp/src/analytics/api.js
@@ -30,10 +30,10 @@ export default class Api {
     return setStartingPointReport.reports[0].value;
   }
   // Get the data requested from filtering on the table
-  async getSelectedFilterData(tableValue, typeValue, storedFilters, currentReport) {
+  async getSelectedFilterData(tableValue, typeValue, storedFilters, currentReport, date) {
     const selectedFilterRequest = {
-      'date_start': '12/01/2016 00:00:00',
-      'date_end': '12/12/2016 23:59:59',
+      'date_start': date.startDate,
+      'date_end': date.endDate,
       'active_filters': storedFilters,
       'report': currentReport,
     };

--- a/gulp/src/analytics/components/AnalyticsApp.jsx
+++ b/gulp/src/analytics/components/AnalyticsApp.jsx
@@ -21,7 +21,6 @@ class AnalyticsApp extends React.Component {
   }
   render() {
     const {analytics} = this.props;
-    console.log('analytics data: ', analytics);
     if (analytics.pageFetching) {
       return (
         <LoadingSpinner/>

--- a/gulp/src/analytics/components/AnalyticsApp.jsx
+++ b/gulp/src/analytics/components/AnalyticsApp.jsx
@@ -21,6 +21,7 @@ class AnalyticsApp extends React.Component {
   }
   render() {
     const {analytics} = this.props;
+    console.log('analytics data: ', analytics);
     if (analytics.pageFetching) {
       return (
         <LoadingSpinner/>

--- a/gulp/src/analytics/reducers/analytics-reducer.js
+++ b/gulp/src/analytics/reducers/analytics-reducer.js
@@ -14,7 +14,8 @@ import {findIndex} from 'lodash-compat';
  *  year stores the current month for when the app boots
  *  activeReport stores the current report type for sending back to the API
  *  primaryDimensions stores the primary dimensions given back from the API to create the sidebar list
- * activePrimaryDimension stores the current primary dimension that is actively chosen at that time
+ *  activePrimaryDimension stores the current primary dimension that is actively chosen at that time
+ *  startDate and endDate are added to the tab object when the page is created. They are used to store the dates for sending off to the API when the call is made
  */
 
 let navCount = 1;
@@ -136,13 +137,16 @@ export default handleActions({
     };
   },
   'SWITCH_MAIN_DIMENSION': (state, action) => {
+    const mainDimensionData = action.payload;
     return {
       ...state,
       navigation: [
         {
           navId: navCount++,
           active: true,
-          PageLoadData: action.payload,
+          startDate: mainDimensionData.startDate,
+          endDate: mainDimensionData.endDate,
+          PageLoadData: mainDimensionData.pageData,
         },
       ],
       activeFilters: [],
@@ -217,7 +221,9 @@ export default handleActions({
         if (nav.active === true) {
           return {
             ...nav,
-            PageLoadData: selectedRangeData,
+            startDate: selectedRangeData.startDate,
+            endDate: selectedRangeData.endDate,
+            PageLoadData: selectedRangeData.data,
           };
         }
         return nav;

--- a/gulp/src/analytics/reducers/analytics-reducer.js
+++ b/gulp/src/analytics/reducers/analytics-reducer.js
@@ -47,6 +47,7 @@ export default handleActions({
     };
   },
   'SET_PAGE_DATA': (state, action) => {
+    const loadData = action.payload;
     return {
       ...state,
       navigation: [
@@ -54,7 +55,9 @@ export default handleActions({
         {
           navId: navCount++,
           active: true,
-          PageLoadData: action.payload,
+          startDate: loadData.startDate,
+          endDate: loadData.endDate,
+          PageLoadData: loadData.pageData,
         },
       ],
     };
@@ -99,6 +102,7 @@ export default handleActions({
     };
   },
   'SET_SELECTED_FILTER_DATA': (state, action) => {
+    const filterData = action.payload;
     return {
       ...state,
       navigation: [
@@ -106,7 +110,9 @@ export default handleActions({
         {
           navId: navCount++,
           active: true,
-          PageLoadData: action.payload,
+          startDate: filterData.date.startDate,
+          endDate: filterData.date.endDate,
+          PageLoadData: filterData.data,
         },
       ],
     };


### PR DESCRIPTION
Task was to update the dates when filtering was done for sending off to the API.

To Test:

Pull down the repository. The best way to test this to make sure the correct request is being sent off is to check the Network Tab. You should see a fetch request sent to DYNAMIC api when the app loads for the start date and end date being 30 days. When you filter the table, you can check it again and it should still be for 30 days. You can also change the date with the quick selections from the calendar for any tab and re-filter and see it is saving the date and sending the correct request off to the API depending on which tab you filtered on and what date was selected. If you change the date in one tab and filter in that tab, the next tab will have that selected date that you changed to.