### PR TITLE
Add campaign tags to partner saved search emails [PD-2873]

### DIFF
--- a/mypartners/helpers.py
+++ b/mypartners/helpers.py
@@ -11,7 +11,6 @@ from django.contrib.contenttypes.models import ContentType
 from django.http import Http404, QueryDict
 from django.shortcuts import get_object_or_404
 from django.template.loader import render_to_string
-from django.utils.http import urlquote_plus, urlunquote_plus
 from django.utils.safestring import mark_safe
 from django.utils.text import get_text_list, force_unicode, force_text
 from django.utils.timezone import now

--- a/mypartners/helpers.py
+++ b/mypartners/helpers.py
@@ -3,15 +3,15 @@ from datetime import datetime, time
 import json
 import os
 from urlparse import urlparse, parse_qsl, urlunparse
-from urllib import urlencode
 
 from django.db.models import Min, Max, Q, Model
 from django.core.serializers.json import DjangoJSONEncoder
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
-from django.http import Http404
+from django.http import Http404, QueryDict
 from django.shortcuts import get_object_or_404
 from django.template.loader import render_to_string
+from django.utils.http import urlquote_plus, urlunquote_plus
 from django.utils.safestring import mark_safe
 from django.utils.text import get_text_list, force_unicode, force_text
 from django.utils.timezone import now
