### PR TITLE
[PD-2884] added end-of-life warning text for classic reporting

### DIFF
--- a/templates/myreports/includes/report_overview.html
+++ b/templates/myreports/includes/report_overview.html
@@ -22,7 +22,11 @@
             <div class="row">
                 <div id="" class="span8 panel">
                     <h2>Create a New Report</h2>
-                    <p><span class="text-error">Classic reporting is no longer supported for new reports. To run a report, please</span> <a id="reporting-version" class="text-info">switch to dynamic reporting</a>.</p>
+                    <p>
+                        <span class="text-error">
+                            Classic reporting is no longer supported for new reports.  Starting on <strong>March 6th, 2017</strong>, reports generated in the old reporting structure will be deleted, and the old reporting will no longer be available. To run a report, please
+                        </span> <a id="reporting-version" class="text-info">switch to dynamic reporting</a>.
+                    </p>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
**Purpose:** 
Add end-of-life warning text to Classic Reporting.

**To Test:**
1.  Please switch to Classic Reporting and ensure the sentence "Starting on March 6th, 2017, reports generated in the old reporting structure will be deleted, and the old reporting will no longer be available." is in the paragraph. 