### PR TITLE
[PD 2881] disable chart clicking last dimension

### DIFF
--- a/analytics/api.py
+++ b/analytics/api.py
@@ -257,8 +257,6 @@ def determine_data_group_by_and_remaining(query_data, reporttype_datatype):
 
 
     """
-    # TODO: Add DB handling / "filter chain" logic
-
     configuration = reporttype_datatype.configuration
     config_columns = configuration.configurationcolumn_set.all().order_by('order')
     active_filters = [f['type'] for f in query_data.get('active_filters', [])]
@@ -267,9 +265,11 @@ def determine_data_group_by_and_remaining(query_data, reporttype_datatype):
     if group_overwrite:
         overwrite = config_columns.get(column_name=group_overwrite)
         return overwrite, remaining.exclude(id=overwrite.id)
-    else:
+    elif remaining:
         return (remaining.first(),
                 remaining.all().exclude(id=remaining.first().id))
+    else:
+        return None, None
 
 
 def retrieve_sampling_query_and_count(collection, top_query, sample_size):
@@ -460,6 +460,14 @@ def dynamic_chart(request):
     group_by, remaining_dimensions = determine_data_group_by_and_remaining(
         query_data, report_data
     )
+
+    if not group_by:
+        return HttpResponse(json.dumps({"rows": [],
+                                        "column_names": [],
+                                        "chart_type": None,
+                                        "group_by": None,
+                                        "remaining_dimensions": []
+                                        }))
 
     group_query = build_group_by_query(group_by.column_name)
 

--- a/gulp/src/analytics/components/Charts/Bar/BarChart.js
+++ b/gulp/src/analytics/components/Charts/Bar/BarChart.js
@@ -2,6 +2,7 @@ import React from 'react';
 import {Component} from 'react';
 import {BarChart, Cell, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer} from 'recharts';
 import RotatedXAxisTick from './RotatedXAxisTick';
+import {isEmpty} from 'lodash-compat/lang';
 
 class SimpleBarChart extends Component {
   render() {
@@ -18,7 +19,7 @@ class SimpleBarChart extends Component {
             height={height}
             data={mainBarData}
             margin={{top: 5, right: 30, left: 20, bottom: 100}}
-            onClick={barClicked}>
+            onClick={isEmpty(chartData.PageLoadData.remaining_dimensions) ? () => {} : barClicked}>
            <XAxis dataKey={xAxis} interval={0} tick={<RotatedXAxisTick />} />
            <YAxis/>
            <CartesianGrid strokeDasharray="3 3" />

--- a/gulp/src/analytics/components/Charts/Bar/BarChart.js
+++ b/gulp/src/analytics/components/Charts/Bar/BarChart.js
@@ -19,7 +19,7 @@ class SimpleBarChart extends Component {
             height={height}
             data={mainBarData}
             margin={{top: 5, right: 30, left: 20, bottom: 100}}
-            onClick={isEmpty(chartData.PageLoadData.remaining_dimensions) ? () => {} : barClicked}>
+            onClick={!isEmpty(chartData.PageLoadData.remaining_dimensions) ? barClicked : () => {}}>
            <XAxis dataKey={xAxis} interval={0} tick={<RotatedXAxisTick />} />
            <YAxis/>
            <CartesianGrid strokeDasharray="3 3" />

--- a/gulp/src/analytics/components/Charts/Map/USAMap.js
+++ b/gulp/src/analytics/components/Charts/Map/USAMap.js
@@ -5,6 +5,7 @@ import Paths from '../Common/Paths';
 import ToolTip from '../Common/ToolTip';
 import Legend from '../Common/Legend';
 import mapData from 'common/resources/maps/us';
+import {isEmpty} from 'lodash-compat/lang';
 
 class USAMap extends Component {
   constructor() {
@@ -51,7 +52,11 @@ class USAMap extends Component {
       return '#E6E6E6';
     };
     const stateClicked = (state) => {
-      return () => {pathClicked(state.properties.STUSPS, 'state');};
+      let returnFunction = () => {};
+      if (!isEmpty(chartData.PageLoadData.remaining_dimensions)) {
+        returnFunction = () => {pathClicked(state.properties.STUSPS, 'state');};
+      }
+      return returnFunction;
     };
     const toolTipData = [];
     for (let i = 0; i < rowData.length; i++) {

--- a/gulp/src/analytics/components/Charts/Map/WorldMap.js
+++ b/gulp/src/analytics/components/Charts/Map/WorldMap.js
@@ -5,6 +5,7 @@ import Paths from '../Common/Paths';
 import ToolTip from '../Common/ToolTip';
 import Legend from '../Common/Legend';
 import mapData from 'common/resources/maps/countries';
+import {isEmpty} from 'lodash-compat/lang';
 
 class WorldMap extends Component {
   constructor() {
@@ -49,7 +50,13 @@ class WorldMap extends Component {
       return '#E6E6E6';
     };
     const countryClicked = (country) => {
-      return () => {pathClicked(country.id, 'country');};
+      let returnFunction = () => {};
+      if (!isEmpty(chartData.PageLoadData.remaining_dimensions)) {
+        returnFunction = () => {
+          pathClicked(country.id, 'country');
+        };
+      }
+      return returnFunction;
     };
     const toolTipData = [];
     for (let i = 0; i < rowData.length; i++) {


### PR DESCRIPTION
## Overview

This ticket aims to fix the clickable charts from attempting to continue to apply filters when no further group_by types remain.

In addition to prevent the UI from sending these requests, this PR modifies the API code to prevent that type of request from sending 500 errors.

## Testing

Click through a report and see that the chart becomes unclickable once are available filters are applied.