### PR TITLE
PD-2614, fix the grayed out tags bug in NUO Communication Record form

### DIFF
--- a/gulp/src/nonuseroutreach/actions/process-outreach-actions.js
+++ b/gulp/src/nonuseroutreach/actions/process-outreach-actions.js
@@ -1,6 +1,7 @@
 import {createAction} from 'redux-actions';
 import {errorAction} from '../../common/actions/error-actions';
 import {map, isEmpty} from 'lodash-compat';
+import {colorizeTagsInForms} from '../forms';
 
 /**
  * add a new tag to the state
@@ -166,7 +167,7 @@ export function doLoadEmail(outreachId) {
   return async (dispatch, getState, {api}) => {
     try {
       const outreach = await api.getOutreach(outreachId);
-      const forms = await api.getForms(outreachId);
+      const forms = colorizeTagsInForms(await api.getForms(outreachId));
 
       dispatch(
         resetProcessAction(

--- a/gulp/src/nonuseroutreach/api.js
+++ b/gulp/src/nonuseroutreach/api.js
@@ -1,4 +1,4 @@
-import {map} from 'lodash-compat/collection';
+import {map} from 'lodash-compat';
 
 export default class Api {
   constructor(api) {

--- a/gulp/src/nonuseroutreach/forms.js
+++ b/gulp/src/nonuseroutreach/forms.js
@@ -1,4 +1,4 @@
-import {mapValues, includes, keys, filter} from 'lodash-compat';
+import {map, mapValues, includes, keys, filter} from 'lodash-compat';
 
 export const states = [
   {display: 'Select a State', value: ''},
@@ -393,3 +393,29 @@ export const contactNotesOnlyForm = {
   fields: mapValues(contactForm.fields, (f, key) =>
     key === 'notes' ? f : readonlyField(f)),
 };
+
+/**
+ * Assign user selected tag colors to default grey tags.
+ * Called as wrapper function around the api.getForms method
+ * in process-outreach-action.js
+ */
+export function colorizeTagsInForms(forms) {
+  const responseWithColoredTags = mapValues(forms, form => ({
+    ...form,
+    fields: mapValues(form.fields, field => {
+      if (field.widget.input_type === 'selectmultiple') {
+        const newField = {
+          ...field,
+          choices: map(field.choices, c => ({
+            ...c,
+            hexColor:
+              field.widget.attrs.tag_colors[c.value].hex_color,
+          })),
+        };
+        return newField;
+      }
+      return field;
+    }),
+  }));
+  return responseWithColoredTags;
+}

--- a/gulp/src/nonuseroutreach/spec/process-outreach-actions-spec.js
+++ b/gulp/src/nonuseroutreach/spec/process-outreach-actions-spec.js
@@ -1,6 +1,7 @@
 import processEmailReducer from '../reducers/process-outreach-reducer';
 import errorReducer from '../../common/reducers/error-reducer';
 import {keys, mapValues} from 'lodash-compat';
+import {colorizeTagsInForms} from '../forms';
 
 import {
   doLoadEmail,
@@ -121,27 +122,6 @@ describe('initial load', () => {
         },
       },
     };
-
-    function colorizeTagsInForms(forms) {
-      const responseWithColoredTags = mapValues(forms, form => ({
-        ...form,
-        fields: mapValues(form.fields, field => {
-          if (field.widget.input_type === 'selectmultiple') {
-            const newField = {
-              ...field,
-              choices: map(field.choices, c => ({
-                ...c,
-                hexColor:
-                  field.widget.attrs.tag_colors[c.value].hex_color,
-              })),
-            };
-            return newField;
-          }
-          return field;
-        }),
-      }));
-      return responseWithColoredTags;
-    }
 
     function expectKeys(forms) {
       return expect(colorizeTagsInForms(forms));

--- a/mypartners/forms.py
+++ b/mypartners/forms.py
@@ -513,6 +513,13 @@ def set_tag_choices(field, company):
         (t.pk, t.name)
         for t in company.tag_set.all()
     ]
+    field.widget.attrs.update({
+        'tag_colors': {
+            t.pk: {'hex_color': t.hex_color}
+            for t in company.tag_set.all()
+        }
+    })
+
 
 class NuoPartnerForm(NormalizedModelForm):
     """


### PR DESCRIPTION
**Purpose:** 
In NUO > Outreach Records > Communication Record > Tags, the tags that end users has assigned a color to shows up grayed out.  This PR attempts to fix this bug.

Before:
![before](https://cloud.githubusercontent.com/assets/5124153/21698797/d3445412-d366-11e6-9528-a2817ba5c585.png)

After:
![after](https://cloud.githubusercontent.com/assets/5124153/21698811/dcd1c820-d366-11e6-8be5-649d51f940c6.png)

**To test:** 
1.  Get to the "Communication Record" form like you normally do.  I get there via: NUO link in topbar > Outreach Records button in right nav > click on Review button > type letter 'a' in Contact Search input box, select AJ Selvey > Communication Record form now renders, click in the Tags input box, color tags should be included in the drop down.  The gray tags that have not been changed by end users will stay gray.

2.  Optionally, you could select a random tag to re-color with Tag Management and then go back to the Communication Record form > Tags, to ascertain that the tag have changed to the color that you wanted.