### PR TITLE
PD-2849, change classic reporting verbiage and added link to Dynamic …

### DIFF
--- a/static/my.jobs.css
+++ b/static/my.jobs.css
@@ -1333,7 +1333,8 @@ ul.header-menu > li > ul > a > li {
     border-bottom: 1px solid #d5d4d0;
 }
 
-ul.header-menu:hover {
+ul.header-menu:hover,
+a.text-info {
     cursor: pointer;
 }
 

--- a/templates/myreports/includes/report_overview.html
+++ b/templates/myreports/includes/report_overview.html
@@ -22,6 +22,7 @@
             <div class="row">
                 <div id="" class="span8 panel">
                     <h2>Create a New Report</h2>
+                    <p><span class="text-error">Classic reporting is no longer supported for new reports. To run a report, please</span> <a id="reporting-version" class="text-info">switch to dynamic reporting</a>.</p>
                     <div class="choices-header">
                         <input type="checkbox" checked disabled /> PRM Reports
                     </div>

--- a/templates/myreports/includes/report_overview.html
+++ b/templates/myreports/includes/report_overview.html
@@ -23,22 +23,6 @@
                 <div id="" class="span8 panel">
                     <h2>Create a New Report</h2>
                     <p><span class="text-error">Classic reporting is no longer supported for new reports. To run a report, please</span> <a id="reporting-version" class="text-info">switch to dynamic reporting</a>.</p>
-                    <div class="choices-header">
-                        <input type="checkbox" checked disabled /> PRM Reports
-                    </div>
-                    <div id="choices">
-                        <label>
-                            <input type="radio" name="report" value="partner" /> Partner
-                        </label>
-                        <label>
-                            <input type="radio" name="report" value="contact" /> Contact
-                        </label>
-                        <label>
-                            <input type="radio" name="report" value="contactrecord" /> Communication Records
-                        </label>
-                    </div>
-                    <div class="clearfix"></div>
-                    <a id="start-report" class="btn disabled pull-right">Next</a>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
**Purpose:**  
MVP for PD-2849, changed verbiage as requested.  I made the advisory text BootStrap 2 red (since we're already using BootStrap 2.2.1 for this view and to avoid redundancy), I also made the hyperlink to Dynamic Reporting BootStrap 2 blue as a form of call-to-action to drive the user towards the new reporting system.  The previous soft gray was too subtle in my opinion.  I also removed the "choices" radio button group with approval from Jason S.

**To Test:**
1.  Please navigate to classic reporting, under the "Create a New Report" header, ensure the text: 
"Classic reporting is no longer supported for new reports. To run a report, please switch to dynamic reporting." is present and in red, except for the hyperlink, which should be in blue.  The "radio buttons group" should be gone.
**Intended effect:**
![report](https://cloud.githubusercontent.com/assets/5124153/21852072/ae3e43da-d7df-11e6-844d-98d4bf082ba5.png)

2. Please click on hyperlink and make sure it takes you to Dynamic Reporting.