### PR TITLE
[PD-2867] Ensure parameters are passed along to the URL on the job view page.

### DIFF
--- a/seo/templatetags/job_setup.py
+++ b/seo/templatetags/job_setup.py
@@ -5,6 +5,7 @@ from django import template
 
 register = template.Library()
 
+
 @register.inclusion_tag('job_result.html', takes_context=True)
 def arrange_jobs(context):
     featured_jobs = context.get('featured_jobs')
@@ -22,6 +23,7 @@ def arrange_jobs(context):
         'title_term': context.get('title_term'),
         'query_string': query_string,
         'site_tags': context.get('site_tags'),
+        'request': request,
     }
 
 

--- a/seo/tests/test_templatetags.py
+++ b/seo/tests/test_templatetags.py
@@ -1,0 +1,130 @@
+# -*- coding: utf-8 -*-
+from collections import namedtuple
+from urllib import quote_plus
+
+from django.test.client import RequestFactory
+
+from seo.templatetags.seo_extras import joblist_url
+from setup import DirectSEOBase
+
+
+Job = namedtuple('Job', 'location title guid')
+
+
+class JobListURLTest(DirectSEOBase):
+    @staticmethod
+    def get_request(querystring=None):
+        """
+        :param querystring:
+        :return: A fake request.
+
+        """
+        url = '/jobs/' if not querystring else '/jobs/?%s' % querystring
+        return RequestFactory().get(url)
+
+    @staticmethod
+    def get_job(location='Avon, IN', title='Software', guid='A'*32):
+        """
+        Generate a fake "job" with location, title, and guid attributes which
+        are required by the joblist_url function.
+
+        :param location: The location of the fake job.
+        :param title: The title of the fake job.
+        :param guid: A fake guid for the fake job.
+
+        :return: A namedtuple with all attributes required for a job in
+                 joblist_url set.
+
+        """
+        return Job(location=location, title=title, guid=guid)
+
+    def test_unicode(self):
+        """
+        Unicode characters in the persistent querystring parameters
+        should not prevent the url from being generated.
+
+        """
+        unicode_title = u'Розничная'
+        encoded_unicode_title = quote_plus(unicode_title.encode('utf8'))
+        utm_campaign = u'utm_campaign=%s' % unicode_title
+        encoded_utm_campaign = u'utm_campaign=%s' % encoded_unicode_title
+        context = {'request': self.get_request(querystring=utm_campaign)}
+        job = self.get_job()
+
+        url = joblist_url(context, job)
+        self.assertIn(job.guid, url)
+        self.assertIn(encoded_utm_campaign, url)
+
+    def test_persisting_params(self):
+        """
+        The querystring parameters that were requested to persist
+        to the apply page should in fact be persistent.
+
+        """
+        params_to_persist = [
+            'de_n', 'de_m', 'de_t', 'de_o', 'de_c', 'utm_source', 'utm_medium',
+            'utm_term', 'utm_content', 'utm_campaign'
+        ]
+
+        for param in params_to_persist:
+            querystring = '%s=VALUE_FOR_PARAM%s' % (param, param)
+            context = {'request': self.get_request(querystring)}
+            job = self.get_job()
+
+            url = joblist_url(context, job)
+            self.assertIn(querystring, url)
+
+    def test_apply_param_from_cookie(self):
+        """
+        If the value for a parameter we persist is stored in a cookie but not
+        the url, the value from the cookie should still end up on the url
+        returned by joblist_url.
+
+        """
+        cookie_field_mappings = {
+            'external_utm_campaign': 'utm_campaign',
+            'external_utm_medium': 'utm_medium',
+            'external_utm_content': 'utm_content',
+            'external_utm_source': 'utm_source',
+            'external_utm_term': 'utm_term',
+        }
+        for cookie_name, param_name in cookie_field_mappings.iteritems():
+            cookie_val = 'COOKIE_%s' % param_name
+            querystring = "%s=%s" % (param_name, cookie_val)
+
+            request = self.get_request()
+            request.COOKIES[cookie_name] = cookie_val
+            context = {'request': request}
+            job = self.get_job()
+
+            url = joblist_url(context, job)
+
+            self.assertIn(querystring, url)
+
+    def test_url_over_cookie(self):
+        """
+        A parameter value retrieved via url should always be preferred over
+        one retrieved via cookie.
+
+        """
+        cookie_field_mappings = {
+            'external_utm_campaign': 'utm_campaign',
+            'external_utm_medium': 'utm_medium',
+            'external_utm_content': 'utm_content',
+            'external_utm_source': 'utm_source',
+            'external_utm_term': 'utm_term',
+        }
+        for cookie_name, param_name in cookie_field_mappings.iteritems():
+            cookie_val = 'COOKIE_%s' % param_name
+            querystring_val = 'QUERYSTRING_%s' % param_name
+            querystring = "%s=%s" % (param_name, querystring_val)
+
+            request = self.get_request(querystring=querystring)
+            request.COOKIES[cookie_name] = cookie_val
+            context = {'request': request}
+            job = self.get_job()
+
+            url = joblist_url(context, job)
+
+            self.assertIn(querystring, url)
+            self.assertNotIn(cookie_val, url)

--- a/templates/job_result.html
+++ b/templates/job_result.html
@@ -15,7 +15,7 @@
           {% if "network" in site_tags and job.company_enhanced %}
               <div class="enhanced_favicon"style="background-image:url('//d2e48ltfsb5exy.cloudfront.net/favicons/{{ job.company_slab|to_slug }}.ico');"></div>
           {% endif %}
