### PR TITLE
[PD-2828] Analytics bar graph label and tooltip display improvements.

### DIFF
--- a/gulp/src/analytics/components/Charts/Bar/BarChart.js
+++ b/gulp/src/analytics/components/Charts/Bar/BarChart.js
@@ -2,34 +2,30 @@ import React from 'react';
 import {Component} from 'react';
 import {BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer} from 'recharts';
 
+
 class SimpleBarChart extends Component {
   render() {
     function truncate(length, value) {
       return value.substring(0, length);
     }
+
+    function truncateTick(value) {
+      return truncate(15, value);
+    }
+
     const {chartData, width, height} = this.props;
     const barData = chartData.PageLoadData.rows;
     const xAxis = chartData.PageLoadData.column_names[0].key;
-    const truncatedBarData = [];
-    for (let i = 0; i < barData.length; i++) {
-      truncatedBarData.push({...barData[i]});
-    }
-    truncatedBarData.map((bar) => {
-      for (const key in bar) {
-        if (key === xAxis) {
-          bar[key] = truncate(15, bar[key]);
-        }
-      }
-    });
+
     return (
       <div style={{width: '100%', height: '500'}}>
         <ResponsiveContainer>
           <BarChart
             width={width}
             height={height}
-            data={truncatedBarData}
+            data={barData}
             margin={{top: 5, right: 30, left: 20, bottom: 5}}>
-           <XAxis dataKey={xAxis}/>
+           <XAxis dataKey={xAxis} tickFormatter={truncateTick}/>
            <YAxis/>
            <CartesianGrid strokeDasharray="3 3"/>
            <Tooltip/>

--- a/gulp/src/analytics/components/Charts/Bar/BarChart.js
+++ b/gulp/src/analytics/components/Charts/Bar/BarChart.js
@@ -1,18 +1,11 @@
 import React from 'react';
 import {Component} from 'react';
 import {BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer} from 'recharts';
+import RotatedXAxisTick from './RotatedXAxisTick';
 
 
 class SimpleBarChart extends Component {
   render() {
-    function truncate(length, value) {
-      return value.substring(0, length);
-    }
-
-    function truncateTick(value) {
-      return truncate(15, value);
-    }
-
     const {chartData, width, height} = this.props;
     const barData = chartData.PageLoadData.rows;
     const xAxis = chartData.PageLoadData.column_names[0].key;
@@ -24,12 +17,12 @@ class SimpleBarChart extends Component {
             width={width}
             height={height}
             data={barData}
-            margin={{top: 5, right: 30, left: 20, bottom: 5}}>
-           <XAxis dataKey={xAxis} tickFormatter={truncateTick}/>
+            margin={{top: 5, right: 30, left: 20, bottom: 100}}>
+           <XAxis dataKey={xAxis} interval={0} tick={<RotatedXAxisTick />} />
            <YAxis/>
-           <CartesianGrid strokeDasharray="3 3"/>
+           <CartesianGrid strokeDasharray="3 3" />
            <Tooltip/>
-           <Legend />
+           <Legend verticalAlign="top" wrapperStyle={{top: '0px'}} />
            <Bar dataKey="job_views" fill="#5a6d81" />
           </BarChart>
         </ResponsiveContainer>

--- a/gulp/src/analytics/components/Charts/Bar/RotatedXAxisTick.js
+++ b/gulp/src/analytics/components/Charts/Bar/RotatedXAxisTick.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import {Component} from 'react';
+import {Text} from 'recharts';
+
+class RotatedXAxisTick extends Component {
+  render() {
+    function truncate(length, value) {
+      if (value.length > length) {
+        return value.substring(0, length) + '...';
+      }
+      return value;
+    }
+
+    const {fill, payload, x, y} = this.props;
+
+    return (
+      <g transform={`translate(${x},${y})`}>
+        <Text
+          textAnchor="end"
+          verticalAnchor="middle"
+          fill={fill}
+          angle={-45}
+        >
+          {truncate(15, payload.value)}
+        </Text>
+      </g>
+    );
+  }
+}
+
+RotatedXAxisTick.propTypes = {
+  fill: React.PropTypes.string,
+  payload: React.PropTypes.object,
+  x: React.PropTypes.number,
+  y: React.PropTypes.number,
+};
+
+export default RotatedXAxisTick;


### PR DESCRIPTION
In this pull request:
* Currently the tooltip text is truncated. This prevents the job title in the tool tip from being truncated, even when the label on the graph is truncated.
* Currently, when the screen is resized, some of the labels containing the job titles are dropped. This prevents the job titles from being dropped, and angles the job titles so they display nicely on any screen type. 


## Tooltip is no longer truncated:
![screen shot 2016-12-27 at 4 27 33 pm](https://cloud.githubusercontent.com/assets/2728248/21508750/87f65ee0-cc51-11e6-91be-a02f7de7d1af.png)


## Label is show for each bar, regardless of screen size:
![screen shot 2016-12-27 at 4 11 40 pm](https://cloud.githubusercontent.com/assets/2728248/21508759/9b6f5d00-cc51-11e6-9371-8050bab8cb58.png)
![screen shot 2016-12-27 at 4 11 55 pm](https://cloud.githubusercontent.com/assets/2728248/21508761/9decf2a4-cc51-11e6-93fc-362688cdf4f3.png)
![screen shot 2016-12-27 at 4 12 06 pm](https://cloud.githubusercontent.com/assets/2728248/21508763/9fd375f2-cc51-11e6-878d-aedcf4cee2d5.png)
