### PR TITLE
[PD 2816] creating custom range selection for calendar

### DIFF
--- a/gulp/src/analytics/actions/calendar-actions.js
+++ b/gulp/src/analytics/actions/calendar-actions.js
@@ -1,5 +1,6 @@
 import {createAction} from 'redux-actions';
 import {markNavLoadingAction} from '../../common/actions/loading-actions';
+import {errorAction} from '../../common/actions/error-actions';
 
 export const setSelectedEndMonth = createAction('SET_SELECTED_END_MONTH');
 export const setSelectedEndYear = createAction('SET_SELECTED_END_YEAR');
@@ -15,7 +16,11 @@ export const setCustomRange = createAction('SET_CUSTOM_RANGE');
  */
 export function doSetSelectedEndMonth(month) {
   return async(dispatch) => {
-    dispatch(setSelectedEndMonth(month));
+    try {
+      dispatch(setSelectedEndMonth(month));
+    } catch (error) {
+      dispatch(errorAction(error.message));
+    }
   };
 }
 /**
@@ -23,7 +28,11 @@ export function doSetSelectedEndMonth(month) {
  */
 export function doSetSelectedStartMonth(month) {
   return async(dispatch) => {
-    dispatch(setSelectedStartMonth(month));
+    try {
+      dispatch(setSelectedStartMonth(month));
+    } catch (error) {
+      dispatch(errorAction(error.message));
+    }
   };
 }
 /**
@@ -31,7 +40,11 @@ export function doSetSelectedStartMonth(month) {
  */
 export function doSetSelectedEndYear(year) {
   return async(dispatch) => {
-    dispatch(setSelectedEndYear(year));
+    try {
+      dispatch(setSelectedEndYear(year));
+    } catch (error) {
+      dispatch(errorAction(error.message));
+    }
   };
 }
 /**
@@ -39,7 +52,11 @@ export function doSetSelectedEndYear(year) {
  */
 export function doSetSelectedStartYear(year) {
   return async(dispatch) => {
-    dispatch(setSelectedStartYear(year));
+    try {
+      dispatch(setSelectedStartYear(year));
+    } catch (error) {
+      dispatch(errorAction(error.message));
+    }
   };
 }
 /**
@@ -47,8 +64,12 @@ export function doSetSelectedStartYear(year) {
  */
 export function doSetSelectedEndDay(day) {
   return async(dispatch) => {
-    const currentDay = day.day;
-    dispatch(setSelectedEndDay(currentDay));
+    try {
+      const currentDay = day.day;
+      dispatch(setSelectedEndDay(currentDay));
+    } catch (error) {
+      dispatch(errorAction(error.message));
+    }
   };
 }
 /**
@@ -56,8 +77,12 @@ export function doSetSelectedEndDay(day) {
  */
 export function doSetSelectedStartDay(day) {
   return async(dispatch) => {
-    const currentDay = day.day;
-    dispatch(setSelectedStartDay(currentDay));
+    try {
+      const currentDay = day.day;
+      dispatch(setSelectedStartDay(currentDay));
+    } catch (error) {
+      dispatch(errorAction(error.message));
+    }
   };
 }
 /**
@@ -65,20 +90,24 @@ export function doSetSelectedStartDay(day) {
  */
 export function doSetSelectedRange(start, end, mainDimension, activeFilters) {
   return async(dispatch, _, {api}) => {
-    dispatch(markNavLoadingAction(true));
-    const currentStartRange = start;
-    const currentEndRange = end;
-    const currentDimension = mainDimension;
-    const currentFilters = activeFilters;
-    const rangeData = await api.getDateRangeData(currentStartRange, currentEndRange, currentDimension, currentFilters);
-    // Creating object to send to reducer with date range data and start and end dates
-    const updatedRangeData = {
-      data: rangeData,
-      startDate: start,
-      endDate: end,
-    };
-    dispatch(setSelectedRange(updatedRangeData));
-    dispatch(markNavLoadingAction(false));
+    try {
+      dispatch(markNavLoadingAction(true));
+      const currentStartRange = start;
+      const currentEndRange = end;
+      const currentDimension = mainDimension;
+      const currentFilters = activeFilters;
+      const rangeData = await api.getDateRangeData(currentStartRange, currentEndRange, currentDimension, currentFilters);
+      // Creating object to send to reducer with date range data and start and end dates
+      const updatedRangeData = {
+        data: rangeData,
+        startDate: start,
+        endDate: end,
+      };
+      dispatch(setSelectedRange(updatedRangeData));
+      dispatch(markNavLoadingAction(false));
+    } catch (err) {
+      dispatch(errorAction(err.message));
+    }
   };
 }
 /**
@@ -86,19 +115,23 @@ export function doSetSelectedRange(start, end, mainDimension, activeFilters) {
  */
 export function doSetCustomRange(start, end, mainDimension, activeFilters) {
   return async(dispatch, _, {api}) => {
-    dispatch(markNavLoadingAction(true));
-    const currentStartRange = start;
-    const currentEndRange = end;
-    const currentDimension = mainDimension;
-    const currentFilters = activeFilters;
-    const rangeData = await api.customDateRangeData(currentStartRange, currentEndRange, currentDimension, currentFilters);
-    // Creating object to send to reducer with date range data and start and end dates
-    const updatedRangeData = {
-      data: rangeData,
-      startDate: start,
-      endDate: end,
-    };
-    dispatch(setCustomRange(updatedRangeData));
-    dispatch(markNavLoadingAction(false));
+    try {
+      dispatch(markNavLoadingAction(true));
+      const currentStartRange = start;
+      const currentEndRange = end;
+      const currentDimension = mainDimension;
+      const currentFilters = activeFilters;
+      const rangeData = await api.customDateRangeData(currentStartRange, currentEndRange, currentDimension, currentFilters);
+      // Creating object to send to reducer with date range data and start and end dates
+      const updatedRangeData = {
+        data: rangeData,
+        startDate: start,
+        endDate: end,
+      };
+      dispatch(setCustomRange(updatedRangeData));
+      dispatch(markNavLoadingAction(false));
+    } catch (err) {
+      dispatch(errorAction(err.message));
+    }
   };
 }