@@ -55,7 +55,7 @@ def add_extra_params(url, extra_urls):
     :url: Input url with parameters added
     """
     extra_urls = extra_urls.lstrip('?&')
-    new_queries = dict(parse_qsl(extra_urls, keep_blank_values=True))
+    new_queries = QueryDict(extra_urls, mutable=True)
 
     # By default, extra parameters besides vs are discarded by the redirect
     # server. We can get around this by adding &z=1 to the url, which enables
@@ -63,10 +63,10 @@ def add_extra_params(url, extra_urls):
     new_queries['z'] = '1'
 
     parts = list(urlparse(url))
-    query = dict(parse_qsl(parts[4], keep_blank_values=True))
+    query = QueryDict(parts[4], mutable=True)
     query.update(new_queries)
-    parts[4] = urlencode(query)
-    return urlunparse(parts)
+    parts[4] = query.urlencode()
+    return mark_safe(urlunparse(parts))
 
 
 def add_extra_params_to_jobs(items, extra_urls):

--- a/mysearches/models.py
+++ b/mysearches/models.py
@@ -164,6 +164,12 @@ class SavedSearch(models.Model):
                                                                     extras)
                         self.url = mypartners.helpers.add_extra_params(self.url,
                                                                        extras)
+                    campaigns = ("de_n=PRM Saved Search"
+                                 "&de_m=email&de_c={partner}").format(
+                        partner=self.partnersavedsearch.partner.name)
+                    mypartners.helpers.add_extra_params_to_jobs(items, campaigns)
+                    self.url = mypartners.helpers.add_extra_params(self.url, campaigns)
+
                 if self.custom_message and not custom_msg:
                     custom_msg = self.custom_message
 
@@ -504,6 +510,12 @@ class SavedSearchDigest(models.Model):
                     mypartners.helpers.add_extra_params_to_jobs(items, extras)
                     search.url = mypartners.helpers.add_extra_params(search.url,
                                                                      extras)
+                campaigns = ("de_n=PRM Saved Search"
+                             "&de_m=email&de_c={partner}").format(
+                    partner=pss.partner.name)
+                mypartners.helpers.add_extra_params_to_jobs(items, campaigns)
+                search.url = mypartners.helpers.add_extra_params(search.url, campaigns)
+
             search_list.append((search, items, count))
 
         saved_searches = [(search, items, count)
@@ -638,6 +650,12 @@ class PartnerSavedSearch(SavedSearch):
             if extras:
                 mypartners.helpers.add_extra_params_to_jobs(items, extras)
                 self.url = mypartners.helpers.add_extra_params(self.url, extras)
+
+            campaigns = ("de_n=PRM Saved Search"
+                         "&de_m=email&de_c={partner}").format(
+                partner=self.partner.name)
+            mypartners.helpers.add_extra_params_to_jobs(items, campaigns)
+            self.url = mypartners.helpers.add_extra_params(self.url, campaigns)
 
             custom_msg = self.custom_message if self.custom_message else ''
             context_dict = {

--- a/mysearches/models.py
+++ b/mysearches/models.py
@@ -164,8 +164,9 @@ class SavedSearch(models.Model):
                                                                     extras)
                         self.url = mypartners.helpers.add_extra_params(self.url,
                                                                        extras)
-                    campaigns = ("de_n=PRM Saved Search"
-                                 "&de_m=email&de_c={partner}").format(
+                    # TODO: make this more generic; it's duplicated twice more.
+                    campaigns = (u"de_n=PRM Saved Search"
+                                 u"&de_m=email&de_c={partner}").format(
                         partner=self.partnersavedsearch.partner.name)
                     mypartners.helpers.add_extra_params_to_jobs(items, campaigns)
                     self.url = mypartners.helpers.add_extra_params(self.url, campaigns)
@@ -218,7 +219,8 @@ class SavedSearch(models.Model):
 
                 if is_pss:
                     record = self.partnersavedsearch.create_record(
-                        custom_msg, failure_message=log_kwargs.get('reason'))
+                        custom_msg, failure_message=log_kwargs.get('reason'),
+                        body=message)
                     log_kwargs['contact_record'] = record
                     log_kwargs['new_jobs'] = len([item for item in items
                                                  if item.get('new')])
@@ -297,7 +299,8 @@ class SavedSearch(models.Model):
                         reason = None
                     self.partnersavedsearch.create_record(
                         "Automatic sending of initial partner saved search",
-                        failure_message=reason
+                        failure_message=reason,
+                        body=message
                     )
         else:
             log_kwargs['reason'] = "User can't receive MyJobs email"
@@ -357,7 +360,8 @@ class SavedSearch(models.Model):
                 reason = None
             self.partnersavedsearch.create_record(
                 "Automatic sending of updated partner saved search.",
-                failure_message=reason
+                failure_message=reason,
+                body=message
             )
 
         SavedSearchLog.objects.create(**log_kwargs)
@@ -510,8 +514,8 @@ class SavedSearchDigest(models.Model):
                     mypartners.helpers.add_extra_params_to_jobs(items, extras)
                     search.url = mypartners.helpers.add_extra_params(search.url,
                                                                      extras)
-                campaigns = ("de_n=PRM Saved Search"
-                             "&de_m=email&de_c={partner}").format(
+                campaigns = (u"de_n=PRM Saved Search"
+                             u"&de_m=email&de_c={partner}").format(
                     partner=pss.partner.name)
                 mypartners.helpers.add_extra_params_to_jobs(items, campaigns)
                 search.url = mypartners.helpers.add_extra_params(search.url, campaigns)
@@ -559,7 +563,8 @@ class SavedSearchDigest(models.Model):
                 log_kwargs['reason'] = "User can't receive MyJobs email"
         for pss in needs_records:
             pss.create_record(custom_msg,
-                              failure_message=log_kwargs.get('reason'))
+                              failure_message=log_kwargs.get('reason'),
+                              body=message)
         SavedSearchLog.objects.create(**log_kwargs)
 
 
@@ -651,8 +656,8 @@ class PartnerSavedSearch(SavedSearch):
                 mypartners.helpers.add_extra_params_to_jobs(items, extras)
                 self.url = mypartners.helpers.add_extra_params(self.url, extras)
 
-            campaigns = ("de_n=PRM Saved Search"
-                         "&de_m=email&de_c={partner}").format(
+            campaigns = (u"de_n=PRM Saved Search"
+                         u"&de_m=email&de_c={partner}").format(
                 partner=self.partner.name)
             mypartners.helpers.add_extra_params_to_jobs(items, campaigns)
             self.url = mypartners.helpers.add_extra_params(self.url, campaigns)

--- a/mysearches/models.py
+++ b/mysearches/models.py
@@ -697,6 +697,10 @@ class PartnerSavedSearch(SavedSearch):
 
     @property
     def campaigns(self):
+        """
+        Calcualtes and returns the DE analytics campaigns that should be
+        attached to links in any resulting emails
+        """
         if not self._campaigns:
             self._campaigns = (u"de_n=PRM Saved Search"
                                u"&de_m=email&de_c={partner}").format(

--- a/mysearches/models.py
+++ b/mysearches/models.py
@@ -164,12 +164,11 @@ class SavedSearch(models.Model):
                                                                     extras)
                         self.url = mypartners.helpers.add_extra_params(self.url,
                                                                        extras)
-                    # TODO: make this more generic; it's duplicated twice more.
-                    campaigns = (u"de_n=PRM Saved Search"
-                                 u"&de_m=email&de_c={partner}").format(
-                        partner=self.partnersavedsearch.partner.name)
-                    mypartners.helpers.add_extra_params_to_jobs(items, campaigns)
-                    self.url = mypartners.helpers.add_extra_params(self.url, campaigns)
+                    campaigns = self.partnersavedsearch.campaigns
+                    mypartners.helpers.add_extra_params_to_jobs(
+                        items, campaigns)
+                    self.url = mypartners.helpers.add_extra_params(
+                        self.url, campaigns)
 
                 if self.custom_message and not custom_msg:
                     custom_msg = self.custom_message
@@ -514,11 +513,10 @@ class SavedSearchDigest(models.Model):
                     mypartners.helpers.add_extra_params_to_jobs(items, extras)
                     search.url = mypartners.helpers.add_extra_params(search.url,
                                                                      extras)
-                campaigns = (u"de_n=PRM Saved Search"
-                             u"&de_m=email&de_c={partner}").format(
-                    partner=pss.partner.name)
+                campaigns = pss.campaigns
                 mypartners.helpers.add_extra_params_to_jobs(items, campaigns)
-                search.url = mypartners.helpers.add_extra_params(search.url, campaigns)
+                search.url = mypartners.helpers.add_extra_params(search.url,
+                                                                 campaigns)
 
             search_list.append((search, items, count))
 
@@ -597,6 +595,7 @@ class PartnerSavedSearch(SavedSearch):
     unsubscriber = models.EmailField(max_length=255, blank=True, editable=False,
                                      verbose_name='Unsubscriber')
     last_action_time = models.DateTimeField(default=datetime.now, blank=True)
+    _campaigns = None
 
     def save(self, *args, **kwargs):
         new = not hasattr(self, 'id') or not self.id
@@ -656,9 +655,7 @@ class PartnerSavedSearch(SavedSearch):
                 mypartners.helpers.add_extra_params_to_jobs(items, extras)
                 self.url = mypartners.helpers.add_extra_params(self.url, extras)
 
-            campaigns = (u"de_n=PRM Saved Search"
-                         u"&de_m=email&de_c={partner}").format(
-                partner=self.partner.name)
+            campaigns = self.campaigns
             mypartners.helpers.add_extra_params_to_jobs(items, campaigns)
             self.url = mypartners.helpers.add_extra_params(self.url, campaigns)
 
@@ -697,6 +694,14 @@ class PartnerSavedSearch(SavedSearch):
         self.last_action_time = datetime.now()
         if save:
             self.save()
+
+    @property
+    def campaigns(self):
+        if not self._campaigns:
+            self._campaigns = (u"de_n=PRM Saved Search"
+                               u"&de_m=email&de_c={partner}").format(
+                partner=self.partner.name)
+        return self._campaigns
 
 
 class SavedSearchLog(models.Model):

--- a/mysearches/templatetags/email_tags.py
+++ b/mysearches/templatetags/email_tags.py
@@ -1,8 +1,8 @@
 from django import template
 from django.core.urlresolvers import reverse
 
+from mypartners.helpers import add_extra_params
 from registration.models import ActivationProfile
-from universal.helpers import update_url_param
 
 register = template.Library()
 
@@ -40,7 +40,7 @@ def get_all_jobs_link(saved_search):
         if feed:
             url = feed.replace('/feed/rss', '')
 
-    url = update_url_param(url, 'sort', 'date')
+    url = add_extra_params(url, 'sort=date')
 
     return url
 


### PR DESCRIPTION
Adds three tags used in DE analytics to partner saved search emails:
`de_n=PRM+Saved+Search`
`de_m=email`
`de_c={{partner_name}}`

