### PR TITLE
[PD-2423] Detect that a user has been logged out and refresh the page so they end up on the login page.

### DIFF
--- a/default_settings.py
+++ b/default_settings.py
@@ -103,6 +103,7 @@ MIDDLEWARE_CLASSES = (
     'middleware.TimezoneMiddleware',
     'redirect.middleware.ExcludedViewSourceMiddleware',
     'middleware.ImpersonateTimeoutMiddleware',
+    'middleware.SessionTimeMiddleware',
 )
 
 AUTHENTICATION_BACKENDS = (

--- a/middleware.py
+++ b/middleware.py
@@ -346,3 +346,24 @@ class ImpersonateTimeoutMiddleware(ImpersonateMiddleware):
                              self).process_request(request)
             else:
                 return redirect(reverse('impersonate-stop'))
+
+
+class SessionTimeMiddleware(object):
+    """
+    Adds a cookie that tracks the amount of time remaining in a session.
+
+    This allows us to redirect a user to the login page via JavaScript
+    if their session expires.
+
+    """
+    def process_response(self, request, response):
+        session_expiry_age = 0
+
+        if hasattr(request, 'user') and request.user.is_authenticated():
+            session_expiry_age = request.session.get_expiry_age()
+
+        if session_expiry_age and session_expiry_age > 0:
+            response.set_cookie('exp', str(session_expiry_age),
+                                expires=session_expiry_age)
+
+        return response

--- a/myjobs/helpers.py
+++ b/myjobs/helpers.py
@@ -3,6 +3,7 @@ from jira.client import JIRA
 from django.contrib import auth
 from django.core import mail
 from django.core.mail import EmailMessage
+from django.utils.safestring import mark_safe
 
 from secrets import options, my_agent_auth, EMAIL_TO_ADMIN
 

--- a/static/utils.183-21.js
+++ b/static/utils.183-21.js
@@ -42,7 +42,7 @@ utils.logoutTimer = function readCookie(url) {
       if (utils.readCookie('loggedout') && window.location.pathname !== url) {
         window.location.assign(url);
       } else if ((!utils.readCookie('exp')) && (window.location.pathname !== url)) {
-        window.location.assign(url);
+        window.location.reload(true);
       }
 
     }, 500);

--- a/static/utils.183-21.js
+++ b/static/utils.183-21.js
@@ -36,9 +36,15 @@ utils.logoutTimer = function readCookie(url) {
   if (!timer) {
     timer = window.setInterval(function redirect() {
       // if we are logged out and not already on the home page
+      // If the loggedout cookie is set, a log out was initiated by the
+      // user via.
+      // If the exp cookie is missing, the user's session has expired.
       if (utils.readCookie('loggedout') && window.location.pathname !== url) {
         window.location.assign(url);
+      } else if ((!utils.readCookie('exp')) && (window.location.pathname !== url)) {
+        window.location.assign(url);
       }
+
     }, 500);
   } else {
     window.clearInterval(timer);

--- a/templates/base-react-analytics.html
+++ b/templates/base-react-analytics.html
@@ -38,7 +38,7 @@
             <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
         <![endif]-->
         {% compress js %}
-            <script type="text/javascript" src="{% static "utils.181-20.js" %}"></script>
+            <script type="text/javascript" src="{% static "utils.183-21.js" %}"></script>
             <script type="text/javascript" src="{% static "custom.166-06.js" %}"></script>
             <script type="text/javascript" src="{% static "svg4everybody.min.js" %}"></script>
         {% endcompress %}

--- a/templates/base-react.html
+++ b/templates/base-react.html
@@ -36,7 +36,7 @@
             <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
         <![endif]-->
         {% compress js %}
-            <script type="text/javascript" src="{% static "utils.181-20.js" %}"></script>
+            <script type="text/javascript" src="{% static "utils.183-21.js" %}"></script>
             <script type="text/javascript" src="{% static "custom.166-06.js" %}"></script>
             <script type="text/javascript" src="{% static "svg4everybody.min.js" %}"></script>
         {% endcompress %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -30,7 +30,7 @@
     <link href="{{ STATIC_URL }}bootstrap/bootstrap-modal.css" rel="stylesheet" type="text/css">
 
     {% compress js %}
-      <script type="text/javascript" src="{% static "utils.181-20.js" %}"></script>
+      <script type="text/javascript" src="{% static "utils.183-21.js" %}"></script>
       <script type="text/javascript" src="{% static "custom.166-06.js" %}"></script>
     {% endcompress %}
 </head>

--- a/templates/redirect/base.html
+++ b/templates/redirect/base.html
@@ -12,7 +12,7 @@
     <link href="{% static "redirect.less" %}" rel="stylesheet" type="text/less">
     {% endcompress %}
     <script src="//d2e48ltfsb5exy.cloudfront.net/framework/v2/secure/js/def.ui.core.js"></script>
-    <script type="text/javascript" src="{% static "utils.181-20.js" %}"></script>
+    <script type="text/javascript" src="{% static "utils.183-21.js" %}"></script>
     <script src="{% static "my.jobs.js" %}"></script>
     {% endblock %}
 

--- a/templates/seo_base.html
+++ b/templates/seo_base.html
@@ -39,7 +39,7 @@
     <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
 
     {% compress js %}
-    <script type="text/javascript" src="{% static "utils.181-20.js" %}"></script>
+    <script type="text/javascript" src="{% static "utils.183-21.js" %}"></script>
     <script type="text/javascript" src="{% static "secure-blocks/secure-block.181-20.js" %}"></script>
     <script type="text/javascript" src="{% static 'search.181-20.js' %}"></script>
     {% endcompress %}


### PR DESCRIPTION
This sets a cookie in middleware that should expire the same time as their session.
On the javascript side, we look for this cookie. If we can't find it, refresh the page, which should redirect them to the login page.

This isn't the cleanest approach, but I'm struggling to come up with a better alternative. 
Because we use `SESSION_SAVE_EVERY_REQUEST` the session is renewed every request, so I needed to use a method for checking whether or not the session has expired that did not involve making another request to the app (and therefore perpetually renewing the session). 