--- a/gulp/src/analytics/actions/calendar-actions.js
+++ b/gulp/src/analytics/actions/calendar-actions.js
@@ -1,36 +1,63 @@
 import {createAction} from 'redux-actions';
 import {markNavLoadingAction} from '../../common/actions/loading-actions';
 
-export const setSelectedMonth = createAction('SET_SELECTED_MONTH');
-export const setSelectedYear = createAction('SET_SELECTED_YEAR');
-export const setSelectedDay = createAction('SET_SELECTED_DAY');
+export const setSelectedEndMonth = createAction('SET_SELECTED_END_MONTH');
+export const setSelectedEndYear = createAction('SET_SELECTED_END_YEAR');
+export const setSelectedEndDay = createAction('SET_SELECTED_END_DAY');
+export const setSelectedStartMonth = createAction('SET_SELECTED_START_MONTH');
+export const setSelectedStartYear = createAction('SET_SELECTED_START_YEAR');
+export const setSelectedStartDay = createAction('SET_SELECTED_START_DAY');
 export const setSelectedRange = createAction('SET_SELECTED_RANGE');
+export const setCustomRange = createAction('SET_CUSTOM_RANGE');
 
 /**
- * This action sets the current month selected from the Calendar ONLY
+ * This action sets the current month selected from the  Ending Date Calendar ONLY
  */
