### PR TITLE
[PD 2889] Fixing the deleting and refiltering of tabs

### DIFF
--- a/gulp/src/analytics/reducers/analytics-reducer.js
+++ b/gulp/src/analytics/reducers/analytics-reducer.js
@@ -98,6 +98,7 @@ export default handleActions({
     if (index > -1) {
       for (let i = 0; i < navigation.length; i++) {
         tabIndex = navigation[i].active ? i : 1;
+        break;
       }
       return {
         ...state,

--- a/gulp/src/analytics/reducers/analytics-reducer.js
+++ b/gulp/src/analytics/reducers/analytics-reducer.js
@@ -91,12 +91,17 @@ export default handleActions({
     };
   },
   'STORE_ACTIVE_FILTER': (state, action) => {
+    const navigation = state.navigation;
     const checkType = action.payload.type;
     const index = findIndex(state.activeFilters, f => f.type === checkType);
+    let tabIndex;
     if (index > -1) {
+      for (let i = 0; i < navigation.length; i++) {
+        tabIndex = navigation[i].active ? i : 1;
+      }
       return {
         ...state,
-        navigation: state.navigation.slice(0, index + 1),
+        navigation: navigation.slice(0, tabIndex + 1),
         activeFilters: state.activeFilters.slice(0, index).concat(action.payload),
       };
     }

--- a/gulp/src/analytics/reducers/analytics-reducer.js
+++ b/gulp/src/analytics/reducers/analytics-reducer.js
@@ -97,12 +97,16 @@ export default handleActions({
     let tabIndex;
     if (index > -1) {
       for (let i = 0; i < navigation.length; i++) {
-        tabIndex = navigation[i].active ? i : 1;
-        break;
+        if (navigation[i].active) {
+          tabIndex = i;
+          break;
+        } else {
+          tabIndex = 0;
+        }
       }
       return {
         ...state,
-        navigation: navigation.slice(0, tabIndex + 1),
+        navigation: state.navigation.slice(0, tabIndex + 1),
         activeFilters: state.activeFilters.slice(0, index).concat(action.payload),
       };
     }


### PR DESCRIPTION
To test:

Pull down the repository. You can add tabs by filtering. Then you can delete a couple of tabs or one if you like. Once you go back to the second or first tab in line and re-filter, it should remove all the tabs before it and start filtering again. Prior, it would just duplicate the very last tab instead of deleting it.