-          <h4 itemprop="title" {% if featured %}style="background-image:url('//d2e48ltfsb5exy.cloudfront.net/favicons/{{ job.company_slab|to_slug }}.ico');"{% endif %}><a href="{{ job|joblist_url }}"><span class="resultHeader">{{ job.title|cut:"?"|cut:"~" }}</span></a></h4>
+          <h4 itemprop="title" {% if featured %}style="background-image:url('//d2e48ltfsb5exy.cloudfront.net/favicons/{{ job.company_slab|to_slug }}.ico');"{% endif %}><a href="{% joblist_url job %}"><span class="resultHeader">{{ job.title|cut:"?"|cut:"~" }}</span></a></h4>
           {% if job.country_short|lower == "usa" and site_commitments_string%}
           <meta itemprop="specialCommitments" content="{{site_commitments_string}}" />
           {% endif %}

--- a/templates/listing_search_items.html
+++ b/templates/listing_search_items.html
@@ -1,12 +1,11 @@
 {% load seo_extras %}
 {% for job in default_jobs %}
-{% with job_url=job|joblist_url %}
 {% if forloop.counter <= site_config.num_job_items_to_show %}
   <li class="direct_joblisting" itemscope itemtype='http://schema.org/JobPosting'>
 {% else %}
   <li class="direct_joblisting direct_hiddenOption" itemscope itemtype='http://schema.org/JobPosting'>
 {% endif %}
-    <a href="{{ job_url }}">{{ job.title|cut:"?"|cut:"~" }}</a>
+    <a href="{% joblist_url job %}">{{ job.title|cut:"?"|cut:"~" }}</a>
     {% if job.highlighted %}
     {% if site_config.browse_company_show %}
     <div class="direct_joblocation"><b>{{ job.company }}</b> - {{ job.location }}</div>
@@ -17,5 +16,4 @@
     <div class="posted_date" itemprop="datePosted">Posted {{ job.date_new|timesince }} ago</div>
     {% endif %}
   </li>
-{% endwith %}
 {% endfor %}

--- a/templates/myblocks/blocks/searchresult.html
+++ b/templates/myblocks/blocks/searchresult.html
@@ -7,7 +7,7 @@
                     {% for job in job_list.jobs %}
                     <li class="direct_joblisting{% if 'network' in site_tags and job.company_enhanced %} enhanced_job{% endif %}{% if job.highlighted %} with_description{% endif %}" itemscope itemtype="http://schema.org/JobPosting">
                         {% if "network" in site_tags and job.company_enhanced %}<div class="enhanced_favicon"style="background-image:url('//d2e48ltfsb5exy.cloudfront.net/favicons/{{ job.company_slab|to_slug }}.ico');"></div>{% endif %}
-                        <h4 itemprop="title" {% if featured %}style="background-image:url('//d2e48ltfsb5exy.cloudfront.net/favicons/{{ job.company_slab|to_slug }}.ico');"{% endif %}><a href="{{ job|joblist_url }}"><span class="resultHeader">{{ job.title|cut:"?"|cut:"~" }}</span></a></h4>
+                        <h4 itemprop="title" {% if featured %}style="background-image:url('//d2e48ltfsb5exy.cloudfront.net/favicons/{{ job.company_slab|to_slug }}.ico');"{% endif %}><a href="{% joblist_url job %}"><span class="resultHeader">{{ job.title|cut:"?"|cut:"~" }}</span></a></h4>
                         {% if job.country_short|lower == "usa" and site_commitments_string%}<meta itemprop="specialCommitments" content="{{site_commitments_string}}" />{% endif %}
                         <div class="direct_joblocation">
                             {% if show_co_names %}

--- a/templates/v2/job_results.html
+++ b/templates/v2/job_results.html
@@ -15,7 +15,7 @@
           {% if "network" in site_tags and job.company_enhanced %}
               <div class="enhanced_favicon"style="background-image:url('//d2e48ltfsb5exy.cloudfront.net/favicons/{{ job.company_slab|to_slug }}.ico');"></div>
           {% endif %}
-          <h2 class="direct-job-title" itemprop="title" {% if featured %}style="background-image:url('//d2e48ltfsb5exy.cloudfront.net/favicons/{{ job.company_slab|to_slug }}.ico');"{% endif %}><a class="direct-job-title-clk" href="{{ job|joblist_url }}"><span class="resultHeader">{{ job.title|cut:"?"|cut:"~" }}</span></a></h2>
+          <h2 class="direct-job-title" itemprop="title" {% if featured %}style="background-image:url('//d2e48ltfsb5exy.cloudfront.net/favicons/{{ job.company_slab|to_slug }}.ico');"{% endif %}><a class="direct-job-title-clk" href="{% joblist_url job %}"><span class="resultHeader">{{ job.title|cut:"?"|cut:"~" }}</span></a></h2>
           {% if job.country_short|lower == "usa" and site_commitments_string%}
           <meta itemprop="specialCommitments" content="{{site_commitments_string}}" />
           {% endif %}


### PR DESCRIPTION
Ensure that parameters used by analytics are passed along to the job view page from the job listing pages. 

The modifications themselves are pretty simple, although it took some searching to confirm that the request was being passed along as context to everything that ended up using `joblist_url()`. In case anyone else is wondering how things end up getting to `joblist_url()`:
![joblist_url](https://cloud.githubusercontent.com/assets/2728248/22207796/9a1b8d18-e14e-11e6-8149-19721408bdda.png)
The templates highlighted in red are unused as far as I can tell. I made the changes there too, but they should be non-impacting. I'd be interested if someone knew otherwise, as I'd like to test manually as well. 


The unused templates are:
* search_results.html
* v2/search_results.html
* v2/job_results.html
* listing_search_item.html