-export function doSetSelectedMonth(month) {
+export function doSetSelectedEndMonth(month) {
   return async(dispatch) => {
-    const currentMonth = month;
-    dispatch(setSelectedMonth(currentMonth));
+    dispatch(setSelectedEndMonth(month));
   };
 }
 /**
- * This action sets the current year selected from the Calendar ONLY
+ * This action sets the current month selected from the Starting Date Calendar ONLY
  */
-export function doSetSelectedYear(year) {
+export function doSetSelectedStartMonth(month) {
   return async(dispatch) => {
-    const currentYear = year;
-    dispatch(setSelectedYear(currentYear));
+    dispatch(setSelectedStartMonth(month));
   };
 }
 /**
- * This action sets the current day selected from the Calendar ONLY
+ * This action sets the current year selected from the Ending Date Calendar ONLY
  */
-export function doSetSelectedDay(day) {
+export function doSetSelectedEndYear(year) {
+  return async(dispatch) => {
+    dispatch(setSelectedEndYear(year));
+  };
+}
+/**
+ * This action sets the current year selected from the Starting Date Calendar ONLY
+ */
+export function doSetSelectedStartYear(year) {
+  return async(dispatch) => {
+    dispatch(setSelectedStartYear(year));
+  };
+}
+/**
+ * This action sets the current day selected from the  Ending Date Calendar ONLY
+ */
+export function doSetSelectedEndDay(day) {
   return async(dispatch) => {
     const currentDay = day.day;
-    dispatch(setSelectedDay(currentDay));
+    dispatch(setSelectedEndDay(currentDay));
+  };
+}
+/**
+ * This action sets the current day selected from the Starting Date Calendar ONLY
+ */
+export function doSetSelectedStartDay(day) {
+  return async(dispatch) => {
+    const currentDay = day.day;
+    dispatch(setSelectedStartDay(currentDay));
   };
 }
 /**
@@ -51,6 +78,27 @@ export function doSetSelectedRange(start, end, mainDimension, activeFilters) {
       endDate: end,
     };
     dispatch(setSelectedRange(updatedRangeData));
+    dispatch(markNavLoadingAction(false));
+  };
+}
+/**
+ * This action sets the custom range selected from the Range Calendars
+ */
+export function doSetCustomRange(start, end, mainDimension, activeFilters) {
+  return async(dispatch, _, {api}) => {
+    dispatch(markNavLoadingAction(true));
+    const currentStartRange = start;
+    const currentEndRange = end;
+    const currentDimension = mainDimension;
+    const currentFilters = activeFilters;
+    const rangeData = await api.customDateRangeData(currentStartRange, currentEndRange, currentDimension, currentFilters);
+    // Creating object to send to reducer with date range data and start and end dates
+    const updatedRangeData = {
+      data: rangeData,
+      startDate: start,
+      endDate: end,
+    };
+    dispatch(setCustomRange(updatedRangeData));
     dispatch(markNavLoadingAction(false));
   };
 }

--- a/gulp/src/analytics/actions/page-loading-actions.js
+++ b/gulp/src/analytics/actions/page-loading-actions.js
@@ -5,14 +5,17 @@ export const setPageData = createAction('SET_PAGE_DATA');
 export const setPrimaryDimensions = createAction('SET_PRIMARY_DIMENSIONS');
 export const setSelectedFilterData = createAction('SET_SELECTED_FILTER_DATA');
 export const storeInitialReport = createAction('STORE_INITIAL_REPORT');
-export const setCurrentMonth = createAction('SET_CURRENT_MONTH');
-export const setCurrentYear = createAction('SET_CURRENT_YEAR');
-export const setCurrentDay = createAction('SET_CURRENT_DAY');
+export const setCurrentEndMonth = createAction('SET_CURRENT_END_MONTH');
+export const setCurrentEndYear = createAction('SET_CURRENT_END_YEAR');
+export const setCurrentEndDay = createAction('SET_CURRENT_END_DAY');
+export const setCurrentStartMonth = createAction('SET_CURRENT_START_MONTH');
+export const setCurrentStartYear = createAction('SET_CURRENT_START_YEAR');
+export const setCurrentStartDay = createAction('SET_CURRENT_START_DAY');
 
 /**
  * This action does all of the necessary steps for getting the page data that will be loaded when the app first boots
  */
-export function doGetPageData(start, end, currentMonth, currentDay, currentYear) {
+export function doGetPageData(start, end, currentEndMonth, currentEndDay, currentEndYear, currentStartMonth, currentStartDay, currentStartYear) {
   return async (dispatch, _, {api}) => {
     dispatch(markPageLoadingAction(true));
     const rawPageData = await api.getInitialPageData(start, end);
@@ -25,9 +28,12 @@ export function doGetPageData(start, end, currentMonth, currentDay, currentYear)
     const dimensionData = await api.getPrimaryDimensions();
     const reportType = await api.getStartingPointReport();
     dispatch(setPageData(allLoadData));
-    dispatch(setCurrentMonth(currentMonth));
-    dispatch(setCurrentYear(currentYear));
-    dispatch(setCurrentDay(currentDay));
+    dispatch(setCurrentEndMonth(currentEndMonth));
+    dispatch(setCurrentEndYear(currentEndYear));
+    dispatch(setCurrentEndDay(currentEndDay));
+    dispatch(setCurrentStartMonth(currentStartMonth));
+    dispatch(setCurrentStartYear(currentStartYear));
+    dispatch(setCurrentStartDay(currentStartDay));
     dispatch(setPrimaryDimensions(dimensionData));
     dispatch(storeInitialReport(reportType));
     dispatch(markPageLoadingAction(false));

--- a/gulp/src/analytics/api.js
+++ b/gulp/src/analytics/api.js
@@ -49,7 +49,7 @@ export default class Api {
     };
     return await this.api.post('/analytics/api/dynamic', {'request': JSON.stringify(mainDimensionDataRequest)});
   }
-  // Get the date range data selected from the Calendar
+  // Get the date range data selected from the Quick Range Selections
   async getDateRangeData(start, end, mainDimension, activeFilters) {
     const setDateRangeDataRequest = {
       'date_start': start,
@@ -58,5 +58,15 @@ export default class Api {
       'report': mainDimension,
     };
     return await this.api.post('/analytics/api/dynamic', {'request': JSON.stringify(setDateRangeDataRequest)});
+  }
+  // Get the custom date range selected from the Range Calendars
+  async customDateRangeData(start, end, mainDimension, activeFilters) {
+    const setCustomDateRangeDataRequest = {
+      'date_start': start + ' 00:00:00',
+      'date_end': end + ' 23:59:59',
+      'active_filters': activeFilters,
+      'report': mainDimension,
+    };
+    return await this.api.post('/analytics/api/dynamic', {'request': JSON.stringify(setCustomDateRangeDataRequest)});
   }
 }

--- a/gulp/src/analytics/components/AnalyticsApp.jsx
+++ b/gulp/src/analytics/components/AnalyticsApp.jsx
@@ -13,11 +13,14 @@ class AnalyticsApp extends React.Component {
     const endDate = moment().format('MM/DD/YYYY H:mm:ss');
     startDate = startDate.subtract(30, 'days');
     startDate = startDate.format('MM/DD/YYYY');
-    const currentMonth = moment().month();
-    const currentDay = moment().date();
-    const currentYear = moment().year();
+    const currentEndMonth = moment().month();
+    const currentEndDay = moment().date();
+    const currentEndYear = moment().year();
+    const currentStartMonth = moment().month() - 1;
+    const currentStartDay = moment().date() + 1;
+    const currentStartYear = moment().year();
     const {dispatch} = this.props;
-    dispatch(doGetPageData(startDate, endDate, currentMonth, currentDay, currentYear));
+    dispatch(doGetPageData(startDate, endDate, currentEndMonth, currentEndDay, currentEndYear, currentStartMonth, currentStartDay, currentStartYear));
   }
   render() {
     const {analytics} = this.props;

--- a/gulp/src/analytics/components/Calendar/Calendar.js
+++ b/gulp/src/analytics/components/Calendar/Calendar.js
@@ -21,12 +21,16 @@ class Calendar extends Component {
     };
   }
   setRangeSelection(range) {
-    const {dispatch, analytics} = this.props;
+    const {dispatch, analytics, hideCalendarRangePicker} = this.props;
     const startRange = range[0];
     const endRange = range[1];
     const activeMainDimension = analytics.activePrimaryDimension;
     const activeFilters = analytics.activeFilters;
     dispatch(doSetSelectedRange(startRange, endRange, activeMainDimension, activeFilters));
+    this.setState({
+      showCalendar: false,
+    });
+    hideCalendarRangePicker();
   }
   showCalendar() {
     this.setState({
@@ -78,12 +82,16 @@ class Calendar extends Component {
     dispatch(doSetSelectedStartDay(day));
   }
   applyCustomRange() {
-    const {dispatch, analytics} = this.props;
+    const {dispatch, analytics, hideCalendarRangePicker} = this.props;
     const startDate = `${analytics.startMonth + 1}/${analytics.startDay}/${analytics.startYear}`;
     const endDate = `${analytics.endMonth + 1}/${analytics.endDay}/${analytics.endYear}`;
     const activeMainDimension = analytics.activePrimaryDimension;
     const activeFilters = analytics.activeFilters;
     dispatch(doSetCustomRange(startDate, endDate, activeMainDimension, activeFilters));
+    this.setState({
+      showCalendar: false,
+    });
+    hideCalendarRangePicker();
   }
   render() {
     const {analytics, showCalendarRangePicker, hideCalendarRangePicker, onMouseDown, onMouseUp} = this.props;
@@ -117,8 +125,14 @@ class Calendar extends Component {
         <ul>
           <li className="calendar-pick full-calendar">
             <div className={this.state.showCalendar ? 'show-calendar' : 'hide-calendar'}>
-              {startCalendar}
-              {endCalendar}
+              <div className="start-calendar">
+                <p className="date-label">Start Date</p>
+                {startCalendar}
+              </div>
+              <div className="end-calendar">
+                <p className="date-label">End Date</p>
+                {endCalendar}
+              </div>
             </div>
             <RangeSelection applySelection={() => this.applyCustomRange()} cancelSelection={hideCalendarRangePicker} showCalendar={this.showCalendar.bind(this)} showCustomRange={() => this.showCalendar()} setRange={y => this.setRangeSelection(y)}/>
           </li>

--- a/gulp/src/analytics/components/Calendar/Calendar.js
+++ b/gulp/src/analytics/components/Calendar/Calendar.js
@@ -10,6 +10,7 @@ import {doSetSelectedStartDay} from '../../actions/calendar-actions';
 import {doSetSelectedRange} from '../../actions/calendar-actions';
 import {doSetCustomRange} from '../../actions/calendar-actions';
 import CalendarPanel from 'common/ui/CalendarPanel';
+import HelpText from 'common/ui/HelpText';
 import RangeSelection from './RangeSelection';
 
 class Calendar extends Component {
@@ -18,6 +19,7 @@ class Calendar extends Component {
 
     this.state = {
       showCalendar: false,
+      errorMessage: false,
     };
   }
   setRangeSelection(range) {
@@ -85,13 +87,21 @@ class Calendar extends Component {
     const {dispatch, analytics, hideCalendarRangePicker} = this.props;
     const startDate = `${analytics.startMonth + 1}/${analytics.startDay}/${analytics.startYear}`;
     const endDate = `${analytics.endMonth + 1}/${analytics.endDay}/${analytics.endYear}`;
-    const activeMainDimension = analytics.activePrimaryDimension;
-    const activeFilters = analytics.activeFilters;
-    dispatch(doSetCustomRange(startDate, endDate, activeMainDimension, activeFilters));
-    this.setState({
-      showCalendar: false,
-    });
-    hideCalendarRangePicker();
+    if (Date.parse(startDate) < Date.parse(endDate)) {
+      const activeMainDimension = analytics.activePrimaryDimension;
+      const activeFilters = analytics.activeFilters;
+      dispatch(doSetCustomRange(startDate, endDate, activeMainDimension, activeFilters));
+      this.setState({
+        showCalendar: false,
+        errorMessage: false,
+      });
+      hideCalendarRangePicker();
+    } else {
+      this.setState({
+        showCalendar: true,
+        errorMessage: true,
+      });
+    }
   }
   render() {
     const {analytics, showCalendarRangePicker, hideCalendarRangePicker, onMouseDown, onMouseUp} = this.props;
@@ -101,6 +111,7 @@ class Calendar extends Component {
     const startDay = analytics.startDay;
     const startMonth = analytics.startMonth;
     const startYear = analytics.startYear;
+    const errorMessage = `INVALID DATE RANGE: Start Date must be before End Date`;
 
     const startCalendar = ( <CalendarPanel
                       year={startYear}
@@ -125,6 +136,7 @@ class Calendar extends Component {
         <ul>
           <li className="calendar-pick full-calendar">
             <div className={this.state.showCalendar ? 'show-calendar' : 'hide-calendar'}>
+              {this.state.errorMessage ? <HelpText message={errorMessage}/> : ''}
               <div className="start-calendar">
                 <p className="date-label">Start Date</p>
                 {startCalendar}

--- a/gulp/src/analytics/components/Calendar/Calendar.js
+++ b/gulp/src/analytics/components/Calendar/Calendar.js
@@ -79,16 +79,14 @@ class Calendar extends Component {
   }
   applyCustomRange() {
     const {dispatch, analytics} = this.props;
-    console.log(analytics);
-    const startDate = (analytics.startMonth + 1) + '/' + analytics.startDay + '/' + analytics.startYear;
-    const endDate = (analytics.endMonth + 1) + '/' + analytics.endDay + '/' + analytics.endYear;
+    const startDate = `${analytics.startMonth + 1}/${analytics.startDay}/${analytics.startYear}`;
+    const endDate = `${analytics.endMonth + 1}/${analytics.endDay}/${analytics.endYear}`;
     const activeMainDimension = analytics.activePrimaryDimension;
     const activeFilters = analytics.activeFilters;
     dispatch(doSetCustomRange(startDate, endDate, activeMainDimension, activeFilters));
   }
   render() {
     const {analytics, showCalendarRangePicker, hideCalendarRangePicker, onMouseDown, onMouseUp} = this.props;
-    console.log(analytics);
     const endDay = analytics.endDay;
     const endMonth = analytics.endMonth;
     const endYear = analytics.endYear;

--- a/gulp/src/analytics/components/Calendar/Calendar.js
+++ b/gulp/src/analytics/components/Calendar/Calendar.js
@@ -1,10 +1,14 @@
 import React from 'react';
 import {Component} from 'react';
 import {connect} from 'react-redux';
-import {doSetSelectedMonth} from '../../actions/calendar-actions';
-import {doSetSelectedYear} from '../../actions/calendar-actions';
-import {doSetSelectedDay} from '../../actions/calendar-actions';
+import {doSetSelectedEndMonth} from '../../actions/calendar-actions';
+import {doSetSelectedEndYear} from '../../actions/calendar-actions';
+import {doSetSelectedEndDay} from '../../actions/calendar-actions';
+import {doSetSelectedStartMonth} from '../../actions/calendar-actions';
+import {doSetSelectedStartYear} from '../../actions/calendar-actions';
+import {doSetSelectedStartDay} from '../../actions/calendar-actions';
 import {doSetSelectedRange} from '../../actions/calendar-actions';
+import {doSetCustomRange} from '../../actions/calendar-actions';
 import CalendarPanel from 'common/ui/CalendarPanel';
 import RangeSelection from './RangeSelection';
 
@@ -29,14 +33,23 @@ class Calendar extends Component {
       showCalendar: true,
     });
   }
-  updateMonth(month) {
+  updateStartMonth(month) {
     const updatedMonth = (month - 1);
     const {dispatch} = this.props;
-    dispatch(doSetSelectedMonth(updatedMonth));
+    dispatch(doSetSelectedStartMonth(updatedMonth));
   }
-  updateYear(year) {
+  updateStartYear(year) {
     const {dispatch} = this.props;
-    dispatch(doSetSelectedYear(year));
+    dispatch(doSetSelectedStartYear(year));
+  }
+  updateEndMonth(month) {
+    const updatedMonth = (month - 1);
+    const {dispatch} = this.props;
+    dispatch(doSetSelectedEndMonth(updatedMonth));
+  }
+  updateEndYear(year) {
+    const {dispatch} = this.props;
+    dispatch(doSetSelectedEndYear(year));
   }
   generateYearChoices() {
     const now = new Date();
@@ -56,23 +69,49 @@ class Calendar extends Component {
     }
     return yearChoices;
   }
-  daySelected(day) {
+  endDaySelected(day) {
     const {dispatch} = this.props;
-    dispatch(doSetSelectedDay(day));
+    dispatch(doSetSelectedEndDay(day));
+  }
+  startDaySelected(day) {
+    const {dispatch} = this.props;
+    dispatch(doSetSelectedStartDay(day));
+  }
+  applyCustomRange() {
+    const {dispatch, analytics} = this.props;
+    console.log(analytics);
+    const startDate = (analytics.startMonth + 1) + '/' + analytics.startDay + '/' + analytics.startYear;
+    const endDate = (analytics.endMonth + 1) + '/' + analytics.endDay + '/' + analytics.endYear;
+    const activeMainDimension = analytics.activePrimaryDimension;
+    const activeFilters = analytics.activeFilters;
+    dispatch(doSetCustomRange(startDate, endDate, activeMainDimension, activeFilters));
   }
   render() {
     const {analytics, showCalendarRangePicker, hideCalendarRangePicker, onMouseDown, onMouseUp} = this.props;
-    const day = analytics.day;
-    const month = analytics.month;
-    const year = analytics.year;
+    console.log(analytics);
+    const endDay = analytics.endDay;
+    const endMonth = analytics.endMonth;
+    const endYear = analytics.endYear;
+    const startDay = analytics.startDay;
+    const startMonth = analytics.startMonth;
+    const startYear = analytics.startYear;
 
-    const calendar = ( <CalendarPanel
-                      year={year}
-                      month={month}
-                      day={day}
-                      onYearChange={y => this.updateYear(y)}
-                      onMonthChange={m => this.updateMonth(m)}
-                      onSelect={d => this.daySelected(d)}
+    const startCalendar = ( <CalendarPanel
+                      year={startYear}
+                      month={startMonth}
+                      day={startDay}
+                      onYearChange={y => this.updateStartYear(y)}
+                      onMonthChange={m => this.updateStartMonth(m)}
+                      onSelect={d => this.startDaySelected(d)}
+                      yearChoices={this.generateYearChoices()}
+                    />);
+    const endCalendar = ( <CalendarPanel
+                      year={endYear}
+                      month={endMonth}
+                      day={endDay}
+                      onYearChange={y => this.updateEndYear(y)}
+                      onMonthChange={m => this.updateEndMonth(m)}
+                      onSelect={d => this.endDaySelected(d)}
                       yearChoices={this.generateYearChoices()}
                     />);
     return (
@@ -80,9 +119,10 @@ class Calendar extends Component {
         <ul>
           <li className="calendar-pick full-calendar">
             <div className={this.state.showCalendar ? 'show-calendar' : 'hide-calendar'}>
-              {calendar}
+              {startCalendar}
+              {endCalendar}
             </div>
-            <RangeSelection cancelSelection={hideCalendarRangePicker} showCalendar={this.showCalendar.bind(this)} showCustomRange={() => this.showCalendar()} setRange={y => this.setRangeSelection(y)}/>
+            <RangeSelection applySelection={() => this.applyCustomRange()} cancelSelection={hideCalendarRangePicker} showCalendar={this.showCalendar.bind(this)} showCustomRange={() => this.showCalendar()} setRange={y => this.setRangeSelection(y)}/>
           </li>
         </ul>
       </div>

--- a/gulp/src/analytics/components/Calendar/RangeSelection.js
+++ b/gulp/src/analytics/components/Calendar/RangeSelection.js
@@ -18,7 +18,7 @@ class RangeSelection extends Component {
     };
   }
   render() {
-    const {setRange, showCustomRange, cancelSelection} = this.props;
+    const {setRange, showCustomRange, cancelSelection, applySelection} = this.props;
     const generateRanges = this.state.ranges.map((range, i) => {
       return (
         <li key={i} className="range" onClick={() => setRange(range.date)}>{range.name}</li>
@@ -29,7 +29,7 @@ class RangeSelection extends Component {
         <ul className="range-selections">
           {generateRanges}
           <li onClick={() => showCustomRange()} className="range">Custom Range</li>
-          <li className="apply-cancel"><button className="range-btn apply-range">APPLY</button><button onClick={cancelSelection} className="range-btn cancel-range">CANCEL</button></li>
+          <li className="apply-cancel"><button onClick={applySelection} className="range-btn apply-range">APPLY</button><button onClick={cancelSelection} className="range-btn cancel-range">CANCEL</button></li>
         </ul>
       </div>
     );
@@ -49,6 +49,10 @@ RangeSelection.propTypes = {
    * Closes the calendar and cancels the date change
    */
   cancelSelection: React.PropTypes.func,
+  /**
+   * Applies the current range from the custom calendar selection
+   */
+  applySelection: React.PropTypes.func,
 };
 
 export default RangeSelection;

--- a/gulp/src/analytics/reducers/analytics-reducer.js
+++ b/gulp/src/analytics/reducers/analytics-reducer.js
@@ -9,9 +9,12 @@ import {findIndex} from 'lodash-compat';
  *  navFetching is used when there is a new tab being created through filtering or dimension switching
  *  navigation holds the tabs and their independent data
  *  activeFilters stores the current filters for sending back to the API
- *  month stores the current month for when the app boots
- *  day stores the current month for when the app boots
- *  year stores the current month for when the app boots
+ *  startMonth stores the current month for the calendar when the app boots
+ *  startDay stores the current month for the calendar when the app boots
+ *  startYear stores the current month for the calendar when the app boots
+ *  endMonth stores the end month for the calendar when the app boots
+ *  endDay stores the end day for the calendar when the app boots
+ *  endYear stores the end year for the calendar when the app boots
  *  activeReport stores the current report type for sending back to the API
  *  primaryDimensions stores the primary dimensions given back from the API to create the sidebar list
  *  activePrimaryDimension stores the current primary dimension that is actively chosen at that time
@@ -24,9 +27,12 @@ export const initialPageData = {
   navFetching: false,
   navigation: [],
   activeFilters: [],
-  month: '',
-  day: '',
-  year: '',
+  startMonth: '',
+  startDay: '',
+  startYear: '',
+  endMonth: '',
+  endDay: '',
+  endYear: '',
   activeReport: '',
   primaryDimensions: {},
   activePrimaryDimension: '',
@@ -171,46 +177,88 @@ export default handleActions({
       }),
     };
   },
-  'SET_CURRENT_MONTH': (state, action) => {
+  'SET_CURRENT_START_MONTH': (state, action) => {
     const currentMonth = action.payload;
     return {
       ...state,
-      month: currentMonth,
+      startMonth: currentMonth,
     };
   },
-  'SET_CURRENT_YEAR': (state, action) => {
+  'SET_CURRENT_START_YEAR': (state, action) => {
     const currentYear = action.payload;
     return {
       ...state,
-      year: currentYear,
+      startYear: currentYear,
     };
   },
-  'SET_CURRENT_DAY': (state, action) => {
+  'SET_CURRENT_START_DAY': (state, action) => {
     const currentDay = action.payload;
     return {
       ...state,
-      day: currentDay,
+      startDay: currentDay,
     };
   },
-  'SET_SELECTED_MONTH': (state, action) => {
+  'SET_CURRENT_END_MONTH': (state, action) => {
+    const currentMonth = action.payload;
+    return {
+      ...state,
+      endMonth: currentMonth,
+    };
+  },
+  'SET_CURRENT_END_YEAR': (state, action) => {
+    const currentYear = action.payload;
+    return {
+      ...state,
+      endYear: currentYear,
+    };
+  },
+  'SET_CURRENT_END_DAY': (state, action) => {
+    const currentDay = action.payload;
+    return {
+      ...state,
+      endDay: currentDay,
+    };
+  },
+  'SET_SELECTED_END_MONTH': (state, action) => {
     const selectedMonth = action.payload;
     return {
       ...state,
-      month: selectedMonth,
+      endMonth: selectedMonth,
     };
   },
-  'SET_SELECTED_YEAR': (state, action) => {
+  'SET_SELECTED_END_YEAR': (state, action) => {
     const selectedYear = action.payload;
     return {
       ...state,
-      year: selectedYear,
+      endYear: selectedYear,
     };
   },
-  'SET_SELECTED_DAY': (state, action) => {
+  'SET_SELECTED_END_DAY': (state, action) => {
     const selectedDay = action.payload;
     return {
       ...state,
-      day: selectedDay,
+      endDay: selectedDay,
+    };
+  },
+  'SET_SELECTED_START_MONTH': (state, action) => {
+    const selectedMonth = action.payload;
+    return {
+      ...state,
+      startMonth: selectedMonth,
+    };
+  },
+  'SET_SELECTED_START_YEAR': (state, action) => {
+    const selectedYear = action.payload;
+    return {
+      ...state,
+      startYear: selectedYear,
+    };
+  },
+  'SET_SELECTED_START_DAY': (state, action) => {
+    const selectedDay = action.payload;
+    return {
+      ...state,
+      startDay: selectedDay,
     };
   },
   'SET_SELECTED_RANGE': (state, action) => {
@@ -224,6 +272,23 @@ export default handleActions({
             startDate: selectedRangeData.startDate,
             endDate: selectedRangeData.endDate,
             PageLoadData: selectedRangeData.data,
+          };
+        }
+        return nav;
+      }),
+    };
+  },
+  'SET_CUSTOM_RANGE': (state, action) => {
+    const customRangeData = action.payload;
+    return {
+      ...state,
+      navigation: state.navigation.map((nav) => {
+        if (nav.active === true) {
+          return {
+            ...nav,
+            startDate: customRangeData.startDate,
+            endDate: customRangeData.endDate,
+            PageLoadData: customRangeData.data,
           };
         }
         return nav;

--- a/gulp/src/sass/analytics.scss
+++ b/gulp/src/sass/analytics.scss
@@ -346,6 +346,15 @@ a {
 .show-calendar {
   float: left;
 }
+.end-calendar, .start-calendar {
+  float: left;
+}
+.date-label {
+  text-align: center;
+  font-size: 20px;
+  font-weight: 100;
+  margin-top: 10px;
+}
 .calendar-container {
   display: block;
   position: absolute;

--- a/gulp/src/sass/analytics.scss
+++ b/gulp/src/sass/analytics.scss
@@ -367,13 +367,6 @@ a {
   border: 1px solid $primary-blue;
   background: $white;
 }
-// .calendar-container.active {
-//   display: block;
-//   position: absolute;
-//   right: 200px;
-//   top: 60px;
-//   z-index: 99;
-// }
 
 .calendar-panel {
   background: $white;
@@ -399,6 +392,9 @@ a {
   color: $white;
   font-size: 14px;
 }
+.range-selections li.range:nth-child(7) {
+  border-bottom: 1px solid $primary-blue;
+}
 .range:hover {
   cursor: pointer;
   background: $white;
@@ -415,19 +411,34 @@ a {
   border-radius: 5px;
 }
 .apply-range {
+  background: $primary-blue;
+  color: $white;
+  border: 1px solid $primary-blue;
+  margin-right: 10px;
+}
+.apply-range:hover {
   background: #63AB62;
   color: $white;
   border: 1px solid #63AB62;
-  margin-right: 10px;
 }
 .cancel-range {
   background: $white;
   border: 1px solid $primary-blue;
   color: $primary-blue
 }
+.cancel-range:hover {
+  background: red;
+  color: $white;
+  border: 1px solid red;
+}
 
 .calendar-pick {
   display: inline-block;
+}
+.input-error {
+  margin-top: 10px;
+  text-align: center;
+  font-size: 16px;
 }
 
 /*CSS FOR THE CHARTS SECTION*/

--- a/gulp/src/sass/analytics.scss
+++ b/gulp/src/sass/analytics.scss
@@ -369,6 +369,7 @@ a {
 .calendar-panel {
   background: $white;
   padding: 17px;
+  float: left;
 }
 
 .range-container {


### PR DESCRIPTION
Task was to create a date range selection with two calendars from the header.

To Test:

Pull down the repository. You can click on the date in the header and bring up the dropdown for quick selections. When you click custom range you will see two calendars appear. One being the start date and one being the end date. You can select that range and click apply and it will apply the filters to the data with those dates being sent to the API. You can also check the Network tab and see the request sent to Dynamic and make sure the headers are sending off the custom range that you selected with start_date and end_date in